### PR TITLE
Add GitHub Actions CI workflow (Issue #3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,14 +29,8 @@ jobs:
           node-version-file: ".nvmrc"
           cache: "pnpm"
 
-      - name: Restore Turborepo cache
-        uses: actions/cache@v4
-        with:
-          path: .turbo
-          key: turbo-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.sha }}
-          restore-keys: |
-            turbo-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-
-            turbo-${{ runner.os }}-
+      - name: Turborepo cache
+        uses: rharkor/caching-for-turbo@v2
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary

- Add `.github/workflows/ci.yml` — single-job CI workflow for PRs and pushes to `main`
- Steps: checkout, pnpm install (frozen lockfile), lint (biome), build, typecheck, test
- Caches pnpm store (`setup-node` cache) and Turborepo local cache (`.turbo/` via `actions/cache`)
- Concurrency groups cancel in-progress runs when new commits are pushed to the same ref
- 15-minute timeout, `ubuntu-latest`, Node 22 (from `.nvmrc`), pnpm 10.27.0 (from `packageManager` field)

## Test plan

- [x] Workflow triggers on this PR
- [ ] All CI steps pass: install, lint, build, typecheck, test
- [ ] Subsequent pushes cancel prior in-progress runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)