### PR TITLE
feat: add @templar/channel-telegram adapter (grammY)

### DIFF
--- a/packages/channel-telegram/package.json
+++ b/packages/channel-telegram/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@templar/channel-telegram",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check .",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@grammyjs/auto-retry": "^2.0.2",
+    "grammy": "^1.35.0",
+    "zod": "^3.24.0"
+  },
+  "devDependencies": {
+    "@templar/core": "workspace:*",
+    "@templar/errors": "workspace:*",
+    "@types/node": "^25.2.2"
+  }
+}

--- a/packages/channel-telegram/src/__tests__/helpers/mock-grammy.ts
+++ b/packages/channel-telegram/src/__tests__/helpers/mock-grammy.ts
@@ -1,0 +1,304 @@
+import type { Api } from "grammy";
+import type {
+  Chat,
+  Document,
+  Message,
+  MessageEntity,
+  PhotoSize,
+  Update,
+  User,
+  UserFromGetMe,
+  Voice,
+} from "grammy/types";
+
+// ---------------------------------------------------------------------------
+// Captured API call type
+// ---------------------------------------------------------------------------
+
+export interface CapturedApiCall {
+  readonly method: string;
+  readonly payload: Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// Mock Bot Info
+// ---------------------------------------------------------------------------
+
+export const MOCK_BOT_INFO: UserFromGetMe = {
+  id: 999,
+  is_bot: true,
+  first_name: "TestBot",
+  username: "test_bot",
+  can_join_groups: true,
+  can_read_all_group_messages: false,
+  supports_inline_queries: false,
+  can_connect_to_business: false,
+  has_main_web_app: false,
+  has_topics_enabled: false,
+  allows_users_to_create_topics: false,
+};
+
+// ---------------------------------------------------------------------------
+// Mock API — captures outgoing calls
+// ---------------------------------------------------------------------------
+
+export function createMockApi(): { api: Api; calls: CapturedApiCall[] } {
+  const calls: CapturedApiCall[] = [];
+
+  // Minimal mock that intercepts all method calls.
+  // grammY API methods accept positional args (e.g., api.getFile(fileId)).
+  const handler: ProxyHandler<object> = {
+    get(_target, prop: string) {
+      if (prop === "config") {
+        return { use: () => {} };
+      }
+      if (prop === "then" || prop === "catch" || prop === "finally") {
+        return undefined; // Prevent proxy from being treated as a thenable
+      }
+      // Return a function that captures the call
+      return (...args: unknown[]) => {
+        const payload =
+          args.length === 1 && typeof args[0] === "object" && args[0] !== null
+            ? (args[0] as Record<string, unknown>)
+            : { _args: args };
+        calls.push({ method: prop, payload });
+
+        // Return mock responses based on method
+        if (prop === "getFile") {
+          const fileId = typeof args[0] === "string" ? args[0] : String(args[0]);
+          return Promise.resolve({
+            file_id: fileId,
+            file_unique_id: "unique_123",
+            file_path: `photos/${fileId}.jpg`,
+          });
+        }
+        if (prop === "sendMessage") {
+          return Promise.resolve({
+            message_id: Math.floor(Math.random() * 10000),
+            date: Math.floor(Date.now() / 1000),
+            chat: { id: args[0], type: "private" },
+          });
+        }
+        if (prop === "sendPhoto" || prop === "sendDocument") {
+          return Promise.resolve({
+            message_id: Math.floor(Math.random() * 10000),
+            date: Math.floor(Date.now() / 1000),
+            chat: { id: args[0], type: "private" },
+          });
+        }
+        if (prop === "sendChatAction") {
+          return Promise.resolve(true);
+        }
+        return Promise.resolve({ ok: true, result: true });
+      };
+    },
+  };
+
+  const api = new Proxy({}, handler) as unknown as Api;
+  return { api, calls };
+}
+
+// ---------------------------------------------------------------------------
+// Default factories
+// ---------------------------------------------------------------------------
+
+const DEFAULT_USER: User = {
+  id: 456,
+  is_bot: false,
+  first_name: "TestUser",
+};
+
+const DEFAULT_CHAT: Chat.PrivateChat = {
+  id: 123,
+  type: "private",
+  first_name: "TestUser",
+};
+
+function baseMessage(overrides: Partial<Message> = {}): Message & Update.NonChannel {
+  return {
+    message_id: Math.floor(Math.random() * 10000),
+    date: Math.floor(Date.now() / 1000),
+    chat: DEFAULT_CHAT,
+    from: DEFAULT_USER,
+    ...overrides,
+  } as Message & Update.NonChannel;
+}
+
+// ---------------------------------------------------------------------------
+// Update factories
+// ---------------------------------------------------------------------------
+
+export interface TextUpdateOptions {
+  readonly chatId?: number;
+  readonly userId?: number;
+  readonly entities?: readonly MessageEntity[];
+  readonly messageThreadId?: number;
+}
+
+export function createTextUpdate(text: string, opts: TextUpdateOptions = {}): Update {
+  const chat = opts.chatId ? { ...DEFAULT_CHAT, id: opts.chatId } : DEFAULT_CHAT;
+  const from = opts.userId ? { ...DEFAULT_USER, id: opts.userId } : DEFAULT_USER;
+
+  return {
+    update_id: Math.floor(Math.random() * 100000),
+    message: baseMessage({
+      chat,
+      from,
+      text,
+      ...(opts.entities ? { entities: [...opts.entities] } : {}),
+      ...(opts.messageThreadId != null ? { message_thread_id: opts.messageThreadId } : {}),
+    }),
+  };
+}
+
+export interface PhotoUpdateOptions {
+  readonly chatId?: number;
+  readonly userId?: number;
+  readonly caption?: string;
+  readonly captionEntities?: readonly MessageEntity[];
+  readonly sizes?: readonly PhotoSize[];
+}
+
+export function createPhotoUpdate(fileId: string, opts: PhotoUpdateOptions = {}): Update {
+  const defaultSizes: PhotoSize[] = [
+    { file_id: `${fileId}_small`, file_unique_id: "s1", width: 90, height: 90 },
+    { file_id: `${fileId}_medium`, file_unique_id: "s2", width: 320, height: 320 },
+    { file_id: fileId, file_unique_id: "s3", width: 800, height: 800, file_size: 50000 },
+  ];
+
+  const msg = baseMessage({
+    photo: opts.sizes ? [...opts.sizes] : defaultSizes,
+    ...(opts.caption != null ? { caption: opts.caption } : {}),
+    ...(opts.captionEntities ? { caption_entities: [...opts.captionEntities] } : {}),
+  });
+
+  return {
+    update_id: Math.floor(Math.random() * 100000),
+    message: msg,
+  };
+}
+
+export interface DocumentUpdateOptions {
+  readonly chatId?: number;
+  readonly userId?: number;
+  readonly fileName?: string;
+  readonly mimeType?: string;
+  readonly fileSize?: number;
+}
+
+export function createDocumentUpdate(fileId: string, opts: DocumentUpdateOptions = {}): Update {
+  const doc: Document = {
+    file_id: fileId,
+    file_unique_id: "doc_unique",
+    file_name: opts.fileName ?? "test.pdf",
+    mime_type: opts.mimeType ?? "application/pdf",
+    file_size: opts.fileSize ?? 1024,
+  };
+
+  return {
+    update_id: Math.floor(Math.random() * 100000),
+    message: baseMessage({ document: doc }),
+  };
+}
+
+export interface VoiceUpdateOptions {
+  readonly chatId?: number;
+  readonly userId?: number;
+  readonly duration?: number;
+  readonly mimeType?: string;
+}
+
+export function createVoiceUpdate(fileId: string, opts: VoiceUpdateOptions = {}): Update {
+  const voice: Voice = {
+    file_id: fileId,
+    file_unique_id: "voice_unique",
+    duration: opts.duration ?? 5,
+    mime_type: opts.mimeType ?? "audio/ogg",
+  };
+
+  return {
+    update_id: Math.floor(Math.random() * 100000),
+    message: baseMessage({ voice }),
+  };
+}
+
+export interface GroupUpdateOptions {
+  readonly chatId?: number;
+  readonly userId?: number;
+  readonly threadId?: number;
+  readonly botMention?: boolean;
+}
+
+export function createGroupUpdate(text: string, opts: GroupUpdateOptions = {}): Update {
+  const groupChat: Chat.SupergroupChat = {
+    id: opts.chatId ?? -100123456,
+    type: "supergroup",
+    title: "Test Group",
+  };
+
+  const entities: MessageEntity[] = [];
+  let finalText = text;
+
+  if (opts.botMention) {
+    const mentionText = `@${MOCK_BOT_INFO.username}`;
+    finalText = `${mentionText} ${text}`;
+    entities.push({
+      type: "mention",
+      offset: 0,
+      length: mentionText.length,
+    });
+  }
+
+  return {
+    update_id: Math.floor(Math.random() * 100000),
+    message: baseMessage({
+      chat: groupChat,
+      from: opts.userId ? { ...DEFAULT_USER, id: opts.userId } : DEFAULT_USER,
+      text: finalText,
+      ...(entities.length > 0 ? { entities } : {}),
+      ...(opts.threadId != null ? { message_thread_id: opts.threadId } : {}),
+    }),
+  };
+}
+
+/**
+ * Create an update with no extractable content (e.g., sticker)
+ */
+export function createStickerUpdate(): Update {
+  return {
+    update_id: Math.floor(Math.random() * 100000),
+    message: baseMessage({
+      sticker: {
+        file_id: "sticker_123",
+        file_unique_id: "sticker_unique",
+        type: "regular",
+        width: 512,
+        height: 512,
+        is_animated: false,
+        is_video: false,
+      },
+    }),
+  };
+}
+
+/**
+ * Create an update with no message (e.g., callback query only)
+ */
+export function createCallbackQueryUpdate(): Update {
+  return {
+    update_id: Math.floor(Math.random() * 100000),
+    callback_query: {
+      id: "cb_123",
+      from: DEFAULT_USER,
+      chat_instance: "instance_123",
+      data: "test_callback",
+    },
+  };
+}
+
+/**
+ * Build a file download URL from a token and file_path
+ */
+export function buildFileUrl(token: string, filePath: string): string {
+  return `https://api.telegram.org/file/bot${token}/${filePath}`;
+}

--- a/packages/channel-telegram/src/__tests__/unit/adapter.test.ts
+++ b/packages/channel-telegram/src/__tests__/unit/adapter.test.ts
@@ -1,0 +1,392 @@
+import type { InboundMessage, OutboundMessage } from "@templar/core";
+import { ChannelLoadError } from "@templar/errors";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { TelegramChannel } from "../../adapter.js";
+import { TELEGRAM_CAPABILITIES } from "../../capabilities.js";
+
+// ---------------------------------------------------------------------------
+// We mock grammY's Bot class at the module level to avoid real network calls.
+// The mock captures method calls and allows us to simulate bot behavior.
+// ---------------------------------------------------------------------------
+
+const mockBotInit = vi.fn().mockResolvedValue(undefined);
+const mockBotStart = vi.fn();
+const mockBotStop = vi.fn().mockResolvedValue(undefined);
+const mockBotOn = vi.fn();
+const mockBotCatch = vi.fn();
+const mockSetWebhook = vi.fn().mockResolvedValue(true);
+const mockDeleteWebhook = vi.fn().mockResolvedValue(true);
+const mockSendMessage = vi.fn().mockResolvedValue({
+  message_id: 1,
+  date: 1234,
+  chat: { id: 123, type: "private" },
+});
+const mockSendChatAction = vi.fn().mockResolvedValue(true);
+const mockSendPhoto = vi.fn().mockResolvedValue({
+  message_id: 2,
+  date: 1234,
+  chat: { id: 123, type: "private" },
+});
+const mockConfigUse = vi.fn();
+
+vi.mock("grammy", () => {
+  return {
+    Bot: class MockBot {
+      botInfo = {
+        id: 999,
+        is_bot: true,
+        first_name: "TestBot",
+        username: "test_bot",
+        can_join_groups: true,
+        can_read_all_group_messages: false,
+        supports_inline_queries: false,
+        can_connect_to_business: false,
+        has_main_web_app: false,
+      };
+
+      api = {
+        config: { use: mockConfigUse },
+        setWebhook: mockSetWebhook,
+        deleteWebhook: mockDeleteWebhook,
+        sendMessage: mockSendMessage,
+        sendPhoto: mockSendPhoto,
+        sendChatAction: mockSendChatAction,
+        getFile: vi.fn().mockResolvedValue({
+          file_id: "f1",
+          file_unique_id: "u1",
+          file_path: "photos/f1.jpg",
+        }),
+      };
+
+      init = mockBotInit;
+      start = mockBotStart;
+      stop = mockBotStop;
+      on = mockBotOn;
+      catch = mockBotCatch;
+    },
+  };
+});
+
+vi.mock("@grammyjs/auto-retry", () => ({
+  autoRetry: () => () => {},
+}));
+
+describe("TelegramChannel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // -----------------------------------------------------------------------
+  // Constructor
+  // -----------------------------------------------------------------------
+
+  describe("constructor", () => {
+    it("creates adapter with valid polling config", () => {
+      const adapter = new TelegramChannel({
+        mode: "polling",
+        token: "123:ABC",
+      });
+      expect(adapter.name).toBe("telegram");
+      expect(adapter.capabilities).toBe(TELEGRAM_CAPABILITIES);
+    });
+
+    it("creates adapter with valid webhook config", () => {
+      const adapter = new TelegramChannel({
+        mode: "webhook",
+        token: "123:ABC",
+        webhookUrl: "https://example.com/webhook",
+      });
+      expect(adapter.name).toBe("telegram");
+    });
+
+    it("throws ChannelLoadError for invalid config", () => {
+      expect(() => new TelegramChannel({ mode: "polling" })).toThrow(ChannelLoadError);
+    });
+
+    it("throws ChannelLoadError for missing mode", () => {
+      expect(() => new TelegramChannel({ token: "123:ABC" })).toThrow(ChannelLoadError);
+    });
+
+    it("installs auto-retry plugin", () => {
+      new TelegramChannel({ mode: "polling", token: "123:ABC" });
+      expect(mockConfigUse).toHaveBeenCalled();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // connect()
+  // -----------------------------------------------------------------------
+
+  describe("connect()", () => {
+    it("calls bot.init() in polling mode", async () => {
+      const adapter = new TelegramChannel({
+        mode: "polling",
+        token: "123:ABC",
+      });
+      await adapter.connect();
+
+      expect(mockBotInit).toHaveBeenCalledOnce();
+      expect(mockBotStart).toHaveBeenCalledOnce();
+    });
+
+    it("calls bot.api.setWebhook() in webhook mode", async () => {
+      const adapter = new TelegramChannel({
+        mode: "webhook",
+        token: "123:ABC",
+        webhookUrl: "https://example.com/webhook",
+        secretToken: "my-secret",
+      });
+      await adapter.connect();
+
+      expect(mockBotInit).toHaveBeenCalledOnce();
+      expect(mockSetWebhook).toHaveBeenCalledWith("https://example.com/webhook", {
+        secret_token: "my-secret",
+      });
+    });
+
+    it("is idempotent — second call is a no-op", async () => {
+      const adapter = new TelegramChannel({
+        mode: "polling",
+        token: "123:ABC",
+      });
+      await adapter.connect();
+      await adapter.connect();
+
+      expect(mockBotInit).toHaveBeenCalledOnce();
+      expect(mockBotStart).toHaveBeenCalledOnce();
+    });
+
+    it("throws ChannelLoadError if bot.init() fails", async () => {
+      mockBotInit.mockRejectedValueOnce(new Error("Invalid token"));
+
+      const adapter = new TelegramChannel({
+        mode: "polling",
+        token: "bad:token",
+      });
+
+      await expect(adapter.connect()).rejects.toThrow(ChannelLoadError);
+    });
+
+    it("includes descriptive message when bot.init() fails", async () => {
+      mockBotInit.mockRejectedValueOnce(new Error("Invalid token"));
+
+      const adapter = new TelegramChannel({
+        mode: "polling",
+        token: "bad:token",
+      });
+
+      await expect(adapter.connect()).rejects.toThrow(/Failed to initialize bot/);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // disconnect()
+  // -----------------------------------------------------------------------
+
+  describe("disconnect()", () => {
+    it("calls bot.stop() in polling mode", async () => {
+      const adapter = new TelegramChannel({
+        mode: "polling",
+        token: "123:ABC",
+      });
+      await adapter.connect();
+      await adapter.disconnect();
+
+      expect(mockBotStop).toHaveBeenCalledOnce();
+    });
+
+    it("calls bot.api.deleteWebhook() in webhook mode", async () => {
+      const adapter = new TelegramChannel({
+        mode: "webhook",
+        token: "123:ABC",
+        webhookUrl: "https://example.com/webhook",
+      });
+      await adapter.connect();
+      await adapter.disconnect();
+
+      expect(mockDeleteWebhook).toHaveBeenCalledOnce();
+    });
+
+    it("is idempotent — second call is a no-op", async () => {
+      const adapter = new TelegramChannel({
+        mode: "polling",
+        token: "123:ABC",
+      });
+      await adapter.connect();
+      await adapter.disconnect();
+      await adapter.disconnect();
+
+      expect(mockBotStop).toHaveBeenCalledOnce();
+    });
+
+    it("is safe to call before connect()", async () => {
+      const adapter = new TelegramChannel({
+        mode: "polling",
+        token: "123:ABC",
+      });
+      await adapter.disconnect(); // Should not throw
+
+      expect(mockBotStop).not.toHaveBeenCalled();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // send()
+  // -----------------------------------------------------------------------
+
+  describe("send()", () => {
+    it("throws if not connected", async () => {
+      const adapter = new TelegramChannel({
+        mode: "polling",
+        token: "123:ABC",
+      });
+
+      const msg: OutboundMessage = {
+        channelId: "123",
+        blocks: [{ type: "text", content: "hi" }],
+      };
+
+      await expect(adapter.send(msg)).rejects.toThrow(ChannelLoadError);
+      await expect(adapter.send(msg)).rejects.toThrow(/not connected/i);
+    });
+
+    it("calls renderMessage when connected", async () => {
+      const adapter = new TelegramChannel({
+        mode: "polling",
+        token: "123:ABC",
+      });
+      await adapter.connect();
+
+      const msg: OutboundMessage = {
+        channelId: "123",
+        blocks: [{ type: "text", content: "Hello" }],
+      };
+      await adapter.send(msg);
+
+      // Should have called sendChatAction and sendMessage
+      expect(mockSendChatAction).toHaveBeenCalled();
+      expect(mockSendMessage).toHaveBeenCalled();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // onMessage()
+  // -----------------------------------------------------------------------
+
+  describe("onMessage()", () => {
+    it("registers a message handler on the bot", () => {
+      const adapter = new TelegramChannel({
+        mode: "polling",
+        token: "123:ABC",
+      });
+
+      const handler = vi.fn();
+      adapter.onMessage(handler);
+
+      expect(mockBotOn).toHaveBeenCalledWith("message", expect.any(Function));
+      expect(mockBotCatch).toHaveBeenCalledWith(expect.any(Function));
+    });
+
+    it("calls handler with normalized inbound message", async () => {
+      const adapter = new TelegramChannel({
+        mode: "polling",
+        token: "123:ABC",
+      });
+
+      const handler = vi.fn();
+      adapter.onMessage(handler);
+
+      // Get the registered handler
+      const registeredHandler = mockBotOn.mock.calls[0]![1] as (ctx: any) => Promise<void>;
+
+      // Simulate an incoming message
+      const ctx = {
+        update: {
+          update_id: 1,
+          message: {
+            message_id: 42,
+            date: 1700000000,
+            chat: { id: 123, type: "private", first_name: "User" },
+            from: { id: 456, is_bot: false, first_name: "User" },
+            text: "Hello bot",
+          },
+        },
+      };
+
+      await registeredHandler(ctx);
+
+      expect(handler).toHaveBeenCalledOnce();
+      const inbound = handler.mock.calls[0]![0] as InboundMessage;
+      expect(inbound.channelType).toBe("telegram");
+      expect(inbound.channelId).toBe("123");
+      expect(inbound.senderId).toBe("456");
+      expect(inbound.blocks[0]).toEqual({
+        type: "text",
+        content: "Hello bot",
+      });
+    });
+
+    it("does not crash when handler throws", async () => {
+      const adapter = new TelegramChannel({
+        mode: "polling",
+        token: "123:ABC",
+      });
+
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const handler = vi.fn().mockRejectedValue(new Error("handler error"));
+      adapter.onMessage(handler);
+
+      const registeredHandler = mockBotOn.mock.calls[0]![1] as (ctx: any) => Promise<void>;
+
+      const ctx = {
+        update: {
+          update_id: 2,
+          message: {
+            message_id: 43,
+            date: 1700000000,
+            chat: { id: 123, type: "private", first_name: "User" },
+            from: { id: 456, is_bot: false, first_name: "User" },
+            text: "trigger error",
+          },
+        },
+      };
+
+      // Should not throw
+      await registeredHandler(ctx);
+
+      expect(consoleSpy).toHaveBeenCalled();
+      consoleSpy.mockRestore();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Properties
+  // -----------------------------------------------------------------------
+
+  describe("properties", () => {
+    it("has name 'telegram'", () => {
+      const adapter = new TelegramChannel({
+        mode: "polling",
+        token: "123:ABC",
+      });
+      expect(adapter.name).toBe("telegram");
+    });
+
+    it("has TELEGRAM_CAPABILITIES as capabilities", () => {
+      const adapter = new TelegramChannel({
+        mode: "polling",
+        token: "123:ABC",
+      });
+      expect(adapter.capabilities).toBe(TELEGRAM_CAPABILITIES);
+    });
+
+    it("exposes getBot() for webhook integration", () => {
+      const adapter = new TelegramChannel({
+        mode: "webhook",
+        token: "123:ABC",
+        webhookUrl: "https://example.com/webhook",
+      });
+      expect(adapter.getBot()).toBeDefined();
+    });
+  });
+});

--- a/packages/channel-telegram/src/__tests__/unit/capabilities.test.ts
+++ b/packages/channel-telegram/src/__tests__/unit/capabilities.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { TELEGRAM_CAPABILITIES } from "../../capabilities.js";
+
+describe("TELEGRAM_CAPABILITIES", () => {
+  it("declares text with 4096 char limit", () => {
+    expect(TELEGRAM_CAPABILITIES.text).toEqual({
+      supported: true,
+      maxLength: 4096,
+    });
+  });
+
+  it("declares richText with supported formats", () => {
+    expect(TELEGRAM_CAPABILITIES.richText?.supported).toBe(true);
+    expect(TELEGRAM_CAPABILITIES.richText?.formats).toContain("bold");
+    expect(TELEGRAM_CAPABILITIES.richText?.formats).toContain("italic");
+    expect(TELEGRAM_CAPABILITIES.richText?.formats).toContain("code");
+    expect(TELEGRAM_CAPABILITIES.richText?.formats).toContain("link");
+  });
+
+  it("declares images with 10MB limit and common formats", () => {
+    expect(TELEGRAM_CAPABILITIES.images).toEqual({
+      supported: true,
+      maxSize: 10_000_000,
+      formats: ["jpeg", "png", "gif", "webp"],
+    });
+  });
+
+  it("declares files with 50MB limit", () => {
+    expect(TELEGRAM_CAPABILITIES.files).toEqual({
+      supported: true,
+      maxSize: 50_000_000,
+    });
+  });
+
+  it("declares buttons with 100 max", () => {
+    expect(TELEGRAM_CAPABILITIES.buttons).toEqual({
+      supported: true,
+      maxButtons: 100,
+    });
+  });
+
+  it("declares typingIndicator", () => {
+    expect(TELEGRAM_CAPABILITIES.typingIndicator).toEqual({
+      supported: true,
+    });
+  });
+
+  it("declares voiceMessages with 60s max, ogg format", () => {
+    expect(TELEGRAM_CAPABILITIES.voiceMessages).toEqual({
+      supported: true,
+      maxDuration: 60,
+      formats: ["ogg"],
+    });
+  });
+
+  it("declares groups with 200k max members", () => {
+    expect(TELEGRAM_CAPABILITIES.groups).toEqual({
+      supported: true,
+      maxMembers: 200_000,
+    });
+  });
+
+  it("does not declare threads", () => {
+    expect(TELEGRAM_CAPABILITIES.threads).toBeUndefined();
+  });
+
+  it("does not declare reactions", () => {
+    expect(TELEGRAM_CAPABILITIES.reactions).toBeUndefined();
+  });
+
+  it("does not declare readReceipts", () => {
+    expect(TELEGRAM_CAPABILITIES.readReceipts).toBeUndefined();
+  });
+});

--- a/packages/channel-telegram/src/__tests__/unit/config.test.ts
+++ b/packages/channel-telegram/src/__tests__/unit/config.test.ts
@@ -1,0 +1,100 @@
+import { ChannelLoadError } from "@templar/errors";
+import { describe, expect, it } from "vitest";
+import { parseTelegramConfig } from "../../config.js";
+
+describe("parseTelegramConfig", () => {
+  describe("polling mode", () => {
+    it("accepts valid polling config", () => {
+      const config = parseTelegramConfig({
+        mode: "polling",
+        token: "123:ABC",
+      });
+      expect(config).toEqual({ mode: "polling", token: "123:ABC" });
+    });
+
+    it("strips extra fields", () => {
+      const config = parseTelegramConfig({
+        mode: "polling",
+        token: "123:ABC",
+        extraField: "should be ignored",
+      });
+      expect(config).toEqual({ mode: "polling", token: "123:ABC" });
+    });
+  });
+
+  describe("webhook mode", () => {
+    it("accepts valid webhook config", () => {
+      const config = parseTelegramConfig({
+        mode: "webhook",
+        token: "123:ABC",
+        webhookUrl: "https://example.com/webhook",
+      });
+      expect(config).toEqual({
+        mode: "webhook",
+        token: "123:ABC",
+        webhookUrl: "https://example.com/webhook",
+      });
+    });
+
+    it("accepts webhook config with secretToken", () => {
+      const config = parseTelegramConfig({
+        mode: "webhook",
+        token: "123:ABC",
+        webhookUrl: "https://example.com/webhook",
+        secretToken: "my-secret",
+      });
+      expect(config).toEqual({
+        mode: "webhook",
+        token: "123:ABC",
+        webhookUrl: "https://example.com/webhook",
+        secretToken: "my-secret",
+      });
+    });
+
+    it("rejects webhook config without webhookUrl", () => {
+      expect(() => parseTelegramConfig({ mode: "webhook", token: "123:ABC" })).toThrow(
+        ChannelLoadError,
+      );
+    });
+
+    it("rejects webhook config with invalid URL", () => {
+      expect(() =>
+        parseTelegramConfig({
+          mode: "webhook",
+          token: "123:ABC",
+          webhookUrl: "not-a-url",
+        }),
+      ).toThrow(ChannelLoadError);
+    });
+  });
+
+  describe("validation errors", () => {
+    it("rejects missing token", () => {
+      expect(() => parseTelegramConfig({ mode: "polling" })).toThrow(ChannelLoadError);
+    });
+
+    it("rejects empty token", () => {
+      expect(() => parseTelegramConfig({ mode: "polling", token: "" })).toThrow(ChannelLoadError);
+    });
+
+    it("rejects invalid mode", () => {
+      expect(() => parseTelegramConfig({ mode: "invalid", token: "123:ABC" })).toThrow(
+        ChannelLoadError,
+      );
+    });
+
+    it("rejects empty config", () => {
+      expect(() => parseTelegramConfig({})).toThrow(ChannelLoadError);
+    });
+
+    it("includes field path in error message", () => {
+      try {
+        parseTelegramConfig({ mode: "polling", token: "" });
+        expect.fail("Should have thrown");
+      } catch (error) {
+        expect(error).toBeInstanceOf(ChannelLoadError);
+        expect((error as ChannelLoadError).message).toContain("token");
+      }
+    });
+  });
+});

--- a/packages/channel-telegram/src/__tests__/unit/normalizer.test.ts
+++ b/packages/channel-telegram/src/__tests__/unit/normalizer.test.ts
@@ -1,0 +1,492 @@
+import type { MessageEntity } from "grammy/types";
+import { describe, expect, it } from "vitest";
+import { entitiesToHtml, hasBotMention, normalizeUpdate } from "../../normalizer.js";
+import {
+  createCallbackQueryUpdate,
+  createDocumentUpdate,
+  createGroupUpdate,
+  createMockApi,
+  createPhotoUpdate,
+  createStickerUpdate,
+  createTextUpdate,
+  createVoiceUpdate,
+  MOCK_BOT_INFO,
+} from "../helpers/mock-grammy.js";
+
+describe("normalizeUpdate", () => {
+  const TOKEN = "fake:token";
+  const BOT_USERNAME = MOCK_BOT_INFO.username;
+
+  function setup() {
+    return createMockApi();
+  }
+
+  // -----------------------------------------------------------------------
+  // Text messages
+  // -----------------------------------------------------------------------
+
+  describe("text messages", () => {
+    it("normalizes plain text", async () => {
+      const { api } = setup();
+      const update = createTextUpdate("Hello world");
+      const result = await normalizeUpdate(update, api, TOKEN, BOT_USERNAME);
+
+      expect(result).toBeDefined();
+      expect(result!.channelType).toBe("telegram");
+      expect(result!.blocks).toHaveLength(1);
+      expect(result!.blocks[0]).toEqual({
+        type: "text",
+        content: "Hello world",
+      });
+    });
+
+    it("populates senderId, channelId, messageId", async () => {
+      const { api } = setup();
+      const update = createTextUpdate("hi", { chatId: 999, userId: 777 });
+      const result = await normalizeUpdate(update, api, TOKEN, BOT_USERNAME);
+
+      expect(result!.senderId).toBe("777");
+      expect(result!.channelId).toBe("999");
+      expect(result!.messageId).toBeDefined();
+    });
+
+    it("converts timestamp from Unix seconds to milliseconds", async () => {
+      const { api } = setup();
+      const update = createTextUpdate("hi");
+      const result = await normalizeUpdate(update, api, TOKEN, BOT_USERNAME);
+
+      // Timestamp should be in milliseconds
+      expect(result!.timestamp).toBeGreaterThan(1_000_000_000_000);
+    });
+
+    it("stores raw update", async () => {
+      const { api } = setup();
+      const update = createTextUpdate("hi");
+      const result = await normalizeUpdate(update, api, TOKEN, BOT_USERNAME);
+
+      expect(result!.raw).toBe(update);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Text with entities
+  // -----------------------------------------------------------------------
+
+  describe("text with entities", () => {
+    it("converts bold entity to HTML", async () => {
+      const { api } = setup();
+      const entities: MessageEntity[] = [{ type: "bold", offset: 0, length: 5 }];
+      const update = createTextUpdate("Hello world", { entities });
+      const result = await normalizeUpdate(update, api, TOKEN, BOT_USERNAME);
+
+      expect(result!.blocks[0]).toEqual({
+        type: "text",
+        content: "<b>Hello</b> world",
+      });
+    });
+
+    it("converts italic entity to HTML", async () => {
+      const { api } = setup();
+      const entities: MessageEntity[] = [{ type: "italic", offset: 6, length: 5 }];
+      const update = createTextUpdate("Hello world", { entities });
+      const result = await normalizeUpdate(update, api, TOKEN, BOT_USERNAME);
+
+      expect(result!.blocks[0]).toEqual({
+        type: "text",
+        content: "Hello <i>world</i>",
+      });
+    });
+
+    it("converts code entity to HTML", async () => {
+      const { api } = setup();
+      const entities: MessageEntity[] = [{ type: "code", offset: 4, length: 3 }];
+      const update = createTextUpdate("Use foo here", { entities });
+      const result = await normalizeUpdate(update, api, TOKEN, BOT_USERNAME);
+
+      expect(result!.blocks[0]).toEqual({
+        type: "text",
+        content: "Use <code>foo</code> here",
+      });
+    });
+
+    it("converts text_link entity to HTML anchor", async () => {
+      const { api } = setup();
+      const entities: MessageEntity[] = [
+        { type: "text_link", offset: 6, length: 4, url: "https://example.com" },
+      ];
+      const update = createTextUpdate("Click here now", { entities });
+      const result = await normalizeUpdate(update, api, TOKEN, BOT_USERNAME);
+
+      expect(result!.blocks[0]).toEqual({
+        type: "text",
+        content: 'Click <a href="https://example.com">here</a> now',
+      });
+    });
+
+    it("converts strikethrough entity to HTML", async () => {
+      const { api } = setup();
+      const entities: MessageEntity[] = [{ type: "strikethrough", offset: 0, length: 6 }];
+      const update = createTextUpdate("delete this", { entities });
+      const result = await normalizeUpdate(update, api, TOKEN, BOT_USERNAME);
+
+      expect(result!.blocks[0]).toEqual({
+        type: "text",
+        content: "<s>delete</s> this",
+      });
+    });
+
+    it("converts underline entity to HTML", async () => {
+      const { api } = setup();
+      const entities: MessageEntity[] = [{ type: "underline", offset: 0, length: 9 }];
+      const update = createTextUpdate("important text", { entities });
+      const result = await normalizeUpdate(update, api, TOKEN, BOT_USERNAME);
+
+      expect(result!.blocks[0]).toEqual({
+        type: "text",
+        content: "<u>important</u> text",
+      });
+    });
+
+    it("converts spoiler entity to HTML", async () => {
+      const { api } = setup();
+      const entities: MessageEntity[] = [{ type: "spoiler", offset: 0, length: 6 }];
+      const update = createTextUpdate("secret info", { entities });
+      const result = await normalizeUpdate(update, api, TOKEN, BOT_USERNAME);
+
+      expect(result!.blocks[0]).toEqual({
+        type: "text",
+        content: "<tg-spoiler>secret</tg-spoiler> info",
+      });
+    });
+
+    it("converts blockquote entity to HTML", async () => {
+      const { api } = setup();
+      const entities: MessageEntity[] = [{ type: "blockquote", offset: 0, length: 12 }];
+      const update = createTextUpdate("quoted text.", { entities });
+      const result = await normalizeUpdate(update, api, TOKEN, BOT_USERNAME);
+
+      expect(result!.blocks[0]).toEqual({
+        type: "text",
+        content: "<blockquote>quoted text.</blockquote>",
+      });
+    });
+
+    it("converts pre entity with language", async () => {
+      const { api } = setup();
+      const entities: MessageEntity[] = [
+        { type: "pre", offset: 0, length: 10, language: "typescript" },
+      ];
+      const update = createTextUpdate("const x =1", { entities });
+      const result = await normalizeUpdate(update, api, TOKEN, BOT_USERNAME);
+
+      expect(result!.blocks[0]).toEqual({
+        type: "text",
+        content: '<pre><code class="language-typescript">const x =1</code></pre>',
+      });
+    });
+
+    it("handles multiple non-overlapping entities", async () => {
+      const { api } = setup();
+      const entities: MessageEntity[] = [
+        { type: "bold", offset: 0, length: 5 },
+        { type: "italic", offset: 6, length: 5 },
+      ];
+      const update = createTextUpdate("Hello world", { entities });
+      const result = await normalizeUpdate(update, api, TOKEN, BOT_USERNAME);
+
+      expect(result!.blocks[0]).toEqual({
+        type: "text",
+        content: "<b>Hello</b> <i>world</i>",
+      });
+    });
+
+    it("preserves plain text without entities as-is", async () => {
+      const { api } = setup();
+      const update = createTextUpdate("a < b && c > d");
+      const result = await normalizeUpdate(update, api, TOKEN, BOT_USERNAME);
+
+      // Plain text (no entities) passes through without HTML escaping
+      expect(result!.blocks[0]).toEqual({
+        type: "text",
+        content: "a < b && c > d",
+      });
+    });
+
+    it("escapes HTML in entity content", async () => {
+      const { api } = setup();
+      const entities: MessageEntity[] = [{ type: "bold", offset: 0, length: 5 }];
+      const update = createTextUpdate("a<b>c test", { entities });
+      const result = await normalizeUpdate(update, api, TOKEN, BOT_USERNAME);
+
+      expect(result!.blocks[0]).toEqual({
+        type: "text",
+        content: "<b>a&lt;b&gt;c</b> test",
+      });
+    });
+
+    it("passes through mention entities without wrapping", async () => {
+      const { api } = setup();
+      const entities: MessageEntity[] = [{ type: "mention", offset: 0, length: 9 }];
+      const update = createTextUpdate("@testuser hello", { entities });
+      const result = await normalizeUpdate(update, api, TOKEN, BOT_USERNAME);
+
+      expect(result!.blocks[0]).toEqual({
+        type: "text",
+        content: "@testuser hello",
+      });
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Photo messages
+  // -----------------------------------------------------------------------
+
+  describe("photo messages", () => {
+    it("normalizes photo (picks largest size)", async () => {
+      const { api, calls } = setup();
+      const update = createPhotoUpdate("photo_123");
+      const result = await normalizeUpdate(update, api, TOKEN, BOT_USERNAME);
+
+      expect(result!.blocks).toHaveLength(1);
+      const block = result!.blocks[0]!;
+      expect(block.type).toBe("image");
+      expect((block as { url: string }).url).toContain("photo_123");
+
+      // Should call getFile with the largest photo's file_id
+      const getFileCalls = calls.filter((c) => c.method === "getFile");
+      expect(getFileCalls).toHaveLength(1);
+      // grammY passes file_id as positional arg
+      expect(getFileCalls[0]!.payload._args).toContain("photo_123");
+    });
+
+    it("stores file_id in alt field", async () => {
+      const { api } = setup();
+      const update = createPhotoUpdate("photo_abc");
+      const result = await normalizeUpdate(update, api, TOKEN, BOT_USERNAME);
+
+      const block = result!.blocks[0] as { alt: string };
+      expect(block.alt).toBe("photo:photo_abc");
+    });
+
+    it("includes file_size from largest photo", async () => {
+      const { api } = setup();
+      const update = createPhotoUpdate("photo_123");
+      const result = await normalizeUpdate(update, api, TOKEN, BOT_USERNAME);
+
+      const block = result!.blocks[0] as { size?: number };
+      expect(block.size).toBe(50000);
+    });
+
+    it("normalizes photo with caption as two blocks", async () => {
+      const { api } = setup();
+      const update = createPhotoUpdate("photo_123", {
+        caption: "Nice photo",
+      });
+      const result = await normalizeUpdate(update, api, TOKEN, BOT_USERNAME);
+
+      expect(result!.blocks).toHaveLength(2);
+      expect(result!.blocks[0]!.type).toBe("image");
+      expect(result!.blocks[1]).toEqual({
+        type: "text",
+        content: "Nice photo",
+      });
+    });
+
+    it("normalizes photo caption with entities", async () => {
+      const { api } = setup();
+      const captionEntities: MessageEntity[] = [{ type: "bold", offset: 0, length: 4 }];
+      const update = createPhotoUpdate("photo_123", {
+        caption: "Nice photo",
+        captionEntities,
+      });
+      const result = await normalizeUpdate(update, api, TOKEN, BOT_USERNAME);
+
+      expect(result!.blocks[1]).toEqual({
+        type: "text",
+        content: "<b>Nice</b> photo",
+      });
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Document messages
+  // -----------------------------------------------------------------------
+
+  describe("document messages", () => {
+    it("normalizes document", async () => {
+      const { api, calls } = setup();
+      const update = createDocumentUpdate("doc_123", {
+        fileName: "report.pdf",
+        mimeType: "application/pdf",
+        fileSize: 2048,
+      });
+      const result = await normalizeUpdate(update, api, TOKEN, BOT_USERNAME);
+
+      expect(result!.blocks).toHaveLength(1);
+      const block = result!.blocks[0]!;
+      expect(block.type).toBe("file");
+      expect((block as { filename: string }).filename).toBe("report.pdf");
+      expect((block as { mimeType: string }).mimeType).toBe("application/pdf");
+      expect((block as { size?: number }).size).toBe(2048);
+
+      const getFileCalls = calls.filter((c) => c.method === "getFile");
+      expect(getFileCalls).toHaveLength(1);
+    });
+
+    it("uses defaults for missing document fields", async () => {
+      const { api } = setup();
+      const update = createDocumentUpdate("doc_456");
+      const result = await normalizeUpdate(update, api, TOKEN, BOT_USERNAME);
+
+      const block = result!.blocks[0]!;
+      expect((block as { filename: string }).filename).toBe("test.pdf");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Voice messages
+  // -----------------------------------------------------------------------
+
+  describe("voice messages", () => {
+    it("normalizes voice message as file block", async () => {
+      const { api } = setup();
+      const update = createVoiceUpdate("voice_123", { duration: 10 });
+      const result = await normalizeUpdate(update, api, TOKEN, BOT_USERNAME);
+
+      expect(result!.blocks).toHaveLength(1);
+      const block = result!.blocks[0]!;
+      expect(block.type).toBe("file");
+      expect((block as { filename: string }).filename).toBe("voice.ogg");
+      expect((block as { mimeType: string }).mimeType).toBe("audio/ogg");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Unsupported / empty content
+  // -----------------------------------------------------------------------
+
+  describe("unsupported content", () => {
+    it("returns message with empty blocks for sticker", async () => {
+      const { api } = setup();
+      const update = createStickerUpdate();
+      const result = await normalizeUpdate(update, api, TOKEN, BOT_USERNAME);
+
+      expect(result).toBeDefined();
+      expect(result!.blocks).toHaveLength(0);
+    });
+
+    it("returns undefined for update without message", async () => {
+      const { api } = setup();
+      const update = createCallbackQueryUpdate();
+      const result = await normalizeUpdate(update, api, TOKEN, BOT_USERNAME);
+
+      expect(result).toBeUndefined();
+    });
+
+    it("returns undefined for empty update", async () => {
+      const { api } = setup();
+      const update = { update_id: 1 } as any;
+      const result = await normalizeUpdate(update, api, TOKEN, BOT_USERNAME);
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Group messages
+  // -----------------------------------------------------------------------
+
+  describe("group messages", () => {
+    it("populates threadId from message_thread_id", async () => {
+      const { api } = setup();
+      const update = createGroupUpdate("hello", { threadId: 42 });
+      const result = await normalizeUpdate(update, api, TOKEN, BOT_USERNAME);
+
+      expect(result!.threadId).toBe("42");
+    });
+
+    it("omits threadId when not present", async () => {
+      const { api } = setup();
+      const update = createTextUpdate("hello");
+      const result = await normalizeUpdate(update, api, TOKEN, BOT_USERNAME);
+
+      expect(result!.threadId).toBeUndefined();
+    });
+
+    it("uses group chat id as channelId", async () => {
+      const { api } = setup();
+      const update = createGroupUpdate("hello", { chatId: -100999 });
+      const result = await normalizeUpdate(update, api, TOKEN, BOT_USERNAME);
+
+      expect(result!.channelId).toBe("-100999");
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// entitiesToHtml (unit tests)
+// ---------------------------------------------------------------------------
+
+describe("entitiesToHtml", () => {
+  it("returns escaped text when no entities", () => {
+    expect(entitiesToHtml("a < b", [])).toBe("a &lt; b");
+  });
+
+  it("handles entity at start of text", () => {
+    const entities: MessageEntity[] = [{ type: "bold", offset: 0, length: 3 }];
+    expect(entitiesToHtml("foo bar", entities)).toBe("<b>foo</b> bar");
+  });
+
+  it("handles entity at end of text", () => {
+    const entities: MessageEntity[] = [{ type: "italic", offset: 4, length: 3 }];
+    expect(entitiesToHtml("foo bar", entities)).toBe("foo <i>bar</i>");
+  });
+
+  it("handles entity spanning entire text", () => {
+    const entities: MessageEntity[] = [{ type: "code", offset: 0, length: 7 }];
+    expect(entitiesToHtml("foo bar", entities)).toBe("<code>foo bar</code>");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// hasBotMention
+// ---------------------------------------------------------------------------
+
+describe("hasBotMention", () => {
+  it("detects bot mention", () => {
+    const msg = {
+      text: "@test_bot hello",
+      entities: [{ type: "mention" as const, offset: 0, length: 9 }],
+    } as any;
+    expect(hasBotMention(msg, "test_bot")).toBe(true);
+  });
+
+  it("is case-insensitive", () => {
+    const msg = {
+      text: "@Test_Bot hello",
+      entities: [{ type: "mention" as const, offset: 0, length: 9 }],
+    } as any;
+    expect(hasBotMention(msg, "test_bot")).toBe(true);
+  });
+
+  it("returns false when no mention", () => {
+    const msg = {
+      text: "hello",
+      entities: [],
+    } as any;
+    expect(hasBotMention(msg, "test_bot")).toBe(false);
+  });
+
+  it("returns false when mentioning different bot", () => {
+    const msg = {
+      text: "@other_bot hello",
+      entities: [{ type: "mention" as const, offset: 0, length: 10 }],
+    } as any;
+    expect(hasBotMention(msg, "test_bot")).toBe(false);
+  });
+
+  it("returns false when no entities", () => {
+    const msg = { text: "@test_bot hello" } as any;
+    expect(hasBotMention(msg, "test_bot")).toBe(false);
+  });
+});

--- a/packages/channel-telegram/src/__tests__/unit/renderer.test.ts
+++ b/packages/channel-telegram/src/__tests__/unit/renderer.test.ts
@@ -1,0 +1,271 @@
+import type { OutboundMessage } from "@templar/core";
+import { describe, expect, it } from "vitest";
+import { buildRenderPlan, renderMessage } from "../../renderer.js";
+import { createMockApi } from "../helpers/mock-grammy.js";
+
+describe("buildRenderPlan", () => {
+  const BASE_MSG: OutboundMessage = {
+    channelId: "123",
+    blocks: [],
+  };
+
+  it("returns empty plan for empty blocks", () => {
+    const plan = buildRenderPlan({ ...BASE_MSG, blocks: [] });
+    expect(plan).toHaveLength(0);
+  });
+
+  it("sends typing indicator before content", () => {
+    const plan = buildRenderPlan({
+      ...BASE_MSG,
+      blocks: [{ type: "text", content: "hi" }],
+    });
+    expect(plan[0]).toEqual({
+      kind: "sendChatAction",
+      chatId: "123",
+      action: "typing",
+    });
+  });
+
+  it("renders single text block as sendMessage", () => {
+    const plan = buildRenderPlan({
+      ...BASE_MSG,
+      blocks: [{ type: "text", content: "Hello" }],
+    });
+    // typing + sendMessage
+    expect(plan).toHaveLength(2);
+    expect(plan[1]).toMatchObject({
+      kind: "sendMessage",
+      chatId: "123",
+      text: "Hello",
+      parseMode: "HTML",
+    });
+  });
+
+  it("renders single image block as sendPhoto", () => {
+    const plan = buildRenderPlan({
+      ...BASE_MSG,
+      blocks: [{ type: "image", url: "https://img.jpg" }],
+    });
+    expect(plan).toHaveLength(2);
+    expect(plan[1]).toMatchObject({
+      kind: "sendPhoto",
+      chatId: "123",
+      photo: "https://img.jpg",
+    });
+  });
+
+  it("renders single file block as sendDocument", () => {
+    const plan = buildRenderPlan({
+      ...BASE_MSG,
+      blocks: [
+        {
+          type: "file",
+          url: "https://file.pdf",
+          filename: "doc.pdf",
+          mimeType: "application/pdf",
+        },
+      ],
+    });
+    expect(plan).toHaveLength(2);
+    expect(plan[1]).toMatchObject({
+      kind: "sendDocument",
+      chatId: "123",
+      document: "https://file.pdf",
+      filename: "doc.pdf",
+    });
+  });
+
+  it("attaches buttons to preceding text message", () => {
+    const plan = buildRenderPlan({
+      ...BASE_MSG,
+      blocks: [
+        { type: "text", content: "Choose:" },
+        {
+          type: "button",
+          buttons: [
+            { label: "A", action: "opt_a" },
+            { label: "B", action: "opt_b" },
+          ],
+        },
+      ],
+    });
+    // typing + sendMessage (with keyboard)
+    expect(plan).toHaveLength(2);
+    const textCall = plan[1]!;
+    expect(textCall).toMatchObject({ kind: "sendMessage", text: "Choose:" });
+    expect((textCall as any).replyMarkup).toEqual({
+      inline_keyboard: [
+        [{ text: "A", callback_data: "opt_a" }],
+        [{ text: "B", callback_data: "opt_b" }],
+      ],
+    });
+  });
+
+  it("attaches buttons to preceding image message", () => {
+    const plan = buildRenderPlan({
+      ...BASE_MSG,
+      blocks: [
+        { type: "image", url: "https://img.jpg" },
+        {
+          type: "button",
+          buttons: [{ label: "Like", action: "like" }],
+        },
+      ],
+    });
+    expect(plan).toHaveLength(2);
+    expect((plan[1] as any).replyMarkup).toBeDefined();
+  });
+
+  it("renders standalone button block with placeholder text", () => {
+    const plan = buildRenderPlan({
+      ...BASE_MSG,
+      blocks: [
+        {
+          type: "button",
+          buttons: [{ label: "Start", action: "start" }],
+        },
+      ],
+    });
+    // typing + sendMessage (placeholder + keyboard)
+    expect(plan).toHaveLength(2);
+    const textCall = plan[1]!;
+    expect(textCall).toMatchObject({
+      kind: "sendMessage",
+      text: "Please choose an option:",
+    });
+    expect((textCall as any).replyMarkup).toBeDefined();
+  });
+
+  it("coalesces multiple adjacent text blocks", () => {
+    const plan = buildRenderPlan({
+      ...BASE_MSG,
+      blocks: [
+        { type: "text", content: "Line 1" },
+        { type: "text", content: "Line 2" },
+        { type: "text", content: "Line 3" },
+      ],
+    });
+    // typing + single coalesced sendMessage
+    expect(plan).toHaveLength(2);
+    expect(plan[1]).toMatchObject({
+      kind: "sendMessage",
+      text: "Line 1\nLine 2\nLine 3",
+    });
+  });
+
+  it("renders text + image + text as 3 separate API calls", () => {
+    const plan = buildRenderPlan({
+      ...BASE_MSG,
+      blocks: [
+        { type: "text", content: "Before" },
+        { type: "image", url: "https://img.jpg" },
+        { type: "text", content: "After" },
+      ],
+    });
+    // typing + sendMessage + sendPhoto + sendMessage
+    expect(plan).toHaveLength(4);
+    expect(plan[1]).toMatchObject({ kind: "sendMessage", text: "Before" });
+    expect(plan[2]).toMatchObject({ kind: "sendPhoto" });
+    expect(plan[3]).toMatchObject({ kind: "sendMessage", text: "After" });
+  });
+
+  it("splits text exceeding 4096 chars into multiple messages", () => {
+    const longText = "x".repeat(5000);
+    const plan = buildRenderPlan({
+      ...BASE_MSG,
+      blocks: [{ type: "text", content: longText }],
+    });
+    // typing + multiple sendMessage calls
+    expect(plan.length).toBeGreaterThan(2);
+    for (let i = 1; i < plan.length; i++) {
+      expect(plan[i]!.kind).toBe("sendMessage");
+      expect(((plan[i] as any).text as string).length).toBeLessThanOrEqual(4096);
+    }
+  });
+
+  it("passes threadId to all calls", () => {
+    const plan = buildRenderPlan({
+      ...BASE_MSG,
+      blocks: [{ type: "text", content: "hi" }],
+      threadId: "42",
+    });
+    expect((plan[1] as any).threadId).toBe("42");
+  });
+
+  it("passes replyTo to all calls", () => {
+    const plan = buildRenderPlan({
+      ...BASE_MSG,
+      blocks: [{ type: "text", content: "hi" }],
+      replyTo: "99",
+    });
+    expect((plan[1] as any).replyTo).toBe("99");
+  });
+});
+
+describe("renderMessage (integration)", () => {
+  it("executes all calls from render plan sequentially", async () => {
+    const { api, calls } = createMockApi();
+
+    await renderMessage(
+      {
+        channelId: "123",
+        blocks: [
+          { type: "text", content: "Hello" },
+          { type: "image", url: "https://img.jpg" },
+        ],
+      },
+      api,
+    );
+
+    // typing + sendMessage + sendPhoto
+    expect(calls).toHaveLength(3);
+    expect(calls[0]!.method).toBe("sendChatAction");
+    expect(calls[1]!.method).toBe("sendMessage");
+    expect(calls[2]!.method).toBe("sendPhoto");
+  });
+
+  it("does nothing for empty blocks", async () => {
+    const { api, calls } = createMockApi();
+
+    await renderMessage({ channelId: "123", blocks: [] }, api);
+
+    expect(calls).toHaveLength(0);
+  });
+
+  it("passes message_thread_id when threadId is set", async () => {
+    const { api, calls } = createMockApi();
+
+    await renderMessage(
+      {
+        channelId: "123",
+        blocks: [{ type: "text", content: "hi" }],
+        threadId: "42",
+      },
+      api,
+    );
+
+    // sendMessage call should include message_thread_id in opts
+    const sendCall = calls.find((c) => c.method === "sendMessage");
+    expect(sendCall).toBeDefined();
+    // The opts are passed as the 3rd argument
+    const opts = (sendCall!.payload._args as unknown[])?.[2] ?? sendCall!.payload;
+    expect((opts as any).message_thread_id).toBe(42);
+  });
+
+  it("passes reply_to_message_id when replyTo is set", async () => {
+    const { api, calls } = createMockApi();
+
+    await renderMessage(
+      {
+        channelId: "123",
+        blocks: [{ type: "text", content: "hi" }],
+        replyTo: "99",
+      },
+      api,
+    );
+
+    const sendCall = calls.find((c) => c.method === "sendMessage");
+    const opts = (sendCall!.payload._args as unknown[])?.[2] ?? sendCall!.payload;
+    expect((opts as any).reply_to_message_id).toBe(99);
+  });
+});

--- a/packages/channel-telegram/src/adapter.ts
+++ b/packages/channel-telegram/src/adapter.ts
@@ -1,0 +1,127 @@
+import { autoRetry } from "@grammyjs/auto-retry";
+import type {
+  ChannelAdapter,
+  ChannelCapabilities,
+  MessageHandler,
+  OutboundMessage,
+} from "@templar/core";
+import { ChannelLoadError } from "@templar/errors";
+import { Bot } from "grammy";
+
+import { TELEGRAM_CAPABILITIES } from "./capabilities.js";
+import { parseTelegramConfig, type TelegramConfig } from "./config.js";
+import { normalizeUpdate } from "./normalizer.js";
+import { renderMessage } from "./renderer.js";
+
+/**
+ * Telegram channel adapter using grammY.
+ *
+ * Implements the ChannelAdapter interface with:
+ * - Config-driven dual mode (polling / webhook)
+ * - Automatic 429 retry via @grammyjs/auto-retry
+ * - Entity-aware message normalization
+ * - Sequential block rendering with text coalescing
+ */
+export class TelegramChannel implements ChannelAdapter {
+  readonly name = "telegram" as const;
+  readonly capabilities: ChannelCapabilities = TELEGRAM_CAPABILITIES;
+
+  private readonly config: TelegramConfig;
+  private readonly bot: Bot;
+  private connected = false;
+
+  constructor(rawConfig: Readonly<Record<string, unknown>>) {
+    this.config = parseTelegramConfig(rawConfig);
+    this.bot = new Bot(this.config.token);
+    this.bot.api.config.use(autoRetry());
+  }
+
+  async connect(): Promise<void> {
+    if (this.connected) return;
+
+    try {
+      await this.bot.init();
+    } catch (error) {
+      throw new ChannelLoadError(
+        "telegram",
+        `Failed to initialize bot: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+
+    if (this.config.mode === "polling") {
+      // bot.start() runs in the background; it resolves after starting to poll
+      this.bot.start({
+        onStart: () => {
+          /* polling started */
+        },
+      });
+      this.connected = true;
+    } else {
+      try {
+        const webhookOpts: Record<string, unknown> = {};
+        if (this.config.secretToken) {
+          webhookOpts.secret_token = this.config.secretToken;
+        }
+        await this.bot.api.setWebhook(this.config.webhookUrl, webhookOpts);
+        this.connected = true;
+      } catch (error) {
+        throw new ChannelLoadError(
+          "telegram",
+          `Failed to set webhook: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    }
+  }
+
+  async disconnect(): Promise<void> {
+    if (!this.connected) return;
+
+    if (this.config.mode === "polling") {
+      await this.bot.stop();
+    } else {
+      await this.bot.api.deleteWebhook();
+    }
+    this.connected = false;
+  }
+
+  async send(message: OutboundMessage): Promise<void> {
+    if (!this.connected) {
+      throw new ChannelLoadError(
+        "telegram",
+        "Cannot send message: adapter not connected. Call connect() first.",
+      );
+    }
+    await renderMessage(message, this.bot.api);
+  }
+
+  onMessage(handler: MessageHandler): void {
+    const botUsername = this.bot.botInfo?.username ?? "";
+    const token = this.config.token;
+
+    this.bot.on("message", async (ctx) => {
+      try {
+        const inbound = await normalizeUpdate(ctx.update, this.bot.api, token, botUsername);
+        if (inbound) {
+          await handler(inbound);
+        }
+      } catch (error) {
+        console.error(
+          `[TelegramChannel] Error handling update ${ctx.update.update_id}:`,
+          error instanceof Error ? error.message : String(error),
+        );
+      }
+    });
+
+    this.bot.catch((err) => {
+      console.error("[TelegramChannel] Unhandled error:", err.message);
+    });
+  }
+
+  /**
+   * Get the underlying grammY Bot instance.
+   * Useful for webhook integration where the caller mounts the webhook handler.
+   */
+  getBot(): Bot {
+    return this.bot;
+  }
+}

--- a/packages/channel-telegram/src/capabilities.ts
+++ b/packages/channel-telegram/src/capabilities.ts
@@ -1,0 +1,34 @@
+import type { ChannelCapabilities } from "@templar/core";
+
+/**
+ * Static capability declaration for Telegram via grammY.
+ *
+ * MVP scope: text, richText, images, files, buttons, typingIndicator,
+ * voiceMessages, groups. Threads and reactions deferred to follow-up.
+ */
+export const TELEGRAM_CAPABILITIES: ChannelCapabilities = {
+  text: { supported: true, maxLength: 4096 },
+  richText: {
+    supported: true,
+    formats: [
+      "bold",
+      "italic",
+      "code",
+      "link",
+      "strikethrough",
+      "underline",
+      "spoiler",
+      "blockquote",
+    ],
+  },
+  images: {
+    supported: true,
+    maxSize: 10_000_000,
+    formats: ["jpeg", "png", "gif", "webp"],
+  },
+  files: { supported: true, maxSize: 50_000_000 },
+  buttons: { supported: true, maxButtons: 100 },
+  typingIndicator: { supported: true },
+  voiceMessages: { supported: true, maxDuration: 60, formats: ["ogg"] },
+  groups: { supported: true, maxMembers: 200_000 },
+} as const;

--- a/packages/channel-telegram/src/config.ts
+++ b/packages/channel-telegram/src/config.ts
@@ -1,0 +1,38 @@
+import { ChannelLoadError } from "@templar/errors";
+import { z } from "zod";
+
+const BaseConfig = z.object({
+  token: z.string().min(1, "Bot token is required"),
+});
+
+const PollingConfig = BaseConfig.extend({
+  mode: z.literal("polling"),
+});
+
+const WebhookConfig = BaseConfig.extend({
+  mode: z.literal("webhook"),
+  webhookUrl: z.string().url("webhookUrl must be a valid URL"),
+  secretToken: z.string().optional(),
+});
+
+export type TelegramConfig =
+  | { mode: "polling"; token: string }
+  | { mode: "webhook"; token: string; webhookUrl: string; secretToken?: string | undefined };
+
+const TelegramConfigSchema: z.ZodType<TelegramConfig> = z.discriminatedUnion("mode", [
+  PollingConfig,
+  WebhookConfig,
+]);
+
+/**
+ * Parse and validate raw config into a typed TelegramConfig.
+ * Throws ChannelLoadError on validation failure.
+ */
+export function parseTelegramConfig(raw: Readonly<Record<string, unknown>>): TelegramConfig {
+  const result = TelegramConfigSchema.safeParse(raw);
+  if (!result.success) {
+    const issues = result.error.issues.map((i) => `${i.path.join(".")}: ${i.message}`).join("; ");
+    throw new ChannelLoadError("telegram", `Invalid config: ${issues}`);
+  }
+  return result.data;
+}

--- a/packages/channel-telegram/src/index.ts
+++ b/packages/channel-telegram/src/index.ts
@@ -1,0 +1,3 @@
+export { TelegramChannel, TelegramChannel as default } from "./adapter.js";
+export { TELEGRAM_CAPABILITIES } from "./capabilities.js";
+export type { TelegramConfig } from "./config.js";

--- a/packages/channel-telegram/src/normalizer.ts
+++ b/packages/channel-telegram/src/normalizer.ts
@@ -1,0 +1,236 @@
+import type { ContentBlock, FileBlock, ImageBlock, InboundMessage, TextBlock } from "@templar/core";
+import type { Api } from "grammy";
+import type { Message, MessageEntity, PhotoSize, Update } from "grammy/types";
+
+// ---------------------------------------------------------------------------
+// File URL resolution
+// ---------------------------------------------------------------------------
+
+const TELEGRAM_FILE_BASE = "https://api.telegram.org/file/bot";
+
+async function resolveFileUrl(api: Api, fileId: string, token: string): Promise<string> {
+  const file = await api.getFile(fileId);
+  if (!file.file_path) {
+    return "";
+  }
+  return `${TELEGRAM_FILE_BASE}${token}/${file.file_path}`;
+}
+
+// ---------------------------------------------------------------------------
+// Entity-to-HTML conversion
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert Telegram MessageEntity array to HTML-formatted text.
+ * Handles nested/overlapping entities by processing them in offset order.
+ *
+ * Note: Telegram entity offsets are in UTF-16 code units.
+ * JavaScript strings use UTF-16 internally, so .length and .slice() work correctly.
+ */
+export function entitiesToHtml(text: string, entities: readonly MessageEntity[]): string {
+  if (entities.length === 0) return escapeHtml(text);
+
+  // Sort by offset ascending, then by length descending (outer entity first)
+  const sorted = [...entities].sort((a, b) => a.offset - b.offset || b.length - a.length);
+
+  let result = "";
+  let lastOffset = 0;
+
+  for (const entity of sorted) {
+    // Add text before this entity (escaped)
+    if (entity.offset > lastOffset) {
+      result += escapeHtml(text.slice(lastOffset, entity.offset));
+    }
+
+    const entityText = text.slice(entity.offset, entity.offset + entity.length);
+    result += wrapEntity(entityText, entity);
+    lastOffset = entity.offset + entity.length;
+  }
+
+  // Add remaining text after last entity
+  if (lastOffset < text.length) {
+    result += escapeHtml(text.slice(lastOffset));
+  }
+
+  return result;
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+function wrapEntity(text: string, entity: MessageEntity): string {
+  const escaped = escapeHtml(text);
+  switch (entity.type) {
+    case "bold":
+      return `<b>${escaped}</b>`;
+    case "italic":
+      return `<i>${escaped}</i>`;
+    case "underline":
+      return `<u>${escaped}</u>`;
+    case "strikethrough":
+      return `<s>${escaped}</s>`;
+    case "code":
+      return `<code>${escaped}</code>`;
+    case "pre":
+      if ("language" in entity && entity.language) {
+        return `<pre><code class="language-${entity.language}">${escaped}</code></pre>`;
+      }
+      return `<pre>${escaped}</pre>`;
+    case "text_link":
+      return `<a href="${("url" in entity ? entity.url : "").replace(/"/g, "&quot;")}">${escaped}</a>`;
+    case "spoiler":
+      return `<tg-spoiler>${escaped}</tg-spoiler>`;
+    case "blockquote":
+    case "expandable_blockquote":
+      return `<blockquote>${escaped}</blockquote>`;
+    default:
+      return escaped;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Block Extractors
+// ---------------------------------------------------------------------------
+
+type BlockExtractor = (
+  msg: Message,
+  api: Api,
+  token: string,
+) => Promise<ContentBlock | ContentBlock[] | undefined>;
+
+async function extractText(msg: Message): Promise<TextBlock | undefined> {
+  if (!msg.text) return undefined;
+  const content =
+    msg.entities && msg.entities.length > 0 ? entitiesToHtml(msg.text, msg.entities) : msg.text;
+  return { type: "text", content };
+}
+
+async function extractPhoto(
+  msg: Message,
+  api: Api,
+  token: string,
+): Promise<ImageBlock | undefined> {
+  if (!msg.photo || msg.photo.length === 0) return undefined;
+
+  // Pick the largest photo (last in array)
+  const largest = msg.photo[msg.photo.length - 1] as PhotoSize;
+  const url = await resolveFileUrl(api, largest.file_id, token);
+
+  return {
+    type: "image",
+    url,
+    alt: `photo:${largest.file_id}`,
+    ...(largest.file_size != null ? { size: largest.file_size } : {}),
+  };
+}
+
+async function extractDocument(
+  msg: Message,
+  api: Api,
+  token: string,
+): Promise<FileBlock | undefined> {
+  if (!msg.document) return undefined;
+
+  const url = await resolveFileUrl(api, msg.document.file_id, token);
+
+  return {
+    type: "file",
+    url,
+    filename: msg.document.file_name ?? "unknown",
+    mimeType: msg.document.mime_type ?? "application/octet-stream",
+    ...(msg.document.file_size != null ? { size: msg.document.file_size } : {}),
+  };
+}
+
+async function extractVoice(msg: Message, api: Api, token: string): Promise<FileBlock | undefined> {
+  if (!msg.voice) return undefined;
+
+  const url = await resolveFileUrl(api, msg.voice.file_id, token);
+
+  return {
+    type: "file",
+    url,
+    filename: "voice.ogg",
+    mimeType: msg.voice.mime_type ?? "audio/ogg",
+    ...(msg.voice.file_size != null ? { size: msg.voice.file_size } : {}),
+  };
+}
+
+async function extractCaption(msg: Message): Promise<TextBlock | undefined> {
+  if (!msg.caption) return undefined;
+  const content =
+    msg.caption_entities && msg.caption_entities.length > 0
+      ? entitiesToHtml(msg.caption, msg.caption_entities)
+      : msg.caption;
+  return { type: "text", content };
+}
+
+const EXTRACTORS: readonly BlockExtractor[] = [
+  extractText,
+  extractPhoto,
+  extractDocument,
+  extractVoice,
+  extractCaption,
+];
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalize a Telegram Update into an InboundMessage.
+ * Returns undefined if the update has no processable message.
+ */
+export async function normalizeUpdate(
+  update: Update,
+  api: Api,
+  token: string,
+  _botUsername: string,
+): Promise<InboundMessage | undefined> {
+  const msg = update.message;
+  if (!msg) return undefined;
+
+  const blocks: ContentBlock[] = [];
+  for (const extractor of EXTRACTORS) {
+    const result = await extractor(msg, api, token);
+    if (result) {
+      if (Array.isArray(result)) {
+        blocks.push(...result);
+      } else {
+        blocks.push(result);
+      }
+    }
+  }
+
+  // If no blocks were extracted, still return the message
+  // (allows consumers to inspect raw data)
+  const senderId = msg.from?.id?.toString() ?? "unknown";
+  const channelId = msg.chat.id.toString();
+  const threadId = msg.message_thread_id?.toString();
+  const messageId = msg.message_id.toString();
+
+  return {
+    channelType: "telegram",
+    channelId,
+    senderId,
+    blocks,
+    ...(threadId != null ? { threadId } : {}),
+    timestamp: msg.date * 1000, // Telegram sends Unix seconds, convert to ms
+    messageId,
+    raw: update,
+  };
+}
+
+/**
+ * Check if a message text contains an @mention of the bot.
+ */
+export function hasBotMention(msg: Message, botUsername: string): boolean {
+  if (!msg.entities) return false;
+  const mentionTag = `@${botUsername}`.toLowerCase();
+  return msg.entities.some(
+    (e) =>
+      e.type === "mention" &&
+      msg.text?.slice(e.offset, e.offset + e.length).toLowerCase() === mentionTag,
+  );
+}

--- a/packages/channel-telegram/src/renderer.ts
+++ b/packages/channel-telegram/src/renderer.ts
@@ -1,0 +1,285 @@
+import type { ButtonBlock, ContentBlock, OutboundMessage } from "@templar/core";
+import type { Api } from "grammy";
+import type { InlineKeyboardButton, InlineKeyboardMarkup } from "grammy/types";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const MAX_TEXT_LENGTH = 4096;
+const BUTTON_PLACEHOLDER = "Please choose an option:";
+
+// ---------------------------------------------------------------------------
+// Inline keyboard builder
+// ---------------------------------------------------------------------------
+
+function buildInlineKeyboard(block: ButtonBlock): InlineKeyboardMarkup {
+  const buttons: InlineKeyboardButton[][] = block.buttons.map((btn) => [
+    { text: btn.label, callback_data: btn.action },
+  ]);
+  return { inline_keyboard: buttons };
+}
+
+// ---------------------------------------------------------------------------
+// Text splitting
+// ---------------------------------------------------------------------------
+
+/**
+ * Split text into chunks that fit within Telegram's message length limit.
+ * Tries to split at newlines, then spaces, then hard-cuts.
+ */
+function splitText(text: string): readonly string[] {
+  if (text.length <= MAX_TEXT_LENGTH) return [text];
+
+  const chunks: string[] = [];
+  let remaining = text;
+
+  while (remaining.length > 0) {
+    if (remaining.length <= MAX_TEXT_LENGTH) {
+      chunks.push(remaining);
+      break;
+    }
+
+    // Try to split at last newline within limit
+    let splitPos = remaining.lastIndexOf("\n", MAX_TEXT_LENGTH);
+    if (splitPos <= 0) {
+      // Try to split at last space within limit
+      splitPos = remaining.lastIndexOf(" ", MAX_TEXT_LENGTH);
+    }
+    if (splitPos <= 0) {
+      // Hard cut
+      splitPos = MAX_TEXT_LENGTH;
+    }
+
+    chunks.push(remaining.slice(0, splitPos));
+    remaining = remaining.slice(splitPos).trimStart();
+  }
+
+  return chunks;
+}
+
+// ---------------------------------------------------------------------------
+// Render plan — intermediate representation
+// ---------------------------------------------------------------------------
+
+interface SendTextCall {
+  readonly kind: "sendMessage";
+  readonly chatId: string;
+  readonly text: string;
+  readonly parseMode: "HTML";
+  readonly replyMarkup?: InlineKeyboardMarkup;
+  readonly threadId?: string;
+  readonly replyTo?: string;
+}
+
+interface SendPhotoCall {
+  readonly kind: "sendPhoto";
+  readonly chatId: string;
+  readonly photo: string;
+  readonly replyMarkup?: InlineKeyboardMarkup;
+  readonly threadId?: string;
+  readonly replyTo?: string;
+}
+
+interface SendDocumentCall {
+  readonly kind: "sendDocument";
+  readonly chatId: string;
+  readonly document: string;
+  readonly filename: string;
+  readonly replyMarkup?: InlineKeyboardMarkup;
+  readonly threadId?: string;
+  readonly replyTo?: string;
+}
+
+interface SendTypingCall {
+  readonly kind: "sendChatAction";
+  readonly chatId: string;
+  readonly action: "typing";
+}
+
+type RenderCall = SendTextCall | SendPhotoCall | SendDocumentCall | SendTypingCall;
+
+// ---------------------------------------------------------------------------
+// Render plan builder
+// ---------------------------------------------------------------------------
+
+/**
+ * Build an ordered list of API calls from an OutboundMessage.
+ * - Adjacent text blocks are coalesced
+ * - Button blocks attach to the preceding message
+ * - A typing indicator is sent first
+ */
+export function buildRenderPlan(message: OutboundMessage): readonly RenderCall[] {
+  const { channelId, blocks, threadId, replyTo } = message;
+  const plan: RenderCall[] = [];
+
+  if (blocks.length === 0) return plan;
+
+  // Send typing indicator first
+  plan.push({ kind: "sendChatAction", chatId: channelId, action: "typing" });
+
+  // Coalesce adjacent text blocks, then process
+  const coalesced = coalesceBlocks(blocks);
+
+  let pendingKeyboard: InlineKeyboardMarkup | undefined;
+
+  for (let i = 0; i < coalesced.length; i++) {
+    const block = coalesced[i]!;
+
+    if (block.type === "button") {
+      const keyboard = buildInlineKeyboard(block);
+
+      // Look back: can we attach to a pending (not-yet-emitted) call?
+      const lastCall = plan[plan.length - 1];
+      if (
+        lastCall &&
+        lastCall.kind !== "sendChatAction" &&
+        !("replyMarkup" in lastCall && lastCall.replyMarkup)
+      ) {
+        // Attach to preceding call
+        (lastCall as { replyMarkup?: InlineKeyboardMarkup }).replyMarkup = keyboard;
+      } else {
+        // No preceding content call — store pending for next content or emit standalone
+        pendingKeyboard = keyboard;
+      }
+      continue;
+    }
+
+    if (block.type === "text") {
+      const chunks = splitText(block.content);
+      for (let c = 0; c < chunks.length; c++) {
+        const isLastChunk = c === chunks.length - 1;
+        plan.push({
+          kind: "sendMessage",
+          chatId: channelId,
+          text: chunks[c]!,
+          parseMode: "HTML",
+          ...(isLastChunk && pendingKeyboard ? { replyMarkup: pendingKeyboard } : {}),
+          ...(threadId != null ? { threadId } : {}),
+          ...(replyTo != null ? { replyTo } : {}),
+        } as SendTextCall);
+        if (isLastChunk && pendingKeyboard) {
+          pendingKeyboard = undefined;
+        }
+      }
+      continue;
+    }
+
+    if (block.type === "image") {
+      plan.push({
+        kind: "sendPhoto",
+        chatId: channelId,
+        photo: block.url,
+        ...(pendingKeyboard ? { replyMarkup: pendingKeyboard } : {}),
+        ...(threadId != null ? { threadId } : {}),
+        ...(replyTo != null ? { replyTo } : {}),
+      } as SendPhotoCall);
+      pendingKeyboard = undefined;
+      continue;
+    }
+
+    if (block.type === "file") {
+      plan.push({
+        kind: "sendDocument",
+        chatId: channelId,
+        document: block.url,
+        filename: block.filename,
+        ...(pendingKeyboard ? { replyMarkup: pendingKeyboard } : {}),
+        ...(threadId != null ? { threadId } : {}),
+        ...(replyTo != null ? { replyTo } : {}),
+      } as SendDocumentCall);
+      pendingKeyboard = undefined;
+    }
+  }
+
+  // If there's a pending keyboard with no content to attach to, emit standalone
+  if (pendingKeyboard) {
+    plan.push({
+      kind: "sendMessage",
+      chatId: channelId,
+      text: BUTTON_PLACEHOLDER,
+      parseMode: "HTML",
+      replyMarkup: pendingKeyboard,
+      ...(threadId != null ? { threadId } : {}),
+      ...(replyTo != null ? { replyTo } : {}),
+    } as SendTextCall);
+  }
+
+  return plan;
+}
+
+/**
+ * Coalesce adjacent text blocks into a single text block.
+ * Non-text blocks act as boundaries.
+ */
+function coalesceBlocks(blocks: readonly ContentBlock[]): readonly ContentBlock[] {
+  const result: ContentBlock[] = [];
+  let textBuffer: string[] = [];
+
+  function flushTextBuffer() {
+    if (textBuffer.length > 0) {
+      result.push({ type: "text", content: textBuffer.join("\n") });
+      textBuffer = [];
+    }
+  }
+
+  for (const block of blocks) {
+    if (block.type === "text") {
+      textBuffer.push(block.content);
+    } else {
+      flushTextBuffer();
+      result.push(block);
+    }
+  }
+  flushTextBuffer();
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Execute render plan
+// ---------------------------------------------------------------------------
+
+/**
+ * Render an OutboundMessage by executing Telegram API calls sequentially.
+ */
+export async function renderMessage(message: OutboundMessage, api: Api): Promise<void> {
+  const plan = buildRenderPlan(message);
+
+  for (const call of plan) {
+    switch (call.kind) {
+      case "sendChatAction":
+        await api.sendChatAction(call.chatId, call.action);
+        break;
+
+      case "sendMessage": {
+        const opts: Record<string, unknown> = {
+          parse_mode: call.parseMode,
+        };
+        if (call.replyMarkup) opts.reply_markup = call.replyMarkup;
+        if (call.threadId) opts.message_thread_id = Number(call.threadId);
+        if (call.replyTo) opts.reply_to_message_id = Number(call.replyTo);
+        await api.sendMessage(call.chatId, call.text, opts);
+        break;
+      }
+
+      case "sendPhoto": {
+        const opts: Record<string, unknown> = {};
+        if (call.replyMarkup) opts.reply_markup = call.replyMarkup;
+        if (call.threadId) opts.message_thread_id = Number(call.threadId);
+        if (call.replyTo) opts.reply_to_message_id = Number(call.replyTo);
+        await api.sendPhoto(call.chatId, call.photo, opts);
+        break;
+      }
+
+      case "sendDocument": {
+        const opts: Record<string, unknown> = {};
+        if (call.replyMarkup) opts.reply_markup = call.replyMarkup;
+        if (call.threadId) opts.message_thread_id = Number(call.threadId);
+        if (call.replyTo) opts.reply_to_message_id = Number(call.replyTo);
+        await api.sendDocument(call.chatId, call.document, opts);
+        break;
+      }
+    }
+  }
+}

--- a/packages/channel-telegram/tsconfig.build.json
+++ b/packages/channel-telegram/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false
+  }
+}

--- a/packages/channel-telegram/tsconfig.json
+++ b/packages/channel-telegram/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": ["node", "vitest/globals"]
+  },
+  "include": ["src/**/*"],
+  "references": [{ "path": "../core" }, { "path": "../errors" }]
+}

--- a/packages/channel-telegram/tsup.config.ts
+++ b/packages/channel-telegram/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: {
+    compilerOptions: {
+      composite: false,
+    },
+  },
+  clean: true,
+  treeshake: true,
+  target: "node22",
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,28 @@ importers:
         specifier: ^4.0.18
         version: 4.0.18(@types/node@25.2.2)(yaml@2.8.2)
 
+  packages/channel-telegram:
+    dependencies:
+      '@grammyjs/auto-retry':
+        specifier: ^2.0.2
+        version: 2.0.2(grammy@1.40.0)
+      grammy:
+        specifier: ^1.35.0
+        version: 1.40.0
+      zod:
+        specifier: ^3.24.0
+        version: 3.25.76
+    devDependencies:
+      '@templar/core':
+        specifier: workspace:*
+        version: link:../core
+      '@templar/errors':
+        specifier: workspace:*
+        version: link:../errors
+      '@types/node':
+        specifier: ^25.2.2
+        version: 25.2.2
+
   packages/core:
     dependencies:
       '@langchain/langgraph':
@@ -367,6 +389,15 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@grammyjs/auto-retry@2.0.2':
+    resolution: {integrity: sha512-b4A4p5jlYDiQtW0c0FXYe11WMkYoiW+5rvOaDMCOk1h7Pu2SDl7B7gmFF8cthWCx2+M2nWLOsBxAgbBG4kKWYg==}
+    engines: {node: '>=12.20.0 || >=14.13.1'}
+    peerDependencies:
+      grammy: ^1.10.0
+
+  '@grammyjs/types@3.24.0':
+    resolution: {integrity: sha512-qQIEs4lN5WqUdr4aT8MeU6UFpMbGYAvcvYSW1A4OO1PABGJQHz/KLON6qvpf+5RxaNDQBxiY2k2otIhg/AG7RQ==}
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -643,6 +674,10 @@ packages:
   '@vitest/utils@4.0.18':
     resolution: {integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==}
 
+  abort-controller@3.0.0:
+    resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
+    engines: {node: '>=6.5'}
+
   acorn@8.15.0:
     resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
     engines: {node: '>=0.4.0'}
@@ -754,6 +789,10 @@ packages:
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
+  event-target-shim@5.0.1:
+    resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
+    engines: {node: '>=6'}
+
   eventemitter3@4.0.7:
     resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
 
@@ -795,6 +834,10 @@ packages:
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
+
+  grammy@1.40.0:
+    resolution: {integrity: sha512-ssuE7fc1AwqlUxHr931OCVW3fU+oFDjHZGgvIedPKXfTdjXvzP19xifvVGCnPtYVUig1Kz+gwxe4A9M5WdkT4Q==}
+    engines: {node: ^12.20.0 || >=14.13.1}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -918,6 +961,15 @@ packages:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -1087,6 +1139,9 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
@@ -1240,6 +1295,12 @@ packages:
       jsdom:
         optional: true
 
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
@@ -1392,6 +1453,15 @@ snapshots:
 
   '@esbuild/win32-x64@0.27.3':
     optional: true
+
+  '@grammyjs/auto-retry@2.0.2(grammy@1.40.0)':
+    dependencies:
+      debug: 4.4.3
+      grammy: 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@grammyjs/types@3.24.0': {}
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -1665,6 +1735,10 @@ snapshots:
       '@vitest/pretty-format': 4.0.18
       tinyrainbow: 3.0.3
 
+  abort-controller@3.0.0:
+    dependencies:
+      event-target-shim: 5.0.1
+
   acorn@8.15.0: {}
 
   ansi-styles@4.3.0:
@@ -1788,6 +1862,8 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
 
+  event-target-shim@5.0.1: {}
+
   eventemitter3@4.0.7: {}
 
   eventemitter3@5.0.4: {}
@@ -1826,6 +1902,16 @@ snapshots:
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
+
+  grammy@1.40.0:
+    dependencies:
+      '@grammyjs/types': 3.24.0
+      abort-controller: 3.0.0
+      debug: 4.4.3
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
 
   has-flag@4.0.0: {}
 
@@ -1942,6 +2028,10 @@ snapshots:
       thenify-all: 1.6.0
 
   nanoid@3.3.11: {}
+
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
 
   object-assign@4.1.1: {}
 
@@ -2101,6 +2191,8 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  tr46@0.0.3: {}
+
   tree-kill@1.2.2: {}
 
   ts-interface-checker@0.1.13: {}
@@ -2219,6 +2311,13 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  webidl-conversions@3.0.1: {}
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
 
   why-is-node-running@2.3.0:
     dependencies:


### PR DESCRIPTION
## Summary
- Implements Issue #16: first real `ChannelAdapter` — a grammY-based Telegram adapter serving as the reference implementation
- Dual-mode transport (polling + webhook) with Zod config validation
- Extractor-map normalizer for inbound messages (text, entities→HTML, photos, documents, voice, captions, groups)
- Plan-based renderer with text coalescing, button attachment, text splitting at 4096 chars, typing indicators
- Static capability declarations: text, richText, images, files, buttons, typingIndicator, voiceMessages, groups
- 101 tests across 5 test files, 94% line coverage

## New files
- `packages/channel-telegram/src/adapter.ts` — `TelegramChannel` class implementing `ChannelAdapter`
- `packages/channel-telegram/src/normalizer.ts` — Inbound message normalization with entity→HTML conversion
- `packages/channel-telegram/src/renderer.ts` — Outbound message rendering with render plan pattern
- `packages/channel-telegram/src/config.ts` — Zod discriminated union schema (polling vs webhook)
- `packages/channel-telegram/src/capabilities.ts` — Static capability declaration
- `packages/channel-telegram/src/__tests__/helpers/mock-grammy.ts` — Proxy-based API mock + update factories

## Test plan
- [x] 101 unit/integration tests pass (`pnpm --filter @templar/channel-telegram test`)
- [x] TypeScript typecheck clean (`tsc --noEmit`)
- [x] Build succeeds with DTS generation (`tsup`)
- [x] Full monorepo build passes (`pnpm build` — 11/11 tasks)
- [x] Biome lint clean (0 errors)
- [x] 94% line coverage (target: 80%+)

Closes #16