### PR TITLE
feat: implement @templar/node local device agent runtime

### DIFF
--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -16,7 +16,21 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@templar/core": "workspace:*",
-    "@templar/errors": "workspace:*"
+    "@templar/gateway-protocol": "workspace:*",
+    "zod": "^3.22.4"
+  },
+  "peerDependencies": {
+    "ws": ">=8.0.0"
+  },
+  "peerDependenciesMeta": {
+    "ws": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@templar/gateway": "workspace:*",
+    "@types/node": "^25.2.2",
+    "@types/ws": "^8.18.1",
+    "ws": "^8.19.0"
   }
 }

--- a/packages/node/src/__tests__/heartbeat-responder.test.ts
+++ b/packages/node/src/__tests__/heartbeat-responder.test.ts
@@ -1,0 +1,66 @@
+import type { GatewayFrame, HeartbeatPongFrame } from "@templar/gateway-protocol";
+import { describe, expect, it, vi } from "vitest";
+import { HeartbeatResponder } from "../heartbeat-responder.js";
+
+describe("HeartbeatResponder", () => {
+  it("should respond to heartbeat.ping with matching pong", () => {
+    const sendPong = vi.fn();
+    const responder = new HeartbeatResponder(sendPong);
+
+    const pingFrame: GatewayFrame = {
+      kind: "heartbeat.ping",
+      timestamp: 1234567890,
+    };
+
+    const handled = responder.handleFrame(pingFrame);
+
+    expect(handled).toBe(true);
+    expect(sendPong).toHaveBeenCalledOnce();
+
+    const pong = sendPong.mock.calls[0]?.[0] as HeartbeatPongFrame;
+    expect(pong.kind).toBe("heartbeat.pong");
+    expect(pong.timestamp).toBe(1234567890);
+  });
+
+  it("should return false for non-ping frames", () => {
+    const sendPong = vi.fn();
+    const responder = new HeartbeatResponder(sendPong);
+
+    const ackFrame: GatewayFrame = {
+      kind: "node.register.ack",
+      nodeId: "test",
+      sessionId: "session-1",
+    };
+
+    const handled = responder.handleFrame(ackFrame);
+
+    expect(handled).toBe(false);
+    expect(sendPong).not.toHaveBeenCalled();
+  });
+
+  it("should track lastPingAt after handling a ping", () => {
+    const sendPong = vi.fn();
+    const responder = new HeartbeatResponder(sendPong);
+
+    expect(responder.lastPingAt).toBeUndefined();
+
+    const pingFrame: GatewayFrame = {
+      kind: "heartbeat.ping",
+      timestamp: 1000,
+    };
+    responder.handleFrame(pingFrame);
+
+    expect(responder.lastPingAt).toBe(1000);
+  });
+
+  it("should update lastPingAt on subsequent pings", () => {
+    const sendPong = vi.fn();
+    const responder = new HeartbeatResponder(sendPong);
+
+    responder.handleFrame({ kind: "heartbeat.ping", timestamp: 1000 });
+    expect(responder.lastPingAt).toBe(1000);
+
+    responder.handleFrame({ kind: "heartbeat.ping", timestamp: 2000 });
+    expect(responder.lastPingAt).toBe(2000);
+  });
+});

--- a/packages/node/src/__tests__/index.test.ts
+++ b/packages/node/src/__tests__/index.test.ts
@@ -1,8 +1,17 @@
 import { describe, expect, it } from "vitest";
-import { PACKAGE_NAME } from "../index.js";
+import { NODE_STATES, NodeConfigSchema, TemplarNode } from "../index.js";
 
-describe("@templar/node", () => {
-  it("should export package name", () => {
-    expect(PACKAGE_NAME).toBe("@templar/node");
+describe("@templar/node exports", () => {
+  it("should export TemplarNode class", () => {
+    expect(TemplarNode).toBeDefined();
+    expect(typeof TemplarNode).toBe("function");
+  });
+
+  it("should export NodeConfigSchema", () => {
+    expect(NodeConfigSchema).toBeDefined();
+  });
+
+  it("should export NODE_STATES", () => {
+    expect(NODE_STATES).toEqual(["disconnected", "connecting", "connected", "reconnecting"]);
   });
 });

--- a/packages/node/src/__tests__/integration.test.ts
+++ b/packages/node/src/__tests__/integration.test.ts
@@ -1,0 +1,392 @@
+/**
+ * Integration tests for @templar/node.
+ *
+ * Uses a real ws.WebSocketServer to test the TemplarNode's actual
+ * WebSocket behavior: connection, auth, registration, heartbeat,
+ * lane message delivery, and graceful shutdown.
+ */
+
+import { type AddressInfo, createServer } from "node:net";
+import type { GatewayFrame, LaneMessage, NodeRegisterFrame } from "@templar/gateway-protocol";
+import { safeParseFrame } from "@templar/gateway-protocol";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type WebSocket from "ws";
+import { WebSocketServer } from "ws";
+import { TemplarNode } from "../node.js";
+import type { NodeConfig } from "../types.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Find an available port */
+async function findFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = createServer();
+    server.listen(0, () => {
+      const addr = server.address() as AddressInfo;
+      server.close((err) => {
+        if (err) reject(err);
+        else resolve(addr.port);
+      });
+    });
+  });
+}
+
+/** Wait for a condition to become true, polling every `interval` ms */
+async function waitFor(condition: () => boolean, timeout = 5_000, interval = 10): Promise<void> {
+  const start = Date.now();
+  while (!condition()) {
+    if (Date.now() - start > timeout) {
+      throw new Error(`waitFor timed out after ${timeout}ms`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, interval));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Mini Gateway Server
+// ---------------------------------------------------------------------------
+
+interface MiniGateway {
+  readonly port: number;
+  readonly wss: WebSocketServer;
+  readonly connections: Map<string, WebSocket>;
+  readonly receivedFrames: GatewayFrame[];
+  sendToNode: (nodeId: string, frame: GatewayFrame) => void;
+  closeConnection: (nodeId: string, code?: number, reason?: string) => void;
+  stop: () => Promise<void>;
+}
+
+/**
+ * Create a minimal WS server that speaks the GatewayFrame protocol.
+ * Handles registration, heartbeat, and forwards lane messages.
+ */
+async function createMiniGateway(
+  opts: { token?: string; autoRegisterAck?: boolean } = {},
+): Promise<MiniGateway> {
+  const { token = "test-token", autoRegisterAck = true } = opts;
+  const port = await findFreePort();
+
+  const connections = new Map<string, WebSocket>();
+  const receivedFrames: GatewayFrame[] = [];
+
+  const wss = new WebSocketServer({
+    port,
+    verifyClient: (info, cb) => {
+      const authHeader = info.req.headers.authorization;
+      if (!authHeader || !authHeader.startsWith("Bearer ")) {
+        cb(false, 401, "Unauthorized");
+        return;
+      }
+      const providedToken = authHeader.slice(7);
+      cb(providedToken === token, providedToken === token ? undefined : 403);
+    },
+  });
+
+  await new Promise<void>((resolve) => wss.on("listening", resolve));
+
+  wss.on("connection", (ws, req) => {
+    const url = new URL(req.url ?? "/", `http://localhost:${port}`);
+    const nodeId = url.searchParams.get("nodeId") ?? `unknown-${Date.now()}`;
+    connections.set(nodeId, ws);
+
+    ws.on("message", (data) => {
+      const result = safeParseFrame(JSON.parse(data.toString()));
+      if (!result.success) return;
+
+      const frame = result.data as GatewayFrame;
+      receivedFrames.push(frame);
+
+      // Auto-respond to registration
+      if (frame.kind === "node.register" && autoRegisterAck) {
+        const registerFrame = frame as NodeRegisterFrame;
+        const ack: GatewayFrame = {
+          kind: "node.register.ack",
+          nodeId: registerFrame.nodeId,
+          sessionId: `session-${Date.now()}`,
+        };
+        ws.send(JSON.stringify(ack));
+      }
+    });
+
+    ws.on("close", () => {
+      connections.delete(nodeId);
+    });
+  });
+
+  return {
+    port,
+    wss,
+    connections,
+    receivedFrames,
+    sendToNode(nodeId: string, frame: GatewayFrame) {
+      const ws = connections.get(nodeId);
+      if (ws && ws.readyState === 1) {
+        ws.send(JSON.stringify(frame));
+      }
+    },
+    closeConnection(nodeId: string, code?: number, reason?: string) {
+      const ws = connections.get(nodeId);
+      if (ws) {
+        if (code === undefined) {
+          // Simulate abnormal closure by terminating the socket
+          ws.terminate();
+        } else {
+          ws.close(code, reason);
+        }
+      }
+    },
+    async stop() {
+      for (const ws of connections.values()) {
+        ws.close(1001, "Server stopping");
+      }
+      connections.clear();
+      await new Promise<void>((resolve, reject) => {
+        wss.close((err) => {
+          if (err) reject(err);
+          else resolve();
+        });
+      });
+    },
+  };
+}
+
+function makeNodeConfig(port: number, overrides?: Partial<NodeConfig>): NodeConfig {
+  return {
+    nodeId: "test-node-1",
+    gatewayUrl: `ws://127.0.0.1:${port}`,
+    token: "test-token",
+    capabilities: {
+      agentTypes: ["high"],
+      tools: ["web-search"],
+      maxConcurrency: 4,
+      channels: ["slack"],
+    },
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("TemplarNode integration", () => {
+  let gateway: MiniGateway;
+
+  beforeEach(async () => {
+    gateway = await createMiniGateway();
+  });
+
+  afterEach(async () => {
+    await gateway.stop();
+  });
+
+  it("scenario 1: full lifecycle — connect, register, disconnect", async () => {
+    const config = makeNodeConfig(gateway.port);
+    const node = new TemplarNode(config);
+
+    const connectedHandler = vi.fn();
+    const disconnectedHandler = vi.fn();
+    node.onConnected(connectedHandler);
+    node.onDisconnected(disconnectedHandler);
+
+    // Start node — real WS connection
+    await node.start();
+
+    expect(node.state).toBe("connected");
+    expect(node.sessionId).toBeDefined();
+    expect(connectedHandler).toHaveBeenCalledOnce();
+
+    // Verify server received register frame
+    const registerFrame = gateway.receivedFrames.find((f) => f.kind === "node.register");
+    expect(registerFrame).toBeDefined();
+    if (registerFrame?.kind === "node.register") {
+      expect(registerFrame.nodeId).toBe("test-node-1");
+      expect(registerFrame.capabilities.agentTypes).toEqual(["high"]);
+    }
+
+    // Verify connection exists on server
+    expect(gateway.connections.has("test-node-1")).toBe(true);
+
+    // Stop node
+    await node.stop();
+
+    expect(node.state).toBe("disconnected");
+
+    // Wait for server to process deregister
+    await waitFor(() => gateway.receivedFrames.some((f) => f.kind === "node.deregister"));
+
+    const deregisterFrame = gateway.receivedFrames.find((f) => f.kind === "node.deregister");
+    expect(deregisterFrame).toBeDefined();
+  });
+
+  it("scenario 2: lane message delivery", async () => {
+    const config = makeNodeConfig(gateway.port);
+    const node = new TemplarNode(config);
+
+    const messageHandler = vi.fn();
+    node.onMessage(messageHandler);
+
+    await node.start();
+
+    // Send a lane message from the gateway to the node
+    const laneMessage: LaneMessage = {
+      id: "msg-1",
+      lane: "steer",
+      channelId: "channel-1",
+      payload: { instruction: "search for foo" },
+      timestamp: Date.now(),
+    };
+    gateway.sendToNode("test-node-1", {
+      kind: "lane.message",
+      lane: "steer",
+      message: laneMessage,
+    });
+
+    // Wait for handler to be called
+    await waitFor(() => messageHandler.mock.calls.length > 0);
+
+    expect(messageHandler).toHaveBeenCalledWith("steer", laneMessage);
+
+    await node.stop();
+  });
+
+  it("scenario 3: heartbeat exchange", async () => {
+    const config = makeNodeConfig(gateway.port);
+    const node = new TemplarNode(config);
+
+    await node.start();
+
+    // Send a heartbeat ping from the gateway
+    gateway.sendToNode("test-node-1", {
+      kind: "heartbeat.ping",
+      timestamp: Date.now(),
+    });
+
+    // Wait for pong response
+    await waitFor(() => gateway.receivedFrames.some((f) => f.kind === "heartbeat.pong"));
+
+    const pongFrame = gateway.receivedFrames.find((f) => f.kind === "heartbeat.pong");
+    expect(pongFrame).toBeDefined();
+    expect(pongFrame?.kind).toBe("heartbeat.pong");
+
+    await node.stop();
+  });
+
+  it("scenario 4: auth failure — wrong token", async () => {
+    const config = makeNodeConfig(gateway.port, { token: "wrong-token" });
+    const node = new TemplarNode(config);
+
+    const errorHandler = vi.fn();
+    node.onError(errorHandler);
+
+    // start() should reject because WS connection fails auth
+    await expect(node.start()).rejects.toThrow();
+
+    expect(node.state).toBe("disconnected");
+  });
+
+  it("scenario 5: graceful shutdown sends deregister", async () => {
+    const config = makeNodeConfig(gateway.port);
+    const node = new TemplarNode(config);
+
+    await node.start();
+    expect(node.state).toBe("connected");
+
+    // Record frame count before stop
+    const frameCountBefore = gateway.receivedFrames.length;
+
+    await node.stop();
+
+    // Wait for server to receive deregister
+    await waitFor(() => gateway.receivedFrames.length > frameCountBefore);
+
+    const deregisterFrame = gateway.receivedFrames.find((f) => f.kind === "node.deregister");
+    expect(deregisterFrame).toBeDefined();
+    if (deregisterFrame?.kind === "node.deregister") {
+      expect(deregisterFrame.nodeId).toBe("test-node-1");
+    }
+
+    // Server should see the connection as closed
+    await waitFor(() => !gateway.connections.has("test-node-1"));
+  });
+
+  it("scenario 6: reconnection after server-side disconnect", async () => {
+    const config = makeNodeConfig(gateway.port, {
+      reconnect: { maxRetries: 5, baseDelay: 50, maxDelay: 200 },
+    });
+    const node = new TemplarNode(config);
+
+    const reconnectingHandler = vi.fn();
+    const reconnectedHandler = vi.fn();
+    node.onReconnecting(reconnectingHandler);
+    node.onReconnected(reconnectedHandler);
+
+    await node.start();
+    const firstSessionId = node.sessionId;
+    expect(node.state).toBe("connected");
+
+    // Server forcefully terminates the connection (no close frame = abnormal)
+    gateway.closeConnection("test-node-1");
+
+    // Wait for disconnect to propagate, then for reconnection to complete
+    await waitFor(() => node.state !== "connected", 3_000);
+    await waitFor(() => node.state === "connected", 3_000);
+
+    expect(reconnectingHandler).toHaveBeenCalled();
+    expect(reconnectedHandler).toHaveBeenCalledOnce();
+    expect(node.sessionId).toBeDefined();
+    expect(node.sessionId).not.toBe(firstSessionId);
+
+    await node.stop();
+  });
+
+  it("scenario 7: session update notification", async () => {
+    const config = makeNodeConfig(gateway.port);
+    const node = new TemplarNode(config);
+
+    const sessionUpdateHandler = vi.fn();
+    node.onSessionUpdate(sessionUpdateHandler);
+
+    await node.start();
+
+    // Gateway sends session update
+    gateway.sendToNode("test-node-1", {
+      kind: "session.update",
+      sessionId: node.sessionId ?? "",
+      nodeId: "test-node-1",
+      state: "idle",
+      timestamp: Date.now(),
+    });
+
+    await waitFor(() => sessionUpdateHandler.mock.calls.length > 0);
+
+    expect(sessionUpdateHandler).toHaveBeenCalledWith("idle");
+
+    await node.stop();
+  });
+
+  it("scenario 8: config change notification", async () => {
+    const config = makeNodeConfig(gateway.port);
+    const node = new TemplarNode(config);
+
+    const configChangedHandler = vi.fn();
+    node.onConfigChanged(configChangedHandler);
+
+    await node.start();
+
+    // Gateway sends config change
+    gateway.sendToNode("test-node-1", {
+      kind: "config.changed",
+      fields: ["sessionTimeout"],
+      timestamp: Date.now(),
+    });
+
+    await waitFor(() => configChangedHandler.mock.calls.length > 0);
+
+    expect(configChangedHandler).toHaveBeenCalledWith(["sessionTimeout"]);
+
+    await node.stop();
+  });
+});

--- a/packages/node/src/__tests__/node.test.ts
+++ b/packages/node/src/__tests__/node.test.ts
@@ -1,0 +1,589 @@
+import type { GatewayFrame, LaneMessage } from "@templar/gateway-protocol";
+import { describe, expect, it, vi } from "vitest";
+import { TemplarNode } from "../node.js";
+import type { NodeConfig } from "../types.js";
+import type { WebSocketClientLike, WsClientFactory } from "../ws-client.js";
+
+// ---------------------------------------------------------------------------
+// Mock WebSocket
+// ---------------------------------------------------------------------------
+
+function createMockWs(): WebSocketClientLike & {
+  _listeners: Map<string, Array<(...args: unknown[]) => void>>;
+  _simulateOpen: () => void;
+  _simulateMessage: (frame: GatewayFrame) => void;
+  _simulateClose: (code: number, reason: string) => void;
+  _simulateError: (error: Error) => void;
+  _sent: GatewayFrame[];
+} {
+  const listeners = new Map<string, Array<(...args: unknown[]) => void>>();
+  const sent: GatewayFrame[] = [];
+
+  const ws: WebSocketClientLike & {
+    _listeners: Map<string, Array<(...args: unknown[]) => void>>;
+    _simulateOpen: () => void;
+    _simulateMessage: (frame: GatewayFrame) => void;
+    _simulateClose: (code: number, reason: string) => void;
+    _simulateError: (error: Error) => void;
+    _sent: GatewayFrame[];
+  } = {
+    readyState: 0,
+    _listeners: listeners,
+    _sent: sent,
+
+    send(data: string) {
+      sent.push(JSON.parse(data) as GatewayFrame);
+    },
+
+    close(code?: number, _reason?: string) {
+      ws.readyState = 3;
+      const handlers = listeners.get("close") ?? [];
+      for (const h of handlers) h(code ?? 1000, "");
+    },
+
+    on(event: string, handler: (...args: unknown[]) => void) {
+      const existing = listeners.get(event) ?? [];
+      listeners.set(event, [...existing, handler]);
+    },
+
+    _simulateOpen() {
+      ws.readyState = 1;
+      const handlers = listeners.get("open") ?? [];
+      for (const h of handlers) h();
+    },
+
+    _simulateMessage(frame: GatewayFrame) {
+      const handlers = listeners.get("message") ?? [];
+      for (const h of handlers) h(JSON.stringify(frame));
+    },
+
+    _simulateClose(code: number, reason: string) {
+      ws.readyState = 3;
+      const handlers = listeners.get("close") ?? [];
+      for (const h of handlers) h(code, reason);
+    },
+
+    _simulateError(error: Error) {
+      const handlers = listeners.get("error") ?? [];
+      for (const h of handlers) h(error);
+    },
+  };
+
+  return ws;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Flush pending microtasks so async chains can progress */
+function tick(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function makeConfig(overrides?: Partial<NodeConfig>): NodeConfig {
+  return {
+    nodeId: "test-node-1",
+    gatewayUrl: "ws://localhost:18789",
+    token: "test-token",
+    capabilities: {
+      agentTypes: ["high"],
+      tools: ["web-search"],
+      maxConcurrency: 4,
+      channels: ["slack"],
+    },
+    ...overrides,
+  };
+}
+
+/**
+ * Start a TemplarNode and complete the connect + register handshake.
+ * Uses tick() to properly sequence the async promise chain.
+ */
+async function startAndConnect(
+  node: TemplarNode,
+  mockWs: ReturnType<typeof createMockWs>,
+  sessionId = "session-1",
+): Promise<void> {
+  const startPromise = node.start();
+
+  // Flush microtasks so resolveToken + wsClient.connect() run
+  // and WS listeners are set up
+  await tick();
+
+  // Open the WS connection
+  mockWs._simulateOpen();
+
+  // Flush microtasks so register frame is sent and waitForRegisterAck is set up
+  await tick();
+
+  // Find the register frame and send ack
+  const registerFrame = mockWs._sent.find((f) => f.kind === "node.register");
+  if (registerFrame?.kind === "node.register") {
+    mockWs._simulateMessage({
+      kind: "node.register.ack",
+      nodeId: registerFrame.nodeId,
+      sessionId,
+    });
+  }
+
+  await startPromise;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("TemplarNode", () => {
+  describe("lifecycle", () => {
+    it("should connect, register, and transition to connected state", async () => {
+      const mockWs = createMockWs();
+      const factory: WsClientFactory = vi.fn(() => mockWs);
+      const node = new TemplarNode(makeConfig(), { wsFactory: factory });
+
+      const connectedHandler = vi.fn();
+      node.onConnected(connectedHandler);
+
+      await startAndConnect(node, mockWs);
+
+      expect(node.state).toBe("connected");
+      expect(node.sessionId).toBe("session-1");
+      expect(connectedHandler).toHaveBeenCalledWith("session-1");
+    });
+
+    it("should send node.register frame on connect", async () => {
+      const mockWs = createMockWs();
+      const factory: WsClientFactory = vi.fn(() => mockWs);
+      const node = new TemplarNode(makeConfig(), { wsFactory: factory });
+
+      await startAndConnect(node, mockWs);
+
+      const registerFrame = mockWs._sent.find((f) => f.kind === "node.register");
+      expect(registerFrame).toBeDefined();
+      if (registerFrame?.kind === "node.register") {
+        expect(registerFrame.nodeId).toBe("test-node-1");
+        expect(registerFrame.capabilities.agentTypes).toEqual(["high"]);
+        expect(registerFrame.token).toBe("test-token");
+      }
+    });
+
+    it("should throw when starting an already-started node", async () => {
+      const mockWs = createMockWs();
+      const factory: WsClientFactory = vi.fn(() => mockWs);
+      const node = new TemplarNode(makeConfig(), { wsFactory: factory });
+
+      await startAndConnect(node, mockWs);
+
+      await expect(node.start()).rejects.toThrow();
+    });
+
+    it("should stop gracefully: deregister, close, transition to disconnected", async () => {
+      const mockWs = createMockWs();
+      const factory: WsClientFactory = vi.fn(() => mockWs);
+      const node = new TemplarNode(makeConfig(), { wsFactory: factory });
+
+      await startAndConnect(node, mockWs);
+
+      await node.stop();
+
+      const deregisterFrame = mockWs._sent.find((f) => f.kind === "node.deregister");
+      expect(deregisterFrame).toBeDefined();
+      expect(node.state).toBe("disconnected");
+    });
+
+    it("should be a no-op when stopping an already-stopped node", async () => {
+      const mockWs = createMockWs();
+      const factory: WsClientFactory = vi.fn(() => mockWs);
+      const node = new TemplarNode(makeConfig(), { wsFactory: factory });
+
+      await expect(node.stop()).resolves.toBeUndefined();
+    });
+  });
+
+  describe("frame dispatch", () => {
+    it("should respond to heartbeat.ping before user handlers", async () => {
+      const mockWs = createMockWs();
+      const factory: WsClientFactory = vi.fn(() => mockWs);
+      const node = new TemplarNode(makeConfig(), { wsFactory: factory });
+
+      const messageHandler = vi.fn();
+      node.onMessage(messageHandler);
+
+      await startAndConnect(node, mockWs);
+
+      mockWs._simulateMessage({ kind: "heartbeat.ping", timestamp: 1000 });
+
+      const pongFrame = mockWs._sent.find((f) => f.kind === "heartbeat.pong");
+      expect(pongFrame).toBeDefined();
+      if (pongFrame?.kind === "heartbeat.pong") {
+        expect(pongFrame.timestamp).toBe(1000);
+      }
+
+      // Ping should NOT reach user handler
+      expect(messageHandler).not.toHaveBeenCalled();
+    });
+
+    it("should dispatch lane.message to onMessage handlers", async () => {
+      const mockWs = createMockWs();
+      const factory: WsClientFactory = vi.fn(() => mockWs);
+      const node = new TemplarNode(makeConfig(), { wsFactory: factory });
+
+      const messageHandler = vi.fn();
+      node.onMessage(messageHandler);
+
+      await startAndConnect(node, mockWs);
+
+      const laneMessage: LaneMessage = {
+        id: "msg-1",
+        lane: "steer",
+        channelId: "channel-1",
+        payload: { text: "hello" },
+        timestamp: Date.now(),
+      };
+      mockWs._simulateMessage({
+        kind: "lane.message",
+        lane: "steer",
+        message: laneMessage,
+      });
+
+      expect(messageHandler).toHaveBeenCalledOnce();
+      expect(messageHandler).toHaveBeenCalledWith("steer", laneMessage);
+    });
+
+    it("should dispatch session.update to onSessionUpdate handlers", async () => {
+      const mockWs = createMockWs();
+      const factory: WsClientFactory = vi.fn(() => mockWs);
+      const node = new TemplarNode(makeConfig(), { wsFactory: factory });
+
+      const sessionHandler = vi.fn();
+      node.onSessionUpdate(sessionHandler);
+
+      await startAndConnect(node, mockWs);
+
+      mockWs._simulateMessage({
+        kind: "session.update",
+        sessionId: "session-1",
+        nodeId: "test-node-1",
+        state: "idle",
+        timestamp: Date.now(),
+      });
+
+      expect(sessionHandler).toHaveBeenCalledWith("idle");
+    });
+
+    it("should dispatch config.changed to onConfigChanged handlers", async () => {
+      const mockWs = createMockWs();
+      const factory: WsClientFactory = vi.fn(() => mockWs);
+      const node = new TemplarNode(makeConfig(), { wsFactory: factory });
+
+      const configHandler = vi.fn();
+      node.onConfigChanged(configHandler);
+
+      await startAndConnect(node, mockWs);
+
+      mockWs._simulateMessage({
+        kind: "config.changed",
+        fields: ["sessionTimeout", "laneCapacity"],
+        timestamp: Date.now(),
+      });
+
+      expect(configHandler).toHaveBeenCalledWith(["sessionTimeout", "laneCapacity"]);
+    });
+
+    it("should dispatch error frames to onError handlers", async () => {
+      const mockWs = createMockWs();
+      const factory: WsClientFactory = vi.fn(() => mockWs);
+      const node = new TemplarNode(makeConfig(), { wsFactory: factory });
+
+      const errorHandler = vi.fn();
+      node.onError(errorHandler);
+
+      await startAndConnect(node, mockWs);
+
+      mockWs._simulateMessage({
+        kind: "error",
+        error: {
+          type: "about:blank",
+          title: "Something failed",
+          status: 500,
+          detail: "Internal error",
+        },
+        timestamp: Date.now(),
+      });
+
+      expect(errorHandler).toHaveBeenCalledOnce();
+      const err = errorHandler.mock.calls[0]?.[0] as Error;
+      expect(err.message).toContain("Something failed");
+    });
+
+    it("should not crash on unhandled frame kinds", async () => {
+      const mockWs = createMockWs();
+      const factory: WsClientFactory = vi.fn(() => mockWs);
+      const node = new TemplarNode(makeConfig(), { wsFactory: factory });
+
+      await startAndConnect(node, mockWs);
+
+      // lane.message.ack is valid but unhandled — should be ignored
+      mockWs._simulateMessage({
+        kind: "lane.message.ack",
+        messageId: "msg-1",
+      });
+
+      expect(node.state).toBe("connected");
+    });
+  });
+
+  describe("error boundary", () => {
+    it("should catch synchronous handler throws and emit error", async () => {
+      const mockWs = createMockWs();
+      const factory: WsClientFactory = vi.fn(() => mockWs);
+      const node = new TemplarNode(makeConfig(), { wsFactory: factory });
+
+      const errorHandler = vi.fn();
+      node.onError(errorHandler);
+      node.onMessage(() => {
+        throw new Error("Handler exploded");
+      });
+
+      await startAndConnect(node, mockWs);
+
+      const laneMessage: LaneMessage = {
+        id: "msg-1",
+        lane: "steer",
+        channelId: "channel-1",
+        payload: {},
+        timestamp: Date.now(),
+      };
+      mockWs._simulateMessage({
+        kind: "lane.message",
+        lane: "steer",
+        message: laneMessage,
+      });
+
+      expect(errorHandler).toHaveBeenCalledOnce();
+      const err = errorHandler.mock.calls[0]?.[0] as Error;
+      expect(err.message).toBe("Handler exploded");
+      expect(node.state).toBe("connected");
+    });
+
+    it("should catch async handler rejections and emit error", async () => {
+      const mockWs = createMockWs();
+      const factory: WsClientFactory = vi.fn(() => mockWs);
+      const node = new TemplarNode(makeConfig(), { wsFactory: factory });
+
+      const errorHandler = vi.fn();
+      node.onError(errorHandler);
+      node.onMessage(async () => {
+        throw new Error("Async handler exploded");
+      });
+
+      await startAndConnect(node, mockWs);
+
+      const laneMessage: LaneMessage = {
+        id: "msg-1",
+        lane: "collect",
+        channelId: "channel-1",
+        payload: {},
+        timestamp: Date.now(),
+      };
+      mockWs._simulateMessage({
+        kind: "lane.message",
+        lane: "collect",
+        message: laneMessage,
+      });
+
+      // Allow the rejected promise to propagate
+      await tick();
+
+      expect(errorHandler).toHaveBeenCalledOnce();
+      const err = errorHandler.mock.calls[0]?.[0] as Error;
+      expect(err.message).toBe("Async handler exploded");
+    });
+  });
+
+  describe("reconnection", () => {
+    it("should attempt reconnection on unexpected close", async () => {
+      const mockWs1 = createMockWs();
+      const mockWs2 = createMockWs();
+      let callCount = 0;
+      const multiFactory: WsClientFactory = () => {
+        callCount++;
+        return callCount === 1 ? mockWs1 : mockWs2;
+      };
+
+      const config = makeConfig({
+        reconnect: { maxRetries: 3, baseDelay: 10, maxDelay: 50 },
+      });
+      const node = new TemplarNode(config, { wsFactory: multiFactory });
+
+      const reconnectingHandler = vi.fn();
+      const reconnectedHandler = vi.fn();
+      node.onReconnecting(reconnectingHandler);
+      node.onReconnected(reconnectedHandler);
+
+      await startAndConnect(node, mockWs1);
+      expect(node.state).toBe("connected");
+
+      // Simulate unexpected close
+      mockWs1._simulateClose(1006, "Abnormal closure");
+
+      expect(node.state).toBe("reconnecting");
+      expect(reconnectingHandler).toHaveBeenCalledOnce();
+
+      // Wait for reconnect backoff + connection
+      // Max delay is 50ms, tick() uses setTimeout(0) which fires after all timers <=0
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // Flush microtasks for WS setup
+      await tick();
+      mockWs2._simulateOpen();
+      await tick();
+
+      // Send register ack for reconnected session
+      const registerFrame = mockWs2._sent.find((f) => f.kind === "node.register");
+      if (registerFrame?.kind === "node.register") {
+        mockWs2._simulateMessage({
+          kind: "node.register.ack",
+          nodeId: registerFrame.nodeId,
+          sessionId: "session-2",
+        });
+      }
+
+      await tick();
+
+      expect(reconnectedHandler).toHaveBeenCalledWith("session-2");
+      expect(node.state).toBe("connected");
+      expect(node.sessionId).toBe("session-2");
+    });
+
+    it("should NOT reconnect on auth-related close (code 1008)", async () => {
+      const mockWs = createMockWs();
+      const factory: WsClientFactory = vi.fn(() => mockWs);
+      const node = new TemplarNode(makeConfig(), { wsFactory: factory });
+
+      const errorHandler = vi.fn();
+      const reconnectingHandler = vi.fn();
+      node.onError(errorHandler);
+      node.onReconnecting(reconnectingHandler);
+
+      await startAndConnect(node, mockWs);
+
+      mockWs._simulateClose(1008, "Policy violation");
+
+      expect(reconnectingHandler).not.toHaveBeenCalled();
+      expect(node.state).toBe("disconnected");
+      expect(errorHandler).toHaveBeenCalledOnce();
+    });
+
+    it("should resolve token factory on each reconnect attempt", async () => {
+      const mockWs1 = createMockWs();
+      const mockWs2 = createMockWs();
+      let callCount = 0;
+      const multiFactory: WsClientFactory = () => {
+        callCount++;
+        return callCount === 1 ? mockWs1 : mockWs2;
+      };
+
+      let tokenCallCount = 0;
+      const tokenFactory = vi.fn(() => {
+        tokenCallCount++;
+        return `token-${tokenCallCount}`;
+      });
+
+      const config = makeConfig({
+        token: tokenFactory,
+        reconnect: { maxRetries: 3, baseDelay: 10, maxDelay: 50 },
+      });
+      const node = new TemplarNode(config, { wsFactory: multiFactory });
+
+      await startAndConnect(node, mockWs1);
+      expect(tokenFactory).toHaveBeenCalledTimes(1);
+
+      // Disconnect
+      mockWs1._simulateClose(1006, "Abnormal");
+
+      // Wait for reconnect backoff
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      await tick();
+      mockWs2._simulateOpen();
+      await tick();
+
+      const registerFrame = mockWs2._sent.find((f) => f.kind === "node.register");
+      if (registerFrame?.kind === "node.register") {
+        mockWs2._simulateMessage({
+          kind: "node.register.ack",
+          nodeId: registerFrame.nodeId,
+          sessionId: "session-2",
+        });
+      }
+      await tick();
+
+      // Token factory should have been called again for reconnect
+      expect(tokenFactory).toHaveBeenCalledTimes(2);
+    });
+
+    it("should cancel reconnection on stop()", async () => {
+      vi.useFakeTimers();
+
+      const mockWs = createMockWs();
+      const factory: WsClientFactory = vi.fn(() => mockWs);
+      const config = makeConfig({
+        reconnect: { maxRetries: 10, baseDelay: 1_000, maxDelay: 30_000 },
+      });
+      const node = new TemplarNode(config, { wsFactory: factory });
+
+      // Manually start since fake timers don't work with tick()
+      const startPromise = node.start();
+      await vi.advanceTimersByTimeAsync(0);
+      mockWs._simulateOpen();
+      await vi.advanceTimersByTimeAsync(0);
+      const registerFrame = mockWs._sent.find((f) => f.kind === "node.register");
+      if (registerFrame?.kind === "node.register") {
+        mockWs._simulateMessage({
+          kind: "node.register.ack",
+          nodeId: registerFrame.nodeId,
+          sessionId: "session-1",
+        });
+      }
+      await startPromise;
+
+      // Trigger reconnection
+      mockWs._simulateClose(1006, "Abnormal");
+      expect(node.state).toBe("reconnecting");
+
+      // Stop should cancel reconnection
+      await node.stop();
+      expect(node.state).toBe("disconnected");
+
+      // Advance timers — no reconnection should happen
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(node.state).toBe("disconnected");
+
+      vi.useRealTimers();
+    });
+  });
+
+  describe("config", () => {
+    it("should expose resolved config with defaults", () => {
+      const mockWs = createMockWs();
+      const factory: WsClientFactory = vi.fn(() => mockWs);
+      const node = new TemplarNode(makeConfig(), { wsFactory: factory });
+
+      const resolved = node.config;
+      expect(resolved.nodeId).toBe("test-node-1");
+      expect(resolved.reconnect.maxRetries).toBe(10);
+    });
+
+    it("should throw ZodError for invalid config", () => {
+      const mockWs = createMockWs();
+      const factory: WsClientFactory = vi.fn(() => mockWs);
+      expect(
+        () =>
+          new TemplarNode(
+            { nodeId: "", gatewayUrl: "not-url", token: "", capabilities: {} } as never,
+            { wsFactory: factory },
+          ),
+      ).toThrow();
+    });
+  });
+});

--- a/packages/node/src/__tests__/reconnect.test.ts
+++ b/packages/node/src/__tests__/reconnect.test.ts
@@ -1,0 +1,183 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ReconnectStrategy } from "../reconnect.js";
+import { DEFAULT_RECONNECT_CONFIG } from "../types.js";
+
+describe("ReconnectStrategy", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("nextDelay", () => {
+    it("should return a delay within the expected range for attempt 0", () => {
+      const strategy = new ReconnectStrategy(DEFAULT_RECONNECT_CONFIG);
+      // Full jitter: random * min(maxDelay, baseDelay * 2^0) = random * 1000
+      const delay = strategy.nextDelay();
+      expect(delay).toBeGreaterThanOrEqual(0);
+      expect(delay).toBeLessThanOrEqual(1_000);
+    });
+
+    it("should increase exponentially across attempts", () => {
+      const strategy = new ReconnectStrategy({
+        maxRetries: 10,
+        baseDelay: 100,
+        maxDelay: 100_000,
+      });
+
+      // Collect max possible delays for each attempt
+      // attempt 0: max 100, attempt 1: max 200, attempt 2: max 400, attempt 3: max 800
+      const delay0 = strategy.nextDelay(); // uses attempt 0, increments to 1
+      const delay1 = strategy.nextDelay(); // uses attempt 1, increments to 2
+      const delay2 = strategy.nextDelay(); // uses attempt 2, increments to 3
+
+      // Due to jitter, individual delays may not be strictly increasing,
+      // but the upper bound doubles each time. We can't test exact values
+      // due to randomness. Instead verify they're within bounds.
+      expect(delay0).toBeLessThanOrEqual(100);
+      expect(delay1).toBeLessThanOrEqual(200);
+      expect(delay2).toBeLessThanOrEqual(400);
+    });
+
+    it("should never exceed maxDelay", () => {
+      const strategy = new ReconnectStrategy({
+        maxRetries: 20,
+        baseDelay: 1_000,
+        maxDelay: 5_000,
+      });
+
+      // Advance to high attempt numbers
+      for (let i = 0; i < 15; i++) {
+        const delay = strategy.nextDelay();
+        expect(delay).toBeLessThanOrEqual(5_000);
+      }
+    });
+  });
+
+  describe("attempt tracking", () => {
+    it("should start at attempt 0", () => {
+      const strategy = new ReconnectStrategy(DEFAULT_RECONNECT_CONFIG);
+      expect(strategy.attempt).toBe(0);
+    });
+
+    it("should increment attempt on nextDelay", () => {
+      const strategy = new ReconnectStrategy(DEFAULT_RECONNECT_CONFIG);
+      strategy.nextDelay();
+      expect(strategy.attempt).toBe(1);
+      strategy.nextDelay();
+      expect(strategy.attempt).toBe(2);
+    });
+
+    it("should reset attempt to 0", () => {
+      const strategy = new ReconnectStrategy(DEFAULT_RECONNECT_CONFIG);
+      strategy.nextDelay();
+      strategy.nextDelay();
+      expect(strategy.attempt).toBe(2);
+
+      strategy.reset();
+      expect(strategy.attempt).toBe(0);
+    });
+  });
+
+  describe("exhausted", () => {
+    it("should not be exhausted initially", () => {
+      const strategy = new ReconnectStrategy(DEFAULT_RECONNECT_CONFIG);
+      expect(strategy.exhausted).toBe(false);
+    });
+
+    it("should be exhausted after maxRetries attempts", () => {
+      const strategy = new ReconnectStrategy({
+        maxRetries: 3,
+        baseDelay: 100,
+        maxDelay: 1_000,
+      });
+
+      strategy.nextDelay(); // attempt 0 → 1
+      strategy.nextDelay(); // attempt 1 → 2
+      strategy.nextDelay(); // attempt 2 → 3
+      expect(strategy.exhausted).toBe(true);
+    });
+
+    it("should not be exhausted before maxRetries", () => {
+      const strategy = new ReconnectStrategy({
+        maxRetries: 3,
+        baseDelay: 100,
+        maxDelay: 1_000,
+      });
+
+      strategy.nextDelay(); // attempt 0 → 1
+      strategy.nextDelay(); // attempt 1 → 2
+      expect(strategy.exhausted).toBe(false);
+    });
+
+    it("should reset exhausted state after reset", () => {
+      const strategy = new ReconnectStrategy({
+        maxRetries: 1,
+        baseDelay: 100,
+        maxDelay: 1_000,
+      });
+
+      strategy.nextDelay(); // attempt 0 → 1
+      expect(strategy.exhausted).toBe(true);
+
+      strategy.reset();
+      expect(strategy.exhausted).toBe(false);
+    });
+  });
+
+  describe("schedule", () => {
+    it("should fire callback after the delay", async () => {
+      const strategy = new ReconnectStrategy({
+        maxRetries: 10,
+        baseDelay: 1_000,
+        maxDelay: 30_000,
+      });
+      const fn = vi.fn().mockResolvedValue(undefined);
+
+      strategy.schedule(fn);
+
+      expect(fn).not.toHaveBeenCalled();
+
+      // Advance past max possible delay for attempt 0
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      expect(fn).toHaveBeenCalledOnce();
+    });
+
+    it("should return a cancel function that prevents callback", async () => {
+      const strategy = new ReconnectStrategy({
+        maxRetries: 10,
+        baseDelay: 1_000,
+        maxDelay: 30_000,
+      });
+      const fn = vi.fn().mockResolvedValue(undefined);
+
+      const { cancel } = strategy.schedule(fn);
+      cancel();
+
+      await vi.advanceTimersByTimeAsync(30_000);
+
+      expect(fn).not.toHaveBeenCalled();
+    });
+
+    it("should cancel previous schedule when scheduling again", async () => {
+      const strategy = new ReconnectStrategy({
+        maxRetries: 10,
+        baseDelay: 1_000,
+        maxDelay: 30_000,
+      });
+      const fn1 = vi.fn().mockResolvedValue(undefined);
+      const fn2 = vi.fn().mockResolvedValue(undefined);
+
+      strategy.schedule(fn1);
+      strategy.schedule(fn2); // should cancel fn1
+
+      await vi.advanceTimersByTimeAsync(30_000);
+
+      expect(fn1).not.toHaveBeenCalled();
+      expect(fn2).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/packages/node/src/__tests__/types.test.ts
+++ b/packages/node/src/__tests__/types.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from "vitest";
+import { ZodError } from "zod";
+import {
+  DEFAULT_RECONNECT_CONFIG,
+  NodeConfigSchema,
+  ReconnectConfigSchema,
+  resolveNodeConfig,
+} from "../types.js";
+
+describe("ReconnectConfigSchema", () => {
+  it("should apply defaults when no values provided", () => {
+    const result = ReconnectConfigSchema.parse({});
+    expect(result).toEqual({
+      maxRetries: 10,
+      baseDelay: 1_000,
+      maxDelay: 30_000,
+    });
+  });
+
+  it("should accept valid custom values", () => {
+    const result = ReconnectConfigSchema.parse({
+      maxRetries: 5,
+      baseDelay: 500,
+      maxDelay: 10_000,
+    });
+    expect(result).toEqual({
+      maxRetries: 5,
+      baseDelay: 500,
+      maxDelay: 10_000,
+    });
+  });
+
+  it("should reject negative maxRetries", () => {
+    expect(() => ReconnectConfigSchema.parse({ maxRetries: -1 })).toThrow(ZodError);
+  });
+
+  it("should reject zero baseDelay", () => {
+    expect(() => ReconnectConfigSchema.parse({ baseDelay: 0 })).toThrow(ZodError);
+  });
+
+  it("should reject zero maxDelay", () => {
+    expect(() => ReconnectConfigSchema.parse({ maxDelay: 0 })).toThrow(ZodError);
+  });
+
+  it("should export DEFAULT_RECONNECT_CONFIG matching schema defaults", () => {
+    expect(DEFAULT_RECONNECT_CONFIG).toEqual({
+      maxRetries: 10,
+      baseDelay: 1_000,
+      maxDelay: 30_000,
+    });
+  });
+});
+
+describe("NodeConfigSchema", () => {
+  const validConfig = {
+    nodeId: "test-node-1",
+    gatewayUrl: "ws://localhost:18789",
+    token: "test-token",
+    capabilities: {
+      agentTypes: ["high"],
+      tools: ["web-search"],
+      maxConcurrency: 4,
+      channels: ["slack"],
+    },
+  };
+
+  it("should parse a valid config with string token", () => {
+    const result = NodeConfigSchema.parse(validConfig);
+    expect(result.nodeId).toBe("test-node-1");
+    expect(result.gatewayUrl).toBe("ws://localhost:18789");
+    expect(result.token).toBe("test-token");
+    expect(result.capabilities.agentTypes).toEqual(["high"]);
+  });
+
+  it("should apply reconnect defaults when reconnect not provided", () => {
+    const result = NodeConfigSchema.parse(validConfig);
+    expect(result.reconnect).toEqual({
+      maxRetries: 10,
+      baseDelay: 1_000,
+      maxDelay: 30_000,
+    });
+  });
+
+  it("should accept custom reconnect config", () => {
+    const result = NodeConfigSchema.parse({
+      ...validConfig,
+      reconnect: { maxRetries: 3, baseDelay: 200, maxDelay: 5_000 },
+    });
+    expect(result.reconnect.maxRetries).toBe(3);
+  });
+
+  it("should reject empty nodeId", () => {
+    expect(() => NodeConfigSchema.parse({ ...validConfig, nodeId: "" })).toThrow(ZodError);
+  });
+
+  it("should reject invalid gatewayUrl", () => {
+    expect(() => NodeConfigSchema.parse({ ...validConfig, gatewayUrl: "not-a-url" })).toThrow(
+      ZodError,
+    );
+  });
+
+  it("should reject missing capabilities", () => {
+    const { capabilities: _, ...withoutCapabilities } = validConfig;
+    expect(() => NodeConfigSchema.parse(withoutCapabilities)).toThrow(ZodError);
+  });
+
+  it("should reject capabilities with empty agentTypes", () => {
+    expect(() =>
+      NodeConfigSchema.parse({
+        ...validConfig,
+        capabilities: { ...validConfig.capabilities, agentTypes: [] },
+      }),
+    ).toThrow(ZodError);
+  });
+
+  it("should accept function token (validated at runtime, not parse time)", () => {
+    // Zod cannot validate function contents, but it should accept functions
+    const result = NodeConfigSchema.parse({
+      ...validConfig,
+      token: () => "dynamic-token",
+    });
+    expect(typeof result.token).toBe("function");
+  });
+
+  it("should accept async function token", () => {
+    const result = NodeConfigSchema.parse({
+      ...validConfig,
+      token: async () => "async-token",
+    });
+    expect(typeof result.token).toBe("function");
+  });
+});
+
+describe("resolveNodeConfig", () => {
+  const validConfig = {
+    nodeId: "test-node-1",
+    gatewayUrl: "ws://localhost:18789",
+    token: "test-token",
+    capabilities: {
+      agentTypes: ["high"],
+      tools: ["web-search"],
+      maxConcurrency: 4,
+      channels: ["slack"],
+    },
+  };
+
+  it("should return resolved config with all defaults applied", () => {
+    const resolved = resolveNodeConfig(validConfig);
+    expect(resolved.nodeId).toBe("test-node-1");
+    expect(resolved.reconnect.maxRetries).toBe(10);
+    expect(resolved.reconnect.baseDelay).toBe(1_000);
+    expect(resolved.reconnect.maxDelay).toBe(30_000);
+  });
+
+  it("should throw ZodError for invalid config", () => {
+    expect(() => resolveNodeConfig({ nodeId: "" } as never)).toThrow(ZodError);
+  });
+
+  it("should return a frozen (readonly) object", () => {
+    const resolved = resolveNodeConfig(validConfig);
+    // TypeScript enforces readonly at compile time;
+    // verify the shape is correct at runtime
+    expect(resolved).toHaveProperty("nodeId");
+    expect(resolved).toHaveProperty("gatewayUrl");
+    expect(resolved).toHaveProperty("token");
+    expect(resolved).toHaveProperty("capabilities");
+    expect(resolved).toHaveProperty("reconnect");
+  });
+});

--- a/packages/node/src/__tests__/ws-client.test.ts
+++ b/packages/node/src/__tests__/ws-client.test.ts
@@ -1,0 +1,264 @@
+import type { GatewayFrame } from "@templar/gateway-protocol";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { type WebSocketClientLike, WsClient, type WsClientFactory } from "../ws-client.js";
+
+// ---------------------------------------------------------------------------
+// Mock WebSocket
+// ---------------------------------------------------------------------------
+
+function createMockWs(): WebSocketClientLike & {
+  _listeners: Map<string, Array<(...args: unknown[]) => void>>;
+  _simulateOpen: () => void;
+  _simulateMessage: (data: string) => void;
+  _simulateClose: (code: number, reason: string) => void;
+  _simulateError: (error: Error) => void;
+  _sent: string[];
+} {
+  const listeners = new Map<string, Array<(...args: unknown[]) => void>>();
+  const sent: string[] = [];
+
+  const ws = {
+    readyState: 0, // CONNECTING
+    _listeners: listeners,
+    _sent: sent,
+
+    send(data: string) {
+      sent.push(data);
+    },
+
+    close(code?: number, _reason?: string) {
+      ws.readyState = 3; // CLOSED
+      const handlers = listeners.get("close") ?? [];
+      for (const h of handlers) {
+        h(code ?? 1000, "");
+      }
+    },
+
+    on(event: string, handler: (...args: unknown[]) => void) {
+      const existing = listeners.get(event) ?? [];
+      listeners.set(event, [...existing, handler]);
+    },
+
+    _simulateOpen() {
+      ws.readyState = 1; // OPEN
+      const handlers = listeners.get("open") ?? [];
+      for (const h of handlers) h();
+    },
+
+    _simulateMessage(data: string) {
+      const handlers = listeners.get("message") ?? [];
+      for (const h of handlers) h(data);
+    },
+
+    _simulateClose(code: number, reason: string) {
+      ws.readyState = 3; // CLOSED
+      const handlers = listeners.get("close") ?? [];
+      for (const h of handlers) h(code, reason);
+    },
+
+    _simulateError(error: Error) {
+      const handlers = listeners.get("error") ?? [];
+      for (const h of handlers) h(error);
+    },
+  };
+
+  return ws;
+}
+
+describe("WsClient", () => {
+  let mockWs: ReturnType<typeof createMockWs>;
+  let factory: WsClientFactory;
+  let client: WsClient;
+
+  beforeEach(() => {
+    mockWs = createMockWs();
+    factory = vi.fn((_url: string, _options) => mockWs);
+    client = new WsClient(factory);
+  });
+
+  describe("connect", () => {
+    it("should resolve when WebSocket opens", async () => {
+      const connectPromise = client.connect("ws://localhost:18789", "test-token");
+      mockWs._simulateOpen();
+      await expect(connectPromise).resolves.toBeUndefined();
+    });
+
+    it("should pass auth header to factory", async () => {
+      const connectPromise = client.connect("ws://localhost:18789", "my-secret");
+      mockWs._simulateOpen();
+      await connectPromise;
+
+      expect(factory).toHaveBeenCalledWith("ws://localhost:18789/?nodeId=", {
+        headers: { Authorization: "Bearer my-secret" },
+      });
+    });
+
+    it("should reject when WebSocket errors during connect", async () => {
+      const connectPromise = client.connect("ws://localhost:18789", "token");
+      mockWs._simulateError(new Error("Connection refused"));
+      await expect(connectPromise).rejects.toThrow("Connection refused");
+    });
+
+    it("should reject when WebSocket closes during connect", async () => {
+      const connectPromise = client.connect("ws://localhost:18789", "token");
+      mockWs._simulateClose(1006, "Abnormal closure");
+      await expect(connectPromise).rejects.toThrow();
+    });
+
+    it("should dispose previous instance on subsequent connect", async () => {
+      const mockWs2 = createMockWs();
+      let callCount = 0;
+      const multiFactory: WsClientFactory = () => {
+        callCount++;
+        return callCount === 1 ? mockWs : mockWs2;
+      };
+      const multiClient = new WsClient(multiFactory);
+
+      // First connect
+      const p1 = multiClient.connect("ws://localhost:18789", "t");
+      mockWs._simulateOpen();
+      await p1;
+
+      // Second connect should dispose first
+      const p2 = multiClient.connect("ws://localhost:18789", "t");
+      mockWs2._simulateOpen();
+      await p2;
+
+      // First WS should have been closed
+      expect(mockWs.readyState).toBe(3); // CLOSED
+    });
+  });
+
+  describe("send", () => {
+    it("should serialize frame and send when connected", async () => {
+      const connectPromise = client.connect("ws://localhost:18789", "token");
+      mockWs._simulateOpen();
+      await connectPromise;
+
+      const frame: GatewayFrame = {
+        kind: "heartbeat.pong",
+        timestamp: Date.now(),
+      };
+      const result = client.send(frame);
+
+      expect(result).toBe(true);
+      expect(mockWs._sent).toHaveLength(1);
+      expect(JSON.parse(mockWs._sent[0] ?? "")).toEqual(frame);
+    });
+
+    it("should return false when not connected", () => {
+      const frame: GatewayFrame = {
+        kind: "heartbeat.pong",
+        timestamp: Date.now(),
+      };
+      const result = client.send(frame);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("onMessage", () => {
+    it("should dispatch valid frames to handler", async () => {
+      const handler = vi.fn();
+      client.onMessage(handler);
+
+      const connectPromise = client.connect("ws://localhost:18789", "token");
+      mockWs._simulateOpen();
+      await connectPromise;
+
+      const frame: GatewayFrame = {
+        kind: "node.register.ack",
+        nodeId: "test-node",
+        sessionId: "session-1",
+      };
+      mockWs._simulateMessage(JSON.stringify(frame));
+
+      expect(handler).toHaveBeenCalledOnce();
+      expect(handler).toHaveBeenCalledWith(frame);
+    });
+
+    it("should not dispatch invalid JSON", async () => {
+      const handler = vi.fn();
+      const errorHandler = vi.fn();
+      client.onMessage(handler);
+      client.onError(errorHandler);
+
+      const connectPromise = client.connect("ws://localhost:18789", "token");
+      mockWs._simulateOpen();
+      await connectPromise;
+
+      mockWs._simulateMessage("not-json{{{");
+
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it("should not dispatch invalid frames", async () => {
+      const handler = vi.fn();
+      client.onMessage(handler);
+
+      const connectPromise = client.connect("ws://localhost:18789", "token");
+      mockWs._simulateOpen();
+      await connectPromise;
+
+      mockWs._simulateMessage(JSON.stringify({ kind: "invalid.frame" }));
+
+      expect(handler).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("onClose", () => {
+    it("should fire close handler on disconnect", async () => {
+      const handler = vi.fn();
+      client.onClose(handler);
+
+      const connectPromise = client.connect("ws://localhost:18789", "token");
+      mockWs._simulateOpen();
+      await connectPromise;
+
+      mockWs._simulateClose(1001, "Going away");
+
+      expect(handler).toHaveBeenCalledWith(1001, "Going away");
+    });
+  });
+
+  describe("onError", () => {
+    it("should fire error handler on WS error", async () => {
+      const handler = vi.fn();
+      client.onError(handler);
+
+      const connectPromise = client.connect("ws://localhost:18789", "token");
+      mockWs._simulateOpen();
+      await connectPromise;
+
+      mockWs._simulateError(new Error("Network error"));
+
+      expect(handler).toHaveBeenCalledOnce();
+      expect(handler.mock.calls[0]?.[0]).toBeInstanceOf(Error);
+    });
+  });
+
+  describe("state", () => {
+    it("should report isConnected correctly", async () => {
+      expect(client.isConnected).toBe(false);
+
+      const connectPromise = client.connect("ws://localhost:18789", "token");
+      mockWs._simulateOpen();
+      await connectPromise;
+
+      expect(client.isConnected).toBe(true);
+
+      mockWs._simulateClose(1000, "Normal");
+      expect(client.isConnected).toBe(false);
+    });
+  });
+
+  describe("dispose", () => {
+    it("should close connection and clear state", async () => {
+      const connectPromise = client.connect("ws://localhost:18789", "token");
+      mockWs._simulateOpen();
+      await connectPromise;
+
+      client.dispose();
+      expect(client.isConnected).toBe(false);
+    });
+  });
+});

--- a/packages/node/src/heartbeat-responder.ts
+++ b/packages/node/src/heartbeat-responder.ts
@@ -1,0 +1,47 @@
+import type { GatewayFrame, HeartbeatPongFrame } from "@templar/gateway-protocol";
+
+// ---------------------------------------------------------------------------
+// HeartbeatResponder
+// ---------------------------------------------------------------------------
+
+/**
+ * Auto-responds to heartbeat.ping frames at the protocol level.
+ *
+ * This should be wired BEFORE user frame dispatch to ensure pong responses
+ * are never delayed by user handler processing (Issue #15).
+ */
+export class HeartbeatResponder {
+  private readonly sendPong: (frame: HeartbeatPongFrame) => void;
+  private _lastPingAt: number | undefined;
+
+  constructor(sendPong: (frame: HeartbeatPongFrame) => void) {
+    this.sendPong = sendPong;
+  }
+
+  /**
+   * Handle an incoming frame. If it's a ping, respond with pong immediately.
+   * Returns true if the frame was a ping (handled), false otherwise.
+   */
+  handleFrame(frame: GatewayFrame): boolean {
+    if (frame.kind !== "heartbeat.ping") {
+      return false;
+    }
+
+    this._lastPingAt = frame.timestamp;
+
+    const pong: HeartbeatPongFrame = {
+      kind: "heartbeat.pong",
+      timestamp: frame.timestamp,
+    };
+    this.sendPong(pong);
+
+    return true;
+  }
+
+  /**
+   * Timestamp of the last ping received, for diagnostics.
+   */
+  get lastPingAt(): number | undefined {
+    return this._lastPingAt;
+  }
+}

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -1,1 +1,29 @@
-export const PACKAGE_NAME = "@templar/node" as const;
+export { HeartbeatResponder } from "./heartbeat-responder.js";
+export { TemplarNode, type TemplarNodeDeps } from "./node.js";
+export { ReconnectStrategy } from "./reconnect.js";
+export {
+  type ConfigChangedHandler,
+  type ConnectedHandler,
+  DEFAULT_RECONNECT_CONFIG,
+  type DisconnectedHandler,
+  type ErrorHandler,
+  type MessageHandler,
+  NODE_STATES,
+  type NodeConfig,
+  NodeConfigSchema,
+  type NodeState,
+  type ReconnectConfig,
+  ReconnectConfigSchema,
+  type ReconnectedHandler,
+  type ReconnectingHandler,
+  type ResolvedNodeConfig,
+  resolveNodeConfig,
+  type SessionUpdateHandler,
+  type TokenProvider,
+} from "./types.js";
+export {
+  type WebSocketClientLike,
+  WsClient,
+  type WsClientFactory,
+  type WsClientOptions,
+} from "./ws-client.js";

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -1,0 +1,434 @@
+import type {
+  GatewayFrame,
+  LaneMessageFrame,
+  NodeRegisterFrame,
+  SessionState,
+} from "@templar/gateway-protocol";
+import { HeartbeatResponder } from "./heartbeat-responder.js";
+import { ReconnectStrategy } from "./reconnect.js";
+import type {
+  ConfigChangedHandler,
+  ConnectedHandler,
+  DisconnectedHandler,
+  ErrorHandler,
+  MessageHandler,
+  NodeConfig,
+  NodeState,
+  ReconnectedHandler,
+  ReconnectingHandler,
+  ResolvedNodeConfig,
+  SessionUpdateHandler,
+} from "./types.js";
+import { resolveNodeConfig } from "./types.js";
+import { WsClient, type WsClientFactory } from "./ws-client.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Close codes that indicate auth failure — do NOT reconnect */
+const AUTH_FAILURE_CODES = new Set([1008, 4401, 4403]);
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface TemplarNodeDeps {
+  readonly wsFactory?: WsClientFactory;
+}
+
+// ---------------------------------------------------------------------------
+// TemplarNode
+// ---------------------------------------------------------------------------
+
+/**
+ * Local device agent runtime that connects to a TemplarGateway
+ * via WebSocket and handles the GatewayFrame protocol.
+ *
+ * Responsibilities:
+ * - WebSocket connection + auth
+ * - Heartbeat response (protocol level, before user dispatch)
+ * - Frame dispatch to user-registered handlers
+ * - Automatic reconnection with exponential backoff + full jitter
+ * - Graceful shutdown
+ */
+export class TemplarNode {
+  private readonly resolvedConfig: ResolvedNodeConfig;
+  private readonly wsClient: WsClient;
+  private readonly reconnectStrategy: ReconnectStrategy;
+  private readonly heartbeatResponder: HeartbeatResponder;
+
+  private _state: NodeState = "disconnected";
+  private _sessionId: string | undefined;
+  private cancelReconnect: (() => void) | undefined;
+  private stopping = false;
+
+  // Event handlers (immutable arrays — Issue #5A)
+  private connectedHandlers: readonly ConnectedHandler[] = [];
+  private disconnectedHandlers: readonly DisconnectedHandler[] = [];
+  private reconnectingHandlers: readonly ReconnectingHandler[] = [];
+  private reconnectedHandlers: readonly ReconnectedHandler[] = [];
+  private messageHandlers: readonly MessageHandler[] = [];
+  private sessionUpdateHandlers: readonly SessionUpdateHandler[] = [];
+  private configChangedHandlers: readonly ConfigChangedHandler[] = [];
+  private errorHandlers: readonly ErrorHandler[] = [];
+
+  constructor(config: NodeConfig, deps: TemplarNodeDeps = {}) {
+    this.resolvedConfig = resolveNodeConfig(config);
+
+    this.wsClient = new WsClient(deps.wsFactory);
+    this.wsClient.setNodeId(this.resolvedConfig.nodeId);
+
+    this.reconnectStrategy = new ReconnectStrategy(this.resolvedConfig.reconnect);
+
+    this.heartbeatResponder = new HeartbeatResponder((pong) => {
+      this.wsClient.send(pong);
+    });
+
+    // Wire WS client events
+    this.wsClient.onMessage((frame) => this.handleFrame(frame));
+    this.wsClient.onClose((code, reason) => this.handleClose(code, reason));
+    this.wsClient.onError((error) => this.emitError(error, "ws-error"));
+  }
+
+  // -------------------------------------------------------------------------
+  // Lifecycle
+  // -------------------------------------------------------------------------
+
+  /**
+   * Connect to the gateway, register, and wait for acknowledgement.
+   */
+  async start(): Promise<void> {
+    if (this._state !== "disconnected") {
+      throw new Error(`Cannot start: node is in state "${this._state}"`);
+    }
+
+    this._state = "connecting";
+    try {
+      await this.connectAndRegister();
+    } catch (err) {
+      this._state = "disconnected";
+      throw err;
+    }
+  }
+
+  /**
+   * Gracefully disconnect: send deregister, cancel reconnection, close WS.
+   */
+  async stop(): Promise<void> {
+    if (this._state === "disconnected") {
+      return;
+    }
+
+    this.stopping = true;
+
+    // Cancel any pending reconnection
+    if (this.cancelReconnect) {
+      this.cancelReconnect();
+      this.cancelReconnect = undefined;
+    }
+
+    // Send deregister if connected
+    if (this._state === "connected") {
+      const frame: GatewayFrame = {
+        kind: "node.deregister",
+        nodeId: this.resolvedConfig.nodeId,
+      };
+      this.wsClient.send(frame);
+    }
+
+    // Close WS
+    this.wsClient.close(1000, "Node stopping");
+    this.wsClient.dispose();
+
+    this._state = "disconnected";
+    this._sessionId = undefined;
+    this.stopping = false;
+  }
+
+  // -------------------------------------------------------------------------
+  // State
+  // -------------------------------------------------------------------------
+
+  get state(): NodeState {
+    return this._state;
+  }
+
+  get sessionId(): string | undefined {
+    return this._sessionId;
+  }
+
+  get config(): ResolvedNodeConfig {
+    return this.resolvedConfig;
+  }
+
+  // -------------------------------------------------------------------------
+  // Event Registration
+  // -------------------------------------------------------------------------
+
+  onConnected(handler: ConnectedHandler): void {
+    this.connectedHandlers = [...this.connectedHandlers, handler];
+  }
+
+  onDisconnected(handler: DisconnectedHandler): void {
+    this.disconnectedHandlers = [...this.disconnectedHandlers, handler];
+  }
+
+  onReconnecting(handler: ReconnectingHandler): void {
+    this.reconnectingHandlers = [...this.reconnectingHandlers, handler];
+  }
+
+  onReconnected(handler: ReconnectedHandler): void {
+    this.reconnectedHandlers = [...this.reconnectedHandlers, handler];
+  }
+
+  onMessage(handler: MessageHandler): void {
+    this.messageHandlers = [...this.messageHandlers, handler];
+  }
+
+  onSessionUpdate(handler: SessionUpdateHandler): void {
+    this.sessionUpdateHandlers = [...this.sessionUpdateHandlers, handler];
+  }
+
+  onConfigChanged(handler: ConfigChangedHandler): void {
+    this.configChangedHandlers = [...this.configChangedHandlers, handler];
+  }
+
+  onError(handler: ErrorHandler): void {
+    this.errorHandlers = [...this.errorHandlers, handler];
+  }
+
+  // -------------------------------------------------------------------------
+  // Connection
+  // -------------------------------------------------------------------------
+
+  private async connectAndRegister(): Promise<void> {
+    const token = await this.resolveToken();
+
+    await this.wsClient.connect(this.resolvedConfig.gatewayUrl, token);
+
+    // Send register frame
+    const registerFrame: NodeRegisterFrame = {
+      kind: "node.register",
+      nodeId: this.resolvedConfig.nodeId,
+      capabilities: this.resolvedConfig.capabilities,
+      token,
+    };
+    this.wsClient.send(registerFrame);
+
+    // Wait for register ack
+    const sessionId = await this.waitForRegisterAck();
+    this._sessionId = sessionId;
+    this._state = "connected";
+    this.reconnectStrategy.reset();
+
+    for (const handler of this.connectedHandlers) {
+      handler(sessionId);
+    }
+  }
+
+  private waitForRegisterAck(): Promise<string> {
+    const timeout = 10_000;
+    return new Promise<string>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this._pendingAckResolve = undefined;
+        reject(new Error(`Registration timed out after ${timeout}ms`));
+      }, timeout);
+
+      this._pendingAckResolve = (sessionId: string) => {
+        clearTimeout(timer);
+        resolve(sessionId);
+      };
+    });
+  }
+
+  private _pendingAckResolve: ((sessionId: string) => void) | undefined;
+
+  // -------------------------------------------------------------------------
+  // Frame Handling
+  // -------------------------------------------------------------------------
+
+  private handleFrame(frame: GatewayFrame): void {
+    // 1. Heartbeat — protocol level, BEFORE user dispatch (Issue #15)
+    if (this.heartbeatResponder.handleFrame(frame)) {
+      return;
+    }
+
+    // 2. Registration ack (during connect/reconnect)
+    if (frame.kind === "node.register.ack" && this._pendingAckResolve) {
+      const resolve = this._pendingAckResolve;
+      this._pendingAckResolve = undefined;
+      resolve(frame.sessionId);
+      return;
+    }
+
+    // 3. Dispatch based on frame kind
+    switch (frame.kind) {
+      case "lane.message":
+        this.handleLaneMessage(frame);
+        break;
+
+      case "session.update":
+        this.dispatchSessionUpdate(frame.state);
+        break;
+
+      case "config.changed":
+        this.dispatchConfigChanged(frame.fields);
+        break;
+
+      case "error":
+        this.emitError(
+          new Error(`${frame.error.title}: ${frame.error.detail ?? ""}`),
+          "gateway-error",
+        );
+        break;
+
+      default:
+        // Unknown or unhandled frames (lane.message.ack, etc.) — ignore
+        break;
+    }
+  }
+
+  private handleLaneMessage(frame: LaneMessageFrame): void {
+    const { lane, message } = frame;
+
+    for (const handler of this.messageHandlers) {
+      try {
+        const result = handler(lane, message);
+        // Handle async rejections (Issue #6A)
+        if (result instanceof Promise) {
+          result.catch((err: unknown) => {
+            const error = err instanceof Error ? err : new Error(String(err));
+            this.emitError(error, "message-handler");
+          });
+        }
+      } catch (err) {
+        const error = err instanceof Error ? err : new Error(String(err));
+        this.emitError(error, "message-handler");
+      }
+    }
+  }
+
+  private dispatchSessionUpdate(state: SessionState): void {
+    for (const handler of this.sessionUpdateHandlers) {
+      try {
+        handler(state);
+      } catch (err) {
+        const error = err instanceof Error ? err : new Error(String(err));
+        this.emitError(error, "session-update-handler");
+      }
+    }
+  }
+
+  private dispatchConfigChanged(fields: readonly string[]): void {
+    for (const handler of this.configChangedHandlers) {
+      try {
+        handler(fields);
+      } catch (err) {
+        const error = err instanceof Error ? err : new Error(String(err));
+        this.emitError(error, "config-changed-handler");
+      }
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Reconnection
+  // -------------------------------------------------------------------------
+
+  private handleClose(code: number, reason: string): void {
+    // If we're intentionally stopping, don't reconnect
+    if (this.stopping) {
+      return;
+    }
+
+    // Emit disconnected event
+    for (const handler of this.disconnectedHandlers) {
+      handler(code, reason);
+    }
+
+    // Auth-related close — do NOT reconnect
+    if (AUTH_FAILURE_CODES.has(code)) {
+      this._state = "disconnected";
+      this._sessionId = undefined;
+      this.emitError(new Error(`Authentication failure (code ${code}): ${reason}`), "auth-failure");
+      return;
+    }
+
+    // Start reconnection
+    this._state = "reconnecting";
+    this.scheduleReconnect();
+  }
+
+  private scheduleReconnect(): void {
+    if (this.reconnectStrategy.exhausted) {
+      this._state = "disconnected";
+      this._sessionId = undefined;
+      this.emitError(
+        new Error(`Reconnection failed after ${this.reconnectStrategy.attempt} attempts`),
+        "reconnect-exhausted",
+      );
+      return;
+    }
+
+    const attempt = this.reconnectStrategy.attempt;
+
+    const { cancel, delay } = this.reconnectStrategy.schedule(async () => {
+      this.cancelReconnect = undefined;
+      await this.attemptReconnect();
+    });
+    this.cancelReconnect = cancel;
+
+    // Emit reconnecting with the current attempt number and computed delay
+    for (const handler of this.reconnectingHandlers) {
+      handler(attempt, delay);
+    }
+  }
+
+  private async attemptReconnect(): Promise<void> {
+    try {
+      // Dispose previous WS instance (fresh instance — Issue #16)
+      this.wsClient.dispose();
+
+      await this.connectAndRegister();
+
+      // On success, emit reconnected
+      const sessionId = this._sessionId;
+      if (sessionId) {
+        for (const handler of this.reconnectedHandlers) {
+          handler(sessionId);
+        }
+      }
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      this.emitError(error, "reconnect-attempt");
+
+      // Schedule next attempt if not stopping
+      if (!this.stopping && this._state === "reconnecting") {
+        this.scheduleReconnect();
+      }
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Helpers
+  // -------------------------------------------------------------------------
+
+  private async resolveToken(): Promise<string> {
+    const { token } = this.resolvedConfig;
+    if (typeof token === "string") {
+      return token;
+    }
+    return token();
+  }
+
+  private emitError(error: Error, context?: string): void {
+    if (this.errorHandlers.length === 0) {
+      // No error handler — log to stderr
+      console.error(`[TemplarNode] Unhandled error (${context ?? "unknown"}):`, error.message);
+      return;
+    }
+    for (const handler of this.errorHandlers) {
+      handler(error, context);
+    }
+  }
+}

--- a/packages/node/src/reconnect.ts
+++ b/packages/node/src/reconnect.ts
@@ -1,0 +1,90 @@
+import type { ReconnectConfig } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// ReconnectStrategy
+// ---------------------------------------------------------------------------
+
+/**
+ * Reconnection strategy with exponential backoff and full jitter.
+ *
+ * Full jitter (AWS Architecture Blog recommended):
+ *   delay = random() * min(maxDelay, baseDelay * 2^attempt)
+ *
+ * Provides maximum spread across reconnecting clients to prevent
+ * thundering herd when a gateway restarts.
+ */
+export class ReconnectStrategy {
+  private readonly config: ReconnectConfig;
+  private currentAttempt = 0;
+  private pendingTimer: ReturnType<typeof setTimeout> | undefined;
+
+  constructor(config: ReconnectConfig) {
+    this.config = config;
+  }
+
+  /**
+   * Calculate the next delay with full jitter and increment the attempt counter.
+   */
+  nextDelay(): number {
+    const { baseDelay, maxDelay } = this.config;
+    const cap = Math.min(maxDelay, baseDelay * 2 ** this.currentAttempt);
+    const delay = Math.random() * cap;
+    this.currentAttempt += 1;
+    return delay;
+  }
+
+  /**
+   * Reset the attempt counter (call on successful connection).
+   */
+  reset(): void {
+    this.currentAttempt = 0;
+    this.cancelPending();
+  }
+
+  /**
+   * Whether max retries have been exhausted.
+   */
+  get exhausted(): boolean {
+    return this.currentAttempt >= this.config.maxRetries;
+  }
+
+  /**
+   * Current attempt number.
+   */
+  get attempt(): number {
+    return this.currentAttempt;
+  }
+
+  /**
+   * Schedule a reconnection attempt after the next backoff delay.
+   * Cancels any previously scheduled attempt.
+   * Returns a cancel function.
+   */
+  schedule(fn: () => Promise<void>): { cancel: () => void; delay: number } {
+    this.cancelPending();
+
+    const delay = this.nextDelay();
+    this.pendingTimer = setTimeout(() => {
+      this.pendingTimer = undefined;
+      fn();
+    }, delay);
+
+    return {
+      cancel: () => {
+        this.cancelPending();
+      },
+      delay,
+    };
+  }
+
+  // -------------------------------------------------------------------------
+  // Private
+  // -------------------------------------------------------------------------
+
+  private cancelPending(): void {
+    if (this.pendingTimer !== undefined) {
+      clearTimeout(this.pendingTimer);
+      this.pendingTimer = undefined;
+    }
+  }
+}

--- a/packages/node/src/types.ts
+++ b/packages/node/src/types.ts
@@ -1,0 +1,100 @@
+import type { Lane, LaneMessage, NodeCapabilities, SessionState } from "@templar/gateway-protocol";
+import { NodeCapabilitiesSchema } from "@templar/gateway-protocol";
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// Node State
+// ---------------------------------------------------------------------------
+
+export const NODE_STATES = ["disconnected", "connecting", "connected", "reconnecting"] as const;
+export type NodeState = (typeof NODE_STATES)[number];
+
+// ---------------------------------------------------------------------------
+// Token Provider
+// ---------------------------------------------------------------------------
+
+/**
+ * Authentication token: static string or factory function for refresh.
+ * Factory is called fresh on each connection/reconnection attempt.
+ */
+export type TokenProvider = string | (() => string | Promise<string>);
+
+// ---------------------------------------------------------------------------
+// Reconnect Config
+// ---------------------------------------------------------------------------
+
+export interface ReconnectConfig {
+  readonly maxRetries: number;
+  readonly baseDelay: number;
+  readonly maxDelay: number;
+}
+
+export const DEFAULT_RECONNECT_CONFIG: ReconnectConfig = {
+  maxRetries: 10,
+  baseDelay: 1_000,
+  maxDelay: 30_000,
+} as const;
+
+export const ReconnectConfigSchema = z
+  .object({
+    maxRetries: z.number().int().nonnegative().default(DEFAULT_RECONNECT_CONFIG.maxRetries),
+    baseDelay: z.number().int().positive().default(DEFAULT_RECONNECT_CONFIG.baseDelay),
+    maxDelay: z.number().int().positive().default(DEFAULT_RECONNECT_CONFIG.maxDelay),
+  })
+  .default({});
+
+// ---------------------------------------------------------------------------
+// Node Config
+// ---------------------------------------------------------------------------
+
+export interface NodeConfig {
+  readonly nodeId: string;
+  readonly gatewayUrl: string;
+  readonly token: TokenProvider;
+  readonly capabilities: NodeCapabilities;
+  readonly reconnect?: ReconnectConfig;
+}
+
+export const NodeConfigSchema = z.object({
+  nodeId: z.string().min(1),
+  gatewayUrl: z.string().url(),
+  token: z.union([z.string().min(1), z.function()]),
+  capabilities: NodeCapabilitiesSchema,
+  reconnect: ReconnectConfigSchema,
+});
+
+// ---------------------------------------------------------------------------
+// Resolved Config
+// ---------------------------------------------------------------------------
+
+/**
+ * Config after Zod parsing — all defaults applied, all fields present.
+ */
+export interface ResolvedNodeConfig {
+  readonly nodeId: string;
+  readonly gatewayUrl: string;
+  readonly token: TokenProvider;
+  readonly capabilities: NodeCapabilities;
+  readonly reconnect: ReconnectConfig;
+}
+
+/**
+ * Parse and resolve a NodeConfig, applying all defaults.
+ * Throws ZodError if config is invalid.
+ */
+export function resolveNodeConfig(config: NodeConfig): ResolvedNodeConfig {
+  return NodeConfigSchema.parse(config) as ResolvedNodeConfig;
+}
+
+// ---------------------------------------------------------------------------
+// Event Handler Types
+// ---------------------------------------------------------------------------
+
+export type ConnectedHandler = (sessionId: string) => void;
+export type DisconnectedHandler = (code: number, reason: string) => void;
+export type ReconnectingHandler = (attempt: number, delay: number) => void;
+export type ReconnectedHandler = (sessionId: string) => void;
+export type MessageHandler = (lane: Lane, message: LaneMessage) => void | Promise<void>;
+export type SessionUpdateHandler = (state: SessionState) => void;
+export type ConfigChangedHandler = (fields: readonly string[]) => void;
+export type ErrorHandler = (error: Error, context?: string) => void;

--- a/packages/node/src/ws-client.ts
+++ b/packages/node/src/ws-client.ts
@@ -1,0 +1,233 @@
+import type { GatewayFrame } from "@templar/gateway-protocol";
+import { safeParseFrame } from "@templar/gateway-protocol";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface WebSocketClientLike {
+  send(data: string): void;
+  close(code?: number, reason?: string): void;
+  on(event: string, handler: (...args: unknown[]) => void): void;
+  readyState: number;
+}
+
+export interface WsClientOptions {
+  readonly headers: Record<string, string>;
+}
+
+/**
+ * Factory for creating WebSocket client instances.
+ * Injectable for testing.
+ */
+export type WsClientFactory = (url: string, options: WsClientOptions) => WebSocketClientLike;
+
+// ---------------------------------------------------------------------------
+// WS Ready States
+// ---------------------------------------------------------------------------
+
+const WS_OPEN = 1;
+
+// ---------------------------------------------------------------------------
+// WsClient
+// ---------------------------------------------------------------------------
+
+/**
+ * Thin wrapper around a WebSocket client with frame serialization,
+ * Zod validation on incoming frames, and injectable factory for testing.
+ */
+export class WsClient {
+  private ws: WebSocketClientLike | undefined;
+  private readonly factory: WsClientFactory | undefined;
+  private nodeId = "";
+
+  private messageHandlers: readonly ((frame: GatewayFrame) => void)[] = [];
+  private closeHandlers: readonly ((code: number, reason: string) => void)[] = [];
+  private errorHandlers: readonly ((error: Error) => void)[] = [];
+
+  constructor(factory?: WsClientFactory) {
+    this.factory = factory;
+  }
+
+  /**
+   * Connect to the gateway.
+   * Resolves when the WebSocket is open.
+   * Rejects on error or unexpected close during handshake.
+   */
+  async connect(url: string, token: string): Promise<void> {
+    // Dispose previous connection if any
+    if (this.ws) {
+      this.disposeWs();
+    }
+
+    const target = new URL(url);
+    target.searchParams.set("nodeId", this.nodeId);
+    const urlWithNodeId = target.toString();
+
+    const options: WsClientOptions = {
+      headers: { Authorization: `Bearer ${token}` },
+    };
+
+    const ws = this.factory
+      ? this.factory(urlWithNodeId, options)
+      : await this.createDefaultWs(urlWithNodeId, options);
+
+    this.ws = ws;
+
+    return new Promise<void>((resolve, reject) => {
+      let settled = false;
+
+      ws.on("open", () => {
+        if (!settled) {
+          settled = true;
+          this.wireEventHandlers(ws);
+          resolve();
+        }
+      });
+
+      ws.on("error", (err: unknown) => {
+        if (!settled) {
+          settled = true;
+          const error = err instanceof Error ? err : new Error(String(err));
+          reject(error);
+        }
+      });
+
+      ws.on("close", (code: unknown, reason: unknown) => {
+        if (!settled) {
+          settled = true;
+          reject(
+            new Error(
+              `WebSocket closed during connect: code=${String(code)}, reason=${String(reason)}`,
+            ),
+          );
+        }
+      });
+    });
+  }
+
+  /**
+   * Set the nodeId for the connection URL.
+   */
+  setNodeId(nodeId: string): void {
+    this.nodeId = nodeId;
+  }
+
+  /**
+   * Send a frame to the gateway.
+   * Returns true if sent, false if not connected.
+   */
+  send(frame: GatewayFrame): boolean {
+    if (!this.ws || this.ws.readyState !== WS_OPEN) {
+      return false;
+    }
+    this.ws.send(JSON.stringify(frame));
+    return true;
+  }
+
+  /**
+   * Close the WebSocket connection.
+   */
+  close(code?: number, reason?: string): void {
+    if (this.ws) {
+      this.ws.close(code, reason);
+    }
+  }
+
+  /**
+   * Register a handler for validated incoming frames.
+   */
+  onMessage(handler: (frame: GatewayFrame) => void): void {
+    this.messageHandlers = [...this.messageHandlers, handler];
+  }
+
+  /**
+   * Register a handler for connection close events.
+   */
+  onClose(handler: (code: number, reason: string) => void): void {
+    this.closeHandlers = [...this.closeHandlers, handler];
+  }
+
+  /**
+   * Register a handler for connection errors.
+   */
+  onError(handler: (error: Error) => void): void {
+    this.errorHandlers = [...this.errorHandlers, handler];
+  }
+
+  /**
+   * Whether the WebSocket is currently open.
+   */
+  get isConnected(): boolean {
+    return this.ws?.readyState === WS_OPEN;
+  }
+
+  /**
+   * Dispose the client: close connection and clear all state.
+   */
+  dispose(): void {
+    this.disposeWs();
+  }
+
+  // -------------------------------------------------------------------------
+  // Private
+  // -------------------------------------------------------------------------
+
+  private wireEventHandlers(ws: WebSocketClientLike): void {
+    ws.on("message", (data: unknown) => {
+      this.handleRawMessage(String(data));
+    });
+
+    ws.on("close", (code: unknown, reason: unknown) => {
+      for (const handler of this.closeHandlers) {
+        handler(Number(code) || 1000, String(reason ?? ""));
+      }
+    });
+
+    ws.on("error", (err: unknown) => {
+      const error = err instanceof Error ? err : new Error(String(err));
+      for (const handler of this.errorHandlers) {
+        handler(error);
+      }
+    });
+  }
+
+  private handleRawMessage(data: string): void {
+    let raw: unknown;
+    try {
+      raw = JSON.parse(data);
+    } catch {
+      // Invalid JSON — ignore
+      return;
+    }
+
+    const result = safeParseFrame(raw);
+    if (!result.success) {
+      // Invalid frame — ignore
+      return;
+    }
+
+    const frame = result.data as GatewayFrame;
+    for (const handler of this.messageHandlers) {
+      handler(frame);
+    }
+  }
+
+  private disposeWs(): void {
+    if (this.ws) {
+      // Close if still open
+      if (this.ws.readyState === WS_OPEN) {
+        this.ws.close(1000, "Disposed");
+      }
+      this.ws = undefined;
+    }
+  }
+
+  private async createDefaultWs(
+    url: string,
+    options: WsClientOptions,
+  ): Promise<WebSocketClientLike> {
+    const { WebSocket } = await import("ws");
+    return new WebSocket(url, { headers: options.headers }) as unknown as WebSocketClientLike;
+  }
+}

--- a/packages/node/tsconfig.json
+++ b/packages/node/tsconfig.json
@@ -2,8 +2,9 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "isolatedDeclarations": false
   },
   "include": ["src"],
-  "references": [{ "path": "../core" }, { "path": "../errors" }]
+  "references": [{ "path": "../gateway-protocol" }]
 }

--- a/packages/node/tsup.config.ts
+++ b/packages/node/tsup.config.ts
@@ -3,7 +3,14 @@ import { defineConfig } from "tsup";
 export default defineConfig({
   entry: ["src/index.ts"],
   format: ["esm"],
-  dts: true,
+  dts: {
+    compilerOptions: {
+      composite: false,
+      isolatedDeclarations: false,
+    },
+  },
+  external: ["ws"],
+  sourcemap: true,
   clean: true,
   treeshake: true,
   target: "node22",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -151,12 +151,25 @@ importers:
 
   packages/node:
     dependencies:
-      '@templar/core':
+      '@templar/gateway-protocol':
         specifier: workspace:*
-        version: link:../core
-      '@templar/errors':
+        version: link:../gateway-protocol
+      zod:
+        specifier: ^3.22.4
+        version: 3.25.76
+    devDependencies:
+      '@templar/gateway':
         specifier: workspace:*
-        version: link:../errors
+        version: link:../gateway
+      '@types/node':
+        specifier: ^25.2.2
+        version: 25.2.2
+      '@types/ws':
+        specifier: ^8.18.1
+        version: 8.18.1
+      ws:
+        specifier: ^8.19.0
+        version: 8.19.0
 
   packages/sandbox:
     dependencies:


### PR DESCRIPTION
## Summary
- Implements Issue #14: `@templar/node` — the client-side counterpart to `@templar/gateway` (#13) that connects local device agents to the gateway via WebSocket
- Adds 6 source modules: `TemplarNode` orchestrator, `WsClient` wrapper, `ReconnectStrategy` (exponential backoff + full jitter), `HeartbeatResponder`, types/schemas, and public API exports
- Includes 79 tests across 7 files: unit tests with injectable mocks + real-WS integration tests against a `MiniGateway` server

## Key Design Decisions
- **ws library** for WebSocket (auth headers on upgrade not possible with native WebSocket)
- **Callback-based handlers** with immutable arrays (matches gateway pattern)
- **Full jitter** exponential backoff (AWS Architecture Blog recommended) for reconnection
- **Protocol-level heartbeat** response before user dispatch to prevent false dead detection
- **10s registration timeout** to prevent indefinite hangs if gateway never acks
- **URL-safe nodeId** encoding via `URLSearchParams` to prevent query string injection
- **Injectable `WsClientFactory`** for deterministic unit testing without real sockets

## Files Changed
| File | Purpose |
|------|---------|
| `src/types.ts` | NodeConfig, ResolvedNodeConfig, Zod schemas, event handler types |
| `src/ws-client.ts` | WebSocket wrapper with frame parsing and injectable factory |
| `src/reconnect.ts` | Backoff strategy returning `{ cancel, delay }` |
| `src/heartbeat-responder.ts` | Ping → pong at protocol level |
| `src/node.ts` | Main `TemplarNode` class: lifecycle, frame dispatch, reconnection |
| `src/index.ts` | Public API re-exports |

## Test plan
- [x] 18 unit tests for Zod config schemas and defaults
- [x] 14 unit tests for WsClient (mock factory, frame parsing, error handling)
- [x] 13 unit tests for ReconnectStrategy (jitter bounds, exhaustion, cancel)
- [x] 4 unit tests for HeartbeatResponder (ping/pong, non-heartbeat passthrough)
- [x] 19 unit tests for TemplarNode orchestrator (lifecycle, frame dispatch, error boundaries)
- [x] 8 integration tests with real `ws.WebSocketServer` (full lifecycle, lane messages, heartbeat, auth failure, reconnection, session/config updates)
- [x] 3 export verification tests
- [x] `pnpm build` — all 11 packages pass
- [x] `pnpm typecheck` — all 11 packages pass
- [x] `pnpm lint` — all 11 packages pass (Biome v2)
- [x] `pnpm test` — all 22 turbo tasks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)