### PR TITLE
feat: add @templar/channel-discord — discord.js v14 integration

### DIFF
--- a/packages/channel-discord/package.json
+++ b/packages/channel-discord/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@templar/channel-discord",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check .",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "discord.js": "^14.18.0",
+    "zod": "^3.24.0"
+  },
+  "devDependencies": {
+    "@templar/core": "workspace:*",
+    "@templar/errors": "workspace:*",
+    "@types/node": "^25.2.2"
+  }
+}

--- a/packages/channel-discord/src/__tests__/helpers/mock-discord.ts
+++ b/packages/channel-discord/src/__tests__/helpers/mock-discord.ts
@@ -1,0 +1,126 @@
+import { vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Captured API call type
+// ---------------------------------------------------------------------------
+
+export interface CapturedApiCall {
+  readonly method: string;
+  readonly payload: Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// Mock Discord Message
+// ---------------------------------------------------------------------------
+
+export interface MockDiscordMessage {
+  id: string;
+  content: string;
+  author: { id: string; bot: boolean; username: string };
+  channelId: string;
+  channel: {
+    id: string;
+    type: number;
+    isThread: () => boolean;
+    send: ReturnType<typeof vi.fn>;
+  };
+  guildId: string | null;
+  attachments: Map<string, MockAttachment>;
+  embeds: MockEmbed[];
+  createdTimestamp: number;
+  reference: { messageId: string } | null;
+}
+
+export interface MockAttachment {
+  id: string;
+  name: string;
+  url: string;
+  contentType: string | null;
+  size: number;
+}
+
+export interface MockEmbed {
+  description: string | null;
+  fields: { name: string; value: string }[];
+}
+
+export function createMockMessage(overrides: Partial<MockDiscordMessage> = {}): MockDiscordMessage {
+  const channelId = overrides.channelId ?? "chan-001";
+  return {
+    id: "msg-001",
+    content: "Hello from Discord",
+    author: { id: "user-001", bot: false, username: "testuser" },
+    channelId,
+    channel: {
+      id: channelId,
+      type: 0, // GuildText
+      isThread: () => false,
+      send: vi.fn().mockResolvedValue({ id: "sent-001" }),
+    },
+    guildId: "guild-001",
+    attachments: new Map(),
+    embeds: [],
+    createdTimestamp: 1700000000000,
+    reference: null,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Mock Discord Client
+// ---------------------------------------------------------------------------
+
+export interface MockClientInstance {
+  readonly login: ReturnType<typeof vi.fn>;
+  readonly destroy: ReturnType<typeof vi.fn>;
+  readonly on: ReturnType<typeof vi.fn>;
+  readonly channels: {
+    fetch: ReturnType<typeof vi.fn>;
+  };
+  readonly user: { id: string; username: string } | null;
+  readonly eventHandlers: Map<string, Array<(...args: unknown[]) => Promise<void>>>;
+}
+
+export function createMockClientInstance(): MockClientInstance {
+  const eventHandlers = new Map<string, Array<(...args: unknown[]) => Promise<void>>>();
+
+  return {
+    login: vi.fn().mockResolvedValue("token"),
+    destroy: vi.fn(),
+    on: vi.fn((event: string, handler: (...args: unknown[]) => Promise<void>) => {
+      const handlers = eventHandlers.get(event) ?? [];
+      handlers.push(handler);
+      eventHandlers.set(event, handlers);
+    }),
+    channels: {
+      fetch: vi.fn().mockResolvedValue({
+        id: "chan-001",
+        type: 0,
+        isThread: () => false,
+        send: vi.fn().mockResolvedValue({ id: "sent-001" }),
+      }),
+    },
+    user: { id: "bot-001", username: "testbot" },
+    eventHandlers,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Mock TextChannel for renderer tests
+// ---------------------------------------------------------------------------
+
+export function createMockTextChannel(): {
+  channel: { send: ReturnType<typeof vi.fn>; id: string };
+  calls: CapturedApiCall[];
+} {
+  const calls: CapturedApiCall[] = [];
+  const send = vi.fn(async (payload: Record<string, unknown>) => {
+    calls.push({ method: "channel.send", payload });
+    return { id: "sent-001" };
+  });
+
+  return {
+    channel: { send, id: "chan-001" },
+    calls,
+  };
+}

--- a/packages/channel-discord/src/__tests__/integration/discord-send-flow.test.ts
+++ b/packages/channel-discord/src/__tests__/integration/discord-send-flow.test.ts
@@ -1,0 +1,186 @@
+import type { OutboundMessage } from "@templar/core";
+import { ChannelSendError } from "@templar/errors";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DiscordChannel } from "../../adapter.js";
+import { createMockClientInstance, type MockClientInstance } from "../helpers/mock-discord.js";
+
+// ---------------------------------------------------------------------------
+// Mock discord.js
+// ---------------------------------------------------------------------------
+
+let mockClient: MockClientInstance;
+const mockChannelSend = vi.fn().mockResolvedValue({ id: "sent-001" });
+
+vi.mock("discord.js", () => {
+  return {
+    Client: class MockDiscordClient {
+      login!: MockClientInstance["login"];
+      destroy!: MockClientInstance["destroy"];
+      on!: MockClientInstance["on"];
+      channels!: MockClientInstance["channels"];
+      user!: MockClientInstance["user"];
+
+      constructor() {
+        // biome-ignore lint/correctness/noConstructorReturn: Test pattern
+        return mockClient;
+      }
+    },
+    GatewayIntentBits: {
+      Guilds: 1,
+      GuildMessages: 512,
+      MessageContent: 32768,
+    },
+  };
+});
+
+const VALID_CONFIG = { token: "Bot integration-test-token" };
+
+describe("Discord send flow (integration)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockClient = createMockClientInstance();
+    mockChannelSend.mockClear();
+
+    // Override channels.fetch to return a channel with our tracked send mock
+    mockClient.channels.fetch = vi.fn().mockResolvedValue({
+      id: "ch-001",
+      type: 0,
+      isThread: () => false,
+      send: mockChannelSend,
+    });
+  });
+
+  it("full lifecycle: connect → onMessage → send → disconnect", async () => {
+    const adapter = new DiscordChannel(VALID_CONFIG);
+
+    // --- Connect ---
+    await adapter.connect();
+    expect(mockClient.login).toHaveBeenCalledWith("Bot integration-test-token");
+    expect(adapter.getClient()).toBeDefined();
+
+    // --- Register message handler ---
+    const handler = vi.fn();
+    adapter.onMessage(handler);
+
+    // --- Simulate incoming message ---
+    const messageHandlers = mockClient.eventHandlers.get("messageCreate");
+    expect(messageHandlers).toBeDefined();
+
+    await messageHandlers?.[0]?.({
+      id: "msg-incoming",
+      content: "Hello from user",
+      author: { id: "user-001", bot: false, username: "testuser" },
+      channelId: "ch-001",
+      channel: { id: "ch-001", type: 0, isThread: () => false },
+      attachments: new Map(),
+      embeds: [],
+      createdTimestamp: 1700000000000,
+    });
+
+    expect(handler).toHaveBeenCalledOnce();
+    const inbound = handler.mock.calls[0]?.[0];
+    expect(inbound.channelType).toBe("discord");
+    expect(inbound.blocks[0]).toEqual({ type: "text", content: "Hello from user" });
+
+    // --- Send multi-block message ---
+    const outbound: OutboundMessage = {
+      channelId: "ch-001",
+      blocks: [
+        { type: "text", content: "Here is your report" },
+        { type: "image", url: "https://cdn.example.com/chart.png", alt: "chart" },
+        {
+          type: "button",
+          buttons: [
+            { label: "Approve", action: "approve", style: "primary" },
+            { label: "Reject", action: "reject", style: "danger" },
+          ],
+        },
+      ],
+    };
+    await adapter.send(outbound);
+
+    // Verify batched into single API call (Decision 14A)
+    expect(mockChannelSend).toHaveBeenCalledOnce();
+    const sentPayload = mockChannelSend.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(sentPayload.content).toBe("Here is your report");
+    expect(sentPayload.files).toBeDefined();
+    expect(sentPayload.components).toBeDefined();
+
+    // --- Disconnect ---
+    await adapter.disconnect();
+    expect(mockClient.destroy).toHaveBeenCalledOnce();
+    expect(adapter.getClient()).toBeUndefined();
+  });
+
+  it("handles send failure with proper error wrapping", async () => {
+    const adapter = new DiscordChannel(VALID_CONFIG);
+    await adapter.connect();
+
+    // Override send to fail with permission error
+    const discordError = new Error("Missing Permissions");
+    (discordError as unknown as Record<string, unknown>).code = 50013;
+    mockChannelSend.mockRejectedValueOnce(discordError);
+
+    const outbound: OutboundMessage = {
+      channelId: "ch-001",
+      blocks: [{ type: "text", content: "Should fail" }],
+    };
+
+    try {
+      await adapter.send(outbound);
+      expect.unreachable("Should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ChannelSendError);
+      expect((err as Error).message).toMatch(/permission/i);
+    }
+  });
+
+  it("handles long messages with auto-split", async () => {
+    const adapter = new DiscordChannel(VALID_CONFIG);
+    await adapter.connect();
+
+    const longContent = "x".repeat(4500);
+    const outbound: OutboundMessage = {
+      channelId: "ch-001",
+      blocks: [{ type: "text", content: longContent }],
+    };
+
+    await adapter.send(outbound);
+
+    // Should have split into multiple sends
+    expect(mockChannelSend.mock.calls.length).toBeGreaterThan(1);
+
+    // Each call's content should be ≤ 2000 chars
+    for (const call of mockChannelSend.mock.calls) {
+      const payload = call[0] as Record<string, unknown>;
+      if (payload.content) {
+        expect((payload.content as string).length).toBeLessThanOrEqual(2000);
+      }
+    }
+  });
+
+  it("rejects send when not connected", async () => {
+    const adapter = new DiscordChannel(VALID_CONFIG);
+
+    const outbound: OutboundMessage = {
+      channelId: "ch-001",
+      blocks: [{ type: "text", content: "Should fail" }],
+    };
+
+    await expect(adapter.send(outbound)).rejects.toThrow(ChannelSendError);
+    await expect(adapter.send(outbound)).rejects.toThrow(/not connected/i);
+  });
+
+  it("rejects send after disconnect", async () => {
+    const adapter = new DiscordChannel(VALID_CONFIG);
+    await adapter.connect();
+    await adapter.disconnect();
+
+    const outbound: OutboundMessage = {
+      channelId: "ch-001",
+      blocks: [{ type: "text", content: "Should fail" }],
+    };
+
+    await expect(adapter.send(outbound)).rejects.toThrow(ChannelSendError);
+  });
+});

--- a/packages/channel-discord/src/__tests__/unit/adapter.test.ts
+++ b/packages/channel-discord/src/__tests__/unit/adapter.test.ts
@@ -1,0 +1,336 @@
+import type { OutboundMessage } from "@templar/core";
+import { ChannelLoadError, ChannelSendError } from "@templar/errors";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DiscordChannel } from "../../adapter.js";
+import { DISCORD_CAPABILITIES } from "../../capabilities.js";
+import { createMockClientInstance, type MockClientInstance } from "../helpers/mock-discord.js";
+
+// ---------------------------------------------------------------------------
+// Mock discord.js
+// ---------------------------------------------------------------------------
+
+let mockClient: MockClientInstance;
+
+vi.mock("discord.js", () => {
+  return {
+    Client: class MockDiscordClient {
+      login!: MockClientInstance["login"];
+      destroy!: MockClientInstance["destroy"];
+      on!: MockClientInstance["on"];
+      channels!: MockClientInstance["channels"];
+      user!: MockClientInstance["user"];
+
+      constructor() {
+        // biome-ignore lint/correctness/noConstructorReturn: Test pattern
+        return mockClient;
+      }
+    },
+    GatewayIntentBits: {
+      Guilds: 1,
+      GuildMembers: 2,
+      GuildModeration: 4,
+      GuildEmojisAndStickers: 8,
+      GuildIntegrations: 16,
+      GuildWebhooks: 32,
+      GuildInvites: 64,
+      GuildVoiceStates: 128,
+      GuildPresences: 256,
+      GuildMessages: 512,
+      GuildMessageReactions: 1024,
+      GuildMessageTyping: 2048,
+      DirectMessages: 4096,
+      DirectMessageReactions: 8192,
+      DirectMessageTyping: 16384,
+      MessageContent: 32768,
+      GuildScheduledEvents: 65536,
+      AutoModerationConfiguration: 1048576,
+      AutoModerationExecution: 2097152,
+    },
+  };
+});
+
+const VALID_CONFIG = {
+  token: "Bot test-token-123",
+};
+
+describe("DiscordChannel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockClient = createMockClientInstance();
+  });
+
+  // -----------------------------------------------------------------------
+  // Constructor
+  // -----------------------------------------------------------------------
+
+  describe("constructor", () => {
+    it("creates adapter with valid config", () => {
+      const adapter = new DiscordChannel(VALID_CONFIG);
+      expect(adapter.name).toBe("discord");
+      expect(adapter.capabilities).toBe(DISCORD_CAPABILITIES);
+    });
+
+    it("throws ChannelLoadError for invalid config", () => {
+      expect(() => new DiscordChannel({})).toThrow(ChannelLoadError);
+    });
+
+    it("throws ChannelLoadError for empty token", () => {
+      expect(() => new DiscordChannel({ token: "" })).toThrow(ChannelLoadError);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // connect()
+  // -----------------------------------------------------------------------
+
+  describe("connect()", () => {
+    it("calls client.login() with token", async () => {
+      const adapter = new DiscordChannel(VALID_CONFIG);
+      await adapter.connect();
+      expect(mockClient.login).toHaveBeenCalledWith("Bot test-token-123");
+    });
+
+    it("is idempotent — second call is a no-op", async () => {
+      const adapter = new DiscordChannel(VALID_CONFIG);
+      await adapter.connect();
+      await adapter.connect();
+      expect(mockClient.login).toHaveBeenCalledOnce();
+    });
+
+    it("throws ChannelLoadError if login fails", async () => {
+      mockClient.login.mockRejectedValueOnce(new Error("Invalid token"));
+      const adapter = new DiscordChannel(VALID_CONFIG);
+      await expect(adapter.connect()).rejects.toThrow(ChannelLoadError);
+    });
+
+    it("includes descriptive message when login fails", async () => {
+      mockClient.login.mockRejectedValueOnce(new Error("Invalid token"));
+      const adapter = new DiscordChannel(VALID_CONFIG);
+      await expect(adapter.connect()).rejects.toThrow(/Failed to connect/);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // disconnect()
+  // -----------------------------------------------------------------------
+
+  describe("disconnect()", () => {
+    it("calls client.destroy()", async () => {
+      const adapter = new DiscordChannel(VALID_CONFIG);
+      await adapter.connect();
+      await adapter.disconnect();
+      expect(mockClient.destroy).toHaveBeenCalledOnce();
+    });
+
+    it("is idempotent — second call is a no-op", async () => {
+      const adapter = new DiscordChannel(VALID_CONFIG);
+      await adapter.connect();
+      await adapter.disconnect();
+      await adapter.disconnect();
+      expect(mockClient.destroy).toHaveBeenCalledOnce();
+    });
+
+    it("is safe to call before connect()", async () => {
+      const adapter = new DiscordChannel(VALID_CONFIG);
+      await adapter.disconnect(); // Should not throw
+      expect(mockClient.destroy).not.toHaveBeenCalled();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // send()
+  // -----------------------------------------------------------------------
+
+  describe("send()", () => {
+    it("throws ChannelSendError if not connected", async () => {
+      const adapter = new DiscordChannel(VALID_CONFIG);
+      const msg: OutboundMessage = {
+        channelId: "ch-001",
+        blocks: [{ type: "text", content: "hi" }],
+      };
+      await expect(adapter.send(msg)).rejects.toThrow(ChannelSendError);
+      await expect(adapter.send(msg)).rejects.toThrow(/not connected/i);
+    });
+
+    it("fetches channel and sends message when connected", async () => {
+      const adapter = new DiscordChannel(VALID_CONFIG);
+      await adapter.connect();
+
+      const msg: OutboundMessage = {
+        channelId: "ch-001",
+        blocks: [{ type: "text", content: "Hello" }],
+      };
+      await adapter.send(msg);
+
+      expect(mockClient.channels.fetch).toHaveBeenCalledWith("ch-001");
+    });
+
+    it("throws ChannelSendError for invalid channel", async () => {
+      mockClient.channels.fetch.mockResolvedValueOnce(null);
+      const adapter = new DiscordChannel(VALID_CONFIG);
+      await adapter.connect();
+
+      const msg: OutboundMessage = {
+        channelId: "invalid-ch",
+        blocks: [{ type: "text", content: "Hello" }],
+      };
+      await expect(adapter.send(msg)).rejects.toThrow(ChannelSendError);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // onMessage()
+  // -----------------------------------------------------------------------
+
+  describe("onMessage()", () => {
+    it("throws ChannelLoadError if client not initialized", () => {
+      const adapter = new DiscordChannel(VALID_CONFIG);
+      expect(() => adapter.onMessage(vi.fn())).toThrow(ChannelLoadError);
+    });
+
+    it("registers a messageCreate handler on the client", async () => {
+      const adapter = new DiscordChannel(VALID_CONFIG);
+      await adapter.connect();
+
+      const handler = vi.fn();
+      adapter.onMessage(handler);
+
+      expect(mockClient.on).toHaveBeenCalledWith("messageCreate", expect.any(Function));
+    });
+
+    it("registers a global error handler on the client", async () => {
+      const adapter = new DiscordChannel(VALID_CONFIG);
+      await adapter.connect();
+
+      adapter.onMessage(vi.fn());
+
+      expect(mockClient.on).toHaveBeenCalledWith("error", expect.any(Function));
+    });
+
+    it("global error handler logs without crashing", async () => {
+      const adapter = new DiscordChannel(VALID_CONFIG);
+      await adapter.connect();
+
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      adapter.onMessage(vi.fn());
+
+      const errorHandlers = mockClient.eventHandlers.get("error");
+      expect(errorHandlers).toBeDefined();
+
+      await errorHandlers?.[0]?.(new Error("Gateway disconnected"));
+
+      expect(consoleSpy).toHaveBeenCalled();
+      consoleSpy.mockRestore();
+    });
+
+    it("calls handler with normalized inbound message", async () => {
+      const adapter = new DiscordChannel(VALID_CONFIG);
+      await adapter.connect();
+
+      const handler = vi.fn();
+      adapter.onMessage(handler);
+
+      // Simulate incoming message through the registered handler
+      const messageCreateHandlers = mockClient.eventHandlers.get("messageCreate");
+      expect(messageCreateHandlers).toBeDefined();
+      expect(messageCreateHandlers?.length).toBeGreaterThan(0);
+
+      await messageCreateHandlers?.[0]?.({
+        id: "msg-001",
+        content: "Hello bot",
+        author: { id: "user-001", bot: false, username: "testuser" },
+        channelId: "ch-001",
+        channel: { id: "ch-001", type: 0, isThread: () => false },
+        attachments: new Map(),
+        embeds: [],
+        createdTimestamp: 1700000000000,
+        reference: null,
+      });
+
+      expect(handler).toHaveBeenCalledOnce();
+      const inbound = handler.mock.calls[0]?.[0];
+      expect(inbound.channelType).toBe("discord");
+      expect(inbound.channelId).toBe("ch-001");
+      expect(inbound.senderId).toBe("user-001");
+      expect(inbound.blocks[0]).toEqual({
+        type: "text",
+        content: "Hello bot",
+      });
+    });
+
+    it("filters bot messages", async () => {
+      const adapter = new DiscordChannel(VALID_CONFIG);
+      await adapter.connect();
+
+      const handler = vi.fn();
+      adapter.onMessage(handler);
+
+      const messageCreateHandlers = mockClient.eventHandlers.get("messageCreate");
+      await messageCreateHandlers?.[0]?.({
+        id: "msg-002",
+        content: "Bot reply",
+        author: { id: "bot-999", bot: true, username: "otherbot" },
+        channelId: "ch-001",
+        channel: { id: "ch-001", type: 0, isThread: () => false },
+        attachments: new Map(),
+        embeds: [],
+        createdTimestamp: 1700000000000,
+        reference: null,
+      });
+
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it("does not crash when handler throws", async () => {
+      const adapter = new DiscordChannel(VALID_CONFIG);
+      await adapter.connect();
+
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const handler = vi.fn().mockRejectedValue(new Error("handler error"));
+      adapter.onMessage(handler);
+
+      const messageCreateHandlers = mockClient.eventHandlers.get("messageCreate");
+      await messageCreateHandlers?.[0]?.({
+        id: "msg-003",
+        content: "trigger error",
+        author: { id: "user-001", bot: false, username: "testuser" },
+        channelId: "ch-001",
+        channel: { id: "ch-001", type: 0, isThread: () => false },
+        attachments: new Map(),
+        embeds: [],
+        createdTimestamp: 1700000000000,
+        reference: null,
+      });
+
+      expect(consoleSpy).toHaveBeenCalled();
+      consoleSpy.mockRestore();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Properties
+  // -----------------------------------------------------------------------
+
+  describe("properties", () => {
+    it("has name 'discord'", () => {
+      const adapter = new DiscordChannel(VALID_CONFIG);
+      expect(adapter.name).toBe("discord");
+    });
+
+    it("has DISCORD_CAPABILITIES as capabilities", () => {
+      const adapter = new DiscordChannel(VALID_CONFIG);
+      expect(adapter.capabilities).toBe(DISCORD_CAPABILITIES);
+    });
+
+    it("exposes getClient() that returns undefined before connect", () => {
+      const adapter = new DiscordChannel(VALID_CONFIG);
+      expect(adapter.getClient()).toBeUndefined();
+    });
+
+    it("exposes getClient() that returns Client after connect", async () => {
+      const adapter = new DiscordChannel(VALID_CONFIG);
+      await adapter.connect();
+      expect(adapter.getClient()).toBeDefined();
+    });
+  });
+});

--- a/packages/channel-discord/src/__tests__/unit/capabilities.test.ts
+++ b/packages/channel-discord/src/__tests__/unit/capabilities.test.ts
@@ -1,0 +1,78 @@
+import type { ChannelCapabilities } from "@templar/core";
+import { describe, expect, it } from "vitest";
+import { DISCORD_CAPABILITIES } from "../../capabilities.js";
+
+describe("DISCORD_CAPABILITIES", () => {
+  it("conforms to ChannelCapabilities type", () => {
+    const caps: ChannelCapabilities = DISCORD_CAPABILITIES;
+    expect(caps).toBeDefined();
+  });
+
+  it("supports text with 2000-char limit", () => {
+    expect(DISCORD_CAPABILITIES.text).toEqual({
+      supported: true,
+      maxLength: 2000,
+    });
+  });
+
+  it("supports richText with standard markdown formats", () => {
+    expect(DISCORD_CAPABILITIES.richText).toEqual({
+      supported: true,
+      formats: ["bold", "italic", "code", "link", "strikethrough", "blockquote"],
+    });
+  });
+
+  it("supports images up to 25MB", () => {
+    expect(DISCORD_CAPABILITIES.images).toEqual({
+      supported: true,
+      maxSize: 25_000_000,
+      formats: ["jpeg", "png", "gif", "webp"],
+    });
+  });
+
+  it("supports files up to 25MB", () => {
+    expect(DISCORD_CAPABILITIES.files).toEqual({
+      supported: true,
+      maxSize: 25_000_000,
+    });
+  });
+
+  it("supports buttons with 25-button max", () => {
+    expect(DISCORD_CAPABILITIES.buttons).toEqual({
+      supported: true,
+      maxButtons: 25,
+    });
+  });
+
+  it("supports non-nested threads", () => {
+    expect(DISCORD_CAPABILITIES.threads).toEqual({
+      supported: true,
+      nested: false,
+    });
+  });
+
+  it("supports reactions", () => {
+    expect(DISCORD_CAPABILITIES.reactions).toEqual({
+      supported: true,
+    });
+  });
+
+  it("supports groups with 500K member limit", () => {
+    expect(DISCORD_CAPABILITIES.groups).toEqual({
+      supported: true,
+      maxMembers: 500_000,
+    });
+  });
+
+  it("does not include typingIndicator", () => {
+    expect(DISCORD_CAPABILITIES.typingIndicator).toBeUndefined();
+  });
+
+  it("does not include voiceMessages", () => {
+    expect(DISCORD_CAPABILITIES.voiceMessages).toBeUndefined();
+  });
+
+  it("does not include readReceipts", () => {
+    expect(DISCORD_CAPABILITIES.readReceipts).toBeUndefined();
+  });
+});

--- a/packages/channel-discord/src/__tests__/unit/config.test.ts
+++ b/packages/channel-discord/src/__tests__/unit/config.test.ts
@@ -1,0 +1,134 @@
+import { ChannelLoadError } from "@templar/errors";
+import { describe, expect, it } from "vitest";
+import { DEFAULT_INTENTS, DEFAULT_SWEEPERS, parseDiscordConfig } from "../../config.js";
+
+describe("parseDiscordConfig", () => {
+  // -----------------------------------------------------------------------
+  // Valid configurations
+  // -----------------------------------------------------------------------
+
+  describe("valid configs", () => {
+    it("accepts token-only config and applies defaults", () => {
+      const config = parseDiscordConfig({ token: "Bot abc123" });
+
+      expect(config.token).toBe("Bot abc123");
+      expect(config.intents).toEqual(DEFAULT_INTENTS);
+      expect(config.sweepers).toEqual(DEFAULT_SWEEPERS);
+      expect(config.presence).toBeUndefined();
+    });
+
+    it("accepts config with custom intents", () => {
+      const config = parseDiscordConfig({
+        token: "Bot abc123",
+        intents: ["Guilds", "GuildMessages"],
+      });
+
+      expect(config.intents).toEqual(["Guilds", "GuildMessages"]);
+    });
+
+    it("accepts config with custom sweepers", () => {
+      const sweepers = {
+        messages: { interval: 1800, lifetime: 900 },
+      };
+      const config = parseDiscordConfig({
+        token: "Bot abc123",
+        sweepers,
+      });
+
+      expect(config.sweepers).toEqual(sweepers);
+    });
+
+    it("accepts config with presence", () => {
+      const config = parseDiscordConfig({
+        token: "Bot abc123",
+        presence: {
+          status: "online",
+          activities: [{ name: "Helping users", type: 0 }],
+        },
+      });
+
+      expect(config.presence).toEqual({
+        status: "online",
+        activities: [{ name: "Helping users", type: 0 }],
+      });
+    });
+
+    it("accepts full config with all fields", () => {
+      const config = parseDiscordConfig({
+        token: "Bot abc123",
+        intents: ["Guilds"],
+        sweepers: { messages: { interval: 600, lifetime: 300 } },
+        presence: { status: "dnd" },
+      });
+
+      expect(config.token).toBe("Bot abc123");
+      expect(config.intents).toEqual(["Guilds"]);
+      expect(config.sweepers).toEqual({ messages: { interval: 600, lifetime: 300 } });
+      expect(config.presence).toEqual({ status: "dnd" });
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Invalid configurations
+  // -----------------------------------------------------------------------
+
+  describe("invalid configs", () => {
+    it("throws ChannelLoadError for missing token", () => {
+      expect(() => parseDiscordConfig({})).toThrow(ChannelLoadError);
+    });
+
+    it("throws ChannelLoadError for empty token", () => {
+      expect(() => parseDiscordConfig({ token: "" })).toThrow(ChannelLoadError);
+    });
+
+    it("throws ChannelLoadError for non-string token", () => {
+      expect(() => parseDiscordConfig({ token: 12345 })).toThrow(ChannelLoadError);
+    });
+
+    it("throws ChannelLoadError for invalid intents type", () => {
+      expect(() => parseDiscordConfig({ token: "Bot abc", intents: "Guilds" })).toThrow(
+        ChannelLoadError,
+      );
+    });
+
+    it("throws ChannelLoadError for invalid intent name", () => {
+      expect(() => parseDiscordConfig({ token: "Bot abc", intents: ["InvalidIntent"] })).toThrow(
+        ChannelLoadError,
+      );
+    });
+
+    it("throws ChannelLoadError for invalid presence status", () => {
+      expect(() =>
+        parseDiscordConfig({ token: "Bot abc", presence: { status: "sleeping" } }),
+      ).toThrow(ChannelLoadError);
+    });
+
+    it("includes descriptive message in error", () => {
+      expect(() => parseDiscordConfig({})).toThrow(/token/i);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Defaults
+  // -----------------------------------------------------------------------
+
+  describe("defaults", () => {
+    it("DEFAULT_INTENTS includes Guilds, GuildMessages, MessageContent", () => {
+      expect(DEFAULT_INTENTS).toContain("Guilds");
+      expect(DEFAULT_INTENTS).toContain("GuildMessages");
+      expect(DEFAULT_INTENTS).toContain("MessageContent");
+    });
+
+    it("DEFAULT_SWEEPERS includes message sweeping config", () => {
+      expect(DEFAULT_SWEEPERS.messages).toBeDefined();
+      expect(DEFAULT_SWEEPERS.messages?.interval).toBeGreaterThan(0);
+      expect(DEFAULT_SWEEPERS.messages?.lifetime).toBeGreaterThan(0);
+    });
+
+    it("DEFAULT_SWEEPERS includes thread sweeping config", () => {
+      expect(DEFAULT_SWEEPERS.threads).toBeDefined();
+      expect(DEFAULT_SWEEPERS.threads?.interval).toBeGreaterThan(0);
+      expect(DEFAULT_SWEEPERS.threads?.lifetime).toBeGreaterThan(0);
+    });
+  });
+});

--- a/packages/channel-discord/src/__tests__/unit/normalizer.test.ts
+++ b/packages/channel-discord/src/__tests__/unit/normalizer.test.ts
@@ -1,0 +1,323 @@
+import { describe, expect, it, vi } from "vitest";
+import { normalizeMessage } from "../../normalizer.js";
+import { createMockMessage, type MockAttachment } from "../helpers/mock-discord.js";
+
+describe("normalizeMessage", () => {
+  // -----------------------------------------------------------------------
+  // Basic text messages
+  // -----------------------------------------------------------------------
+
+  describe("text messages", () => {
+    it("normalizes a simple text message", () => {
+      const msg = createMockMessage({ content: "Hello world" });
+      const result = normalizeMessage(msg as never);
+
+      expect(result).toBeDefined();
+      expect(result?.channelType).toBe("discord");
+      expect(result?.channelId).toBe("chan-001");
+      expect(result?.senderId).toBe("user-001");
+      expect(result?.messageId).toBe("msg-001");
+      expect(result?.blocks).toHaveLength(1);
+      expect(result?.blocks[0]).toEqual({ type: "text", content: "Hello world" });
+    });
+
+    it("normalizes empty content as empty blocks", () => {
+      const msg = createMockMessage({ content: "" });
+      const result = normalizeMessage(msg as never);
+
+      expect(result).toBeDefined();
+      expect(result?.blocks).toHaveLength(0);
+    });
+
+    it("preserves markdown in content", () => {
+      const msg = createMockMessage({ content: "**bold** and *italic*" });
+      const result = normalizeMessage(msg as never);
+
+      expect(result?.blocks[0]).toEqual({
+        type: "text",
+        content: "**bold** and *italic*",
+      });
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Attachments
+  // -----------------------------------------------------------------------
+
+  describe("attachments", () => {
+    it("normalizes image attachment as ImageBlock", () => {
+      const attachments = new Map<string, MockAttachment>();
+      attachments.set("att-001", {
+        id: "att-001",
+        name: "photo.png",
+        url: "https://cdn.discord.com/photo.png",
+        contentType: "image/png",
+        size: 1024,
+      });
+
+      const msg = createMockMessage({ attachments });
+      const result = normalizeMessage(msg as never);
+
+      expect(result?.blocks).toContainEqual({
+        type: "image",
+        url: "https://cdn.discord.com/photo.png",
+        alt: "photo.png",
+        size: 1024,
+      });
+    });
+
+    it("normalizes non-image attachment as FileBlock", () => {
+      const attachments = new Map<string, MockAttachment>();
+      attachments.set("att-001", {
+        id: "att-001",
+        name: "document.pdf",
+        url: "https://cdn.discord.com/document.pdf",
+        contentType: "application/pdf",
+        size: 5000,
+      });
+
+      const msg = createMockMessage({ attachments });
+      const result = normalizeMessage(msg as never);
+
+      expect(result?.blocks).toContainEqual({
+        type: "file",
+        url: "https://cdn.discord.com/document.pdf",
+        filename: "document.pdf",
+        mimeType: "application/pdf",
+        size: 5000,
+      });
+    });
+
+    it("handles attachment with null contentType as file", () => {
+      const attachments = new Map<string, MockAttachment>();
+      attachments.set("att-001", {
+        id: "att-001",
+        name: "data.bin",
+        url: "https://cdn.discord.com/data.bin",
+        contentType: null,
+        size: 100,
+      });
+
+      const msg = createMockMessage({ attachments });
+      const result = normalizeMessage(msg as never);
+
+      expect(result?.blocks).toContainEqual({
+        type: "file",
+        url: "https://cdn.discord.com/data.bin",
+        filename: "data.bin",
+        mimeType: "application/octet-stream",
+        size: 100,
+      });
+    });
+
+    it("normalizes gif attachment as ImageBlock", () => {
+      const attachments = new Map<string, MockAttachment>();
+      attachments.set("att-001", {
+        id: "att-001",
+        name: "funny.gif",
+        url: "https://cdn.discord.com/funny.gif",
+        contentType: "image/gif",
+        size: 2000,
+      });
+
+      const msg = createMockMessage({ attachments });
+      const result = normalizeMessage(msg as never);
+
+      expect(result?.blocks).toContainEqual({
+        type: "image",
+        url: "https://cdn.discord.com/funny.gif",
+        alt: "funny.gif",
+        size: 2000,
+      });
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Embeds
+  // -----------------------------------------------------------------------
+
+  describe("embeds", () => {
+    it("extracts embed description as TextBlock", () => {
+      const msg = createMockMessage({
+        embeds: [{ description: "Embed text here", fields: [] }],
+      });
+      const result = normalizeMessage(msg as never);
+
+      expect(result?.blocks).toContainEqual({
+        type: "text",
+        content: "Embed text here",
+      });
+    });
+
+    it("extracts embed fields as TextBlock", () => {
+      const msg = createMockMessage({
+        embeds: [
+          {
+            description: null,
+            fields: [
+              { name: "Status", value: "Active" },
+              { name: "Count", value: "42" },
+            ],
+          },
+        ],
+      });
+      const result = normalizeMessage(msg as never);
+
+      expect(result?.blocks).toContainEqual({
+        type: "text",
+        content: "Status: Active\nCount: 42",
+      });
+    });
+
+    it("skips embeds with no description and no fields", () => {
+      const msg = createMockMessage({
+        content: "",
+        embeds: [{ description: null, fields: [] }],
+      });
+      const result = normalizeMessage(msg as never);
+
+      expect(result?.blocks).toHaveLength(0);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Thread messages (edge case #4)
+  // -----------------------------------------------------------------------
+
+  describe("thread messages", () => {
+    it("includes threadId for messages in threads", () => {
+      const msg = createMockMessage({
+        channel: {
+          id: "thread-001",
+          type: 11, // PublicThread
+          isThread: () => true,
+          send: vi.fn(),
+        },
+        channelId: "thread-001",
+      });
+      const result = normalizeMessage(msg as never);
+
+      expect(result?.threadId).toBe("thread-001");
+    });
+
+    it("omits threadId for non-thread messages", () => {
+      const msg = createMockMessage();
+      const result = normalizeMessage(msg as never);
+
+      expect(result?.threadId).toBeUndefined();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // DM messages (edge case #5)
+  // -----------------------------------------------------------------------
+
+  describe("DM messages", () => {
+    it("normalizes DM message correctly", () => {
+      const msg = createMockMessage({
+        channel: {
+          id: "dm-001",
+          type: 1, // DM
+          isThread: () => false,
+          send: vi.fn(),
+        },
+        channelId: "dm-001",
+        guildId: null,
+      });
+      const result = normalizeMessage(msg as never);
+
+      expect(result?.channelId).toBe("dm-001");
+      expect(result?.channelType).toBe("discord");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Bot messages filtered (edge case #6)
+  // -----------------------------------------------------------------------
+
+  describe("bot message filtering", () => {
+    it("returns undefined for bot messages", () => {
+      const msg = createMockMessage({
+        author: { id: "bot-999", bot: true, username: "otherbot" },
+      });
+      const result = normalizeMessage(msg as never);
+
+      expect(result).toBeUndefined();
+    });
+
+    it("does not filter non-bot messages", () => {
+      const msg = createMockMessage({
+        author: { id: "user-001", bot: false, username: "human" },
+      });
+      const result = normalizeMessage(msg as never);
+
+      expect(result).toBeDefined();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Partial messages (edge case #8)
+  // -----------------------------------------------------------------------
+
+  describe("partial messages", () => {
+    it("handles null/undefined content gracefully", () => {
+      const msg = createMockMessage({ content: undefined as unknown as string });
+      const result = normalizeMessage(msg as never);
+
+      expect(result).toBeDefined();
+      expect(result?.blocks).toHaveLength(0);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Combined messages
+  // -----------------------------------------------------------------------
+
+  describe("combined content", () => {
+    it("includes text + attachments in correct order", () => {
+      const attachments = new Map<string, MockAttachment>();
+      attachments.set("att-001", {
+        id: "att-001",
+        name: "image.png",
+        url: "https://cdn.discord.com/image.png",
+        contentType: "image/png",
+        size: 512,
+      });
+
+      const msg = createMockMessage({
+        content: "Check this out",
+        attachments,
+      });
+      const result = normalizeMessage(msg as never);
+
+      expect(result?.blocks).toHaveLength(2);
+      expect(result?.blocks[0]).toEqual({ type: "text", content: "Check this out" });
+      expect(result?.blocks[1]).toEqual({
+        type: "image",
+        url: "https://cdn.discord.com/image.png",
+        alt: "image.png",
+        size: 512,
+      });
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Metadata
+  // -----------------------------------------------------------------------
+
+  describe("metadata", () => {
+    it("includes timestamp from createdTimestamp", () => {
+      const msg = createMockMessage({ createdTimestamp: 1700000000000 });
+      const result = normalizeMessage(msg as never);
+
+      expect(result?.timestamp).toBe(1700000000000);
+    });
+
+    it("includes raw message as escape hatch", () => {
+      const msg = createMockMessage();
+      const result = normalizeMessage(msg as never);
+
+      expect(result?.raw).toBe(msg);
+    });
+  });
+});

--- a/packages/channel-discord/src/__tests__/unit/renderer.test.ts
+++ b/packages/channel-discord/src/__tests__/unit/renderer.test.ts
@@ -1,0 +1,371 @@
+import type { OutboundMessage } from "@templar/core";
+import { ChannelSendError } from "@templar/errors";
+import { describe, expect, it, vi } from "vitest";
+import { buildRenderPlan, type DiscordSendable, renderMessage } from "../../renderer.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createMockSendable(): {
+  sendable: DiscordSendable;
+  calls: Record<string, unknown>[];
+} {
+  const calls: Record<string, unknown>[] = [];
+  const sendable: DiscordSendable = {
+    send: vi.fn(async (payload: Record<string, unknown>) => {
+      calls.push(payload);
+      return { id: "sent-001" };
+    }),
+  };
+  return { sendable, calls };
+}
+
+// ---------------------------------------------------------------------------
+// buildRenderPlan
+// ---------------------------------------------------------------------------
+
+describe("buildRenderPlan", () => {
+  it("returns empty plan for empty blocks", () => {
+    const msg: OutboundMessage = { channelId: "ch-001", blocks: [] };
+    const plan = buildRenderPlan(msg);
+    expect(plan).toHaveLength(0);
+  });
+
+  it("builds a single text message call", () => {
+    const msg: OutboundMessage = {
+      channelId: "ch-001",
+      blocks: [{ type: "text", content: "Hello" }],
+    };
+    const plan = buildRenderPlan(msg);
+
+    expect(plan).toHaveLength(1);
+    expect(plan[0]?.content).toBe("Hello");
+    expect(plan[0]?.files).toHaveLength(0);
+    expect(plan[0]?.components).toHaveLength(0);
+  });
+
+  it("builds a single image-only call", () => {
+    const msg: OutboundMessage = {
+      channelId: "ch-001",
+      blocks: [{ type: "image", url: "https://example.com/img.png", alt: "test" }],
+    };
+    const plan = buildRenderPlan(msg);
+
+    expect(plan).toHaveLength(1);
+    expect(plan[0]?.content).toBe("");
+    expect(plan[0]?.files).toHaveLength(1);
+    expect(plan[0]?.files[0]?.url).toBe("https://example.com/img.png");
+  });
+
+  it("builds a single file-only call", () => {
+    const msg: OutboundMessage = {
+      channelId: "ch-001",
+      blocks: [
+        {
+          type: "file",
+          url: "https://example.com/doc.pdf",
+          filename: "doc.pdf",
+          mimeType: "application/pdf",
+        },
+      ],
+    };
+    const plan = buildRenderPlan(msg);
+
+    expect(plan).toHaveLength(1);
+    expect(plan[0]?.files).toHaveLength(1);
+    expect(plan[0]?.files[0]?.filename).toBe("doc.pdf");
+  });
+
+  it("builds a single button-only call with components", () => {
+    const msg: OutboundMessage = {
+      channelId: "ch-001",
+      blocks: [
+        {
+          type: "button",
+          buttons: [
+            { label: "Yes", action: "confirm", style: "primary" },
+            { label: "No", action: "cancel", style: "danger" },
+          ],
+        },
+      ],
+    };
+    const plan = buildRenderPlan(msg);
+
+    expect(plan).toHaveLength(1);
+    expect(plan[0]?.components).toHaveLength(1); // 1 ActionRow
+  });
+
+  it("batches text + image + buttons into a single call", () => {
+    const msg: OutboundMessage = {
+      channelId: "ch-001",
+      blocks: [
+        { type: "text", content: "Check this out" },
+        { type: "image", url: "https://example.com/img.png" },
+        {
+          type: "button",
+          buttons: [{ label: "Like", action: "like" }],
+        },
+      ],
+    };
+    const plan = buildRenderPlan(msg);
+
+    expect(plan).toHaveLength(1);
+    expect(plan[0]?.content).toBe("Check this out");
+    expect(plan[0]?.files).toHaveLength(1);
+    expect(plan[0]?.components).toHaveLength(1);
+  });
+
+  it("coalesces adjacent text blocks", () => {
+    const msg: OutboundMessage = {
+      channelId: "ch-001",
+      blocks: [
+        { type: "text", content: "Hello" },
+        { type: "text", content: "World" },
+      ],
+    };
+    const plan = buildRenderPlan(msg);
+
+    expect(plan).toHaveLength(1);
+    expect(plan[0]?.content).toBe("Hello\nWorld");
+  });
+
+  // -----------------------------------------------------------------------
+  // Auto-split at 2000 chars
+  // -----------------------------------------------------------------------
+
+  describe("auto-split at 2000 chars", () => {
+    it("splits text exceeding 2000 chars into multiple calls", () => {
+      const longText = "a".repeat(4500);
+      const msg: OutboundMessage = {
+        channelId: "ch-001",
+        blocks: [{ type: "text", content: longText }],
+      };
+      const plan = buildRenderPlan(msg);
+
+      expect(plan.length).toBeGreaterThan(1);
+      // All chunks should be ≤ 2000 chars
+      for (const call of plan) {
+        expect(call.content.length).toBeLessThanOrEqual(2000);
+      }
+      // Total content should be preserved
+      const totalContent = plan.map((c) => c.content).join("");
+      expect(totalContent).toBe(longText);
+    });
+
+    it("attaches files and components only to the last chunk", () => {
+      const longText = "b".repeat(3000);
+      const msg: OutboundMessage = {
+        channelId: "ch-001",
+        blocks: [
+          { type: "text", content: longText },
+          { type: "image", url: "https://example.com/img.png" },
+          { type: "button", buttons: [{ label: "OK", action: "ok" }] },
+        ],
+      };
+      const plan = buildRenderPlan(msg);
+
+      expect(plan.length).toBeGreaterThan(1);
+
+      // First N-1 calls: text only, no files or components
+      for (let i = 0; i < plan.length - 1; i++) {
+        expect(plan[i]?.files).toHaveLength(0);
+        expect(plan[i]?.components).toHaveLength(0);
+      }
+
+      // Last call: has text + files + components
+      const lastCall = plan.at(-1);
+      expect(lastCall?.files).toHaveLength(1);
+      expect(lastCall?.components).toHaveLength(1);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Thread support
+  // -----------------------------------------------------------------------
+
+  describe("thread support", () => {
+    it("includes threadId in plan calls", () => {
+      const msg: OutboundMessage = {
+        channelId: "ch-001",
+        threadId: "thread-001",
+        blocks: [{ type: "text", content: "In a thread" }],
+      };
+      const plan = buildRenderPlan(msg);
+
+      expect(plan[0]?.threadId).toBe("thread-001");
+    });
+
+    it("omits threadId when not set", () => {
+      const msg: OutboundMessage = {
+        channelId: "ch-001",
+        blocks: [{ type: "text", content: "Not in a thread" }],
+      };
+      const plan = buildRenderPlan(msg);
+
+      expect(plan[0]?.threadId).toBeUndefined();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Multiple files
+  // -----------------------------------------------------------------------
+
+  it("collects multiple files into a single call", () => {
+    const msg: OutboundMessage = {
+      channelId: "ch-001",
+      blocks: [
+        {
+          type: "file",
+          url: "https://example.com/a.pdf",
+          filename: "a.pdf",
+          mimeType: "application/pdf",
+        },
+        {
+          type: "file",
+          url: "https://example.com/b.txt",
+          filename: "b.txt",
+          mimeType: "text/plain",
+        },
+      ],
+    };
+    const plan = buildRenderPlan(msg);
+
+    expect(plan).toHaveLength(1);
+    expect(plan[0]?.files).toHaveLength(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// renderMessage
+// ---------------------------------------------------------------------------
+
+describe("renderMessage", () => {
+  it("sends a simple text message", async () => {
+    const { sendable, calls } = createMockSendable();
+    const msg: OutboundMessage = {
+      channelId: "ch-001",
+      blocks: [{ type: "text", content: "Hello" }],
+    };
+
+    await renderMessage(msg, sendable);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toHaveProperty("content", "Hello");
+  });
+
+  it("sends batched message with content + files + components", async () => {
+    const { sendable, calls } = createMockSendable();
+    const msg: OutboundMessage = {
+      channelId: "ch-001",
+      blocks: [
+        { type: "text", content: "Look at this" },
+        { type: "image", url: "https://example.com/img.png" },
+        { type: "button", buttons: [{ label: "OK", action: "ok" }] },
+      ],
+    };
+
+    await renderMessage(msg, sendable);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toHaveProperty("content", "Look at this");
+    expect((calls[0] as Record<string, unknown[]>).files).toHaveLength(1);
+    expect((calls[0] as Record<string, unknown[]>).components).toHaveLength(1);
+  });
+
+  it("sends multiple calls for split text", async () => {
+    const { sendable, calls } = createMockSendable();
+    const longText = "c".repeat(4500);
+    const msg: OutboundMessage = {
+      channelId: "ch-001",
+      blocks: [{ type: "text", content: longText }],
+    };
+
+    await renderMessage(msg, sendable);
+
+    expect(calls.length).toBeGreaterThan(1);
+  });
+
+  // -----------------------------------------------------------------------
+  // Error handling (Decision 6A)
+  // -----------------------------------------------------------------------
+
+  describe("error handling", () => {
+    it("throws ChannelSendError on send failure", async () => {
+      const sendable: DiscordSendable = {
+        send: vi.fn().mockRejectedValue(new Error("Network error")),
+      };
+      const msg: OutboundMessage = {
+        channelId: "ch-001",
+        blocks: [{ type: "text", content: "Hello" }],
+      };
+
+      await expect(renderMessage(msg, sendable)).rejects.toThrow(ChannelSendError);
+    });
+
+    it("includes descriptive message for permission errors (50013)", async () => {
+      const discordError = new Error("Missing Permissions");
+      (discordError as unknown as Record<string, unknown>).code = 50013;
+      const sendable: DiscordSendable = {
+        send: vi.fn().mockRejectedValue(discordError),
+      };
+      const msg: OutboundMessage = {
+        channelId: "ch-001",
+        blocks: [{ type: "text", content: "Hello" }],
+      };
+
+      await expect(renderMessage(msg, sendable)).rejects.toThrow(/permission/i);
+    });
+
+    it("includes descriptive message for missing access errors (50001)", async () => {
+      const discordError = new Error("Missing Access");
+      (discordError as unknown as Record<string, unknown>).code = 50001;
+      const sendable: DiscordSendable = {
+        send: vi.fn().mockRejectedValue(discordError),
+      };
+      const msg: OutboundMessage = {
+        channelId: "ch-001",
+        blocks: [{ type: "text", content: "Hello" }],
+      };
+
+      await expect(renderMessage(msg, sendable)).rejects.toThrow(/access/i);
+    });
+
+    it("preserves original error as cause", async () => {
+      const originalError = new Error("Discord API error");
+      const sendable: DiscordSendable = {
+        send: vi.fn().mockRejectedValue(originalError),
+      };
+      const msg: OutboundMessage = {
+        channelId: "ch-001",
+        blocks: [{ type: "text", content: "Hello" }],
+      };
+
+      try {
+        await renderMessage(msg, sendable);
+        expect.unreachable("Should have thrown");
+      } catch (err) {
+        expect(err).toBeInstanceOf(ChannelSendError);
+        expect((err as ChannelSendError).cause).toBe(originalError);
+      }
+    });
+
+    it("re-throws ChannelSendError without re-wrapping", async () => {
+      const sendError = new ChannelSendError("discord", "Already wrapped");
+      const sendable: DiscordSendable = {
+        send: vi.fn().mockRejectedValue(sendError),
+      };
+      const msg: OutboundMessage = {
+        channelId: "ch-001",
+        blocks: [{ type: "text", content: "Hello" }],
+      };
+
+      try {
+        await renderMessage(msg, sendable);
+        expect.unreachable("Should have thrown");
+      } catch (err) {
+        expect(err).toBe(sendError);
+      }
+    });
+  });
+});

--- a/packages/channel-discord/src/adapter.ts
+++ b/packages/channel-discord/src/adapter.ts
@@ -1,0 +1,214 @@
+import type {
+  ChannelAdapter,
+  ChannelCapabilities,
+  MessageHandler,
+  OutboundMessage,
+} from "@templar/core";
+import { ChannelLoadError, ChannelSendError } from "@templar/errors";
+
+import { DISCORD_CAPABILITIES } from "./capabilities.js";
+import { type DiscordConfig, type IntentName, parseDiscordConfig } from "./config.js";
+import { normalizeMessage } from "./normalizer.js";
+import { type DiscordSendable, renderMessage } from "./renderer.js";
+
+// ---------------------------------------------------------------------------
+// Minimal discord.js types (avoid hard coupling to discord.js imports)
+// ---------------------------------------------------------------------------
+
+interface DiscordClient {
+  login(token: string): Promise<string>;
+  destroy(): void;
+  on(event: string, handler: (...args: never[]) => void): void;
+  channels: {
+    fetch(id: string): Promise<DiscordSendable | null>;
+  };
+  user: { id: string } | null;
+}
+
+type DiscordClientConstructor = new (opts: Record<string, unknown>) => DiscordClient;
+
+// ---------------------------------------------------------------------------
+// Intent name → GatewayIntentBits resolution
+// ---------------------------------------------------------------------------
+
+async function resolveIntents(names: readonly IntentName[]): Promise<number[]> {
+  const { GatewayIntentBits } = await import("discord.js");
+  return names.map((name) => {
+    const value = GatewayIntentBits[name as keyof typeof GatewayIntentBits];
+    if (value === undefined) {
+      throw new ChannelLoadError("discord", `Unknown intent: ${name}`);
+    }
+    return value as number;
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Lazy loader (Decision 15A)
+// ---------------------------------------------------------------------------
+
+/**
+ * Lazily load the Discord Client class to keep it as a runtime-only dependency.
+ */
+async function loadDiscordClient(): Promise<DiscordClientConstructor> {
+  try {
+    const mod = await import("discord.js");
+    return mod.Client as unknown as DiscordClientConstructor;
+  } catch (error) {
+    throw new ChannelLoadError(
+      "discord",
+      `Failed to load discord.js: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Sweeper config builder
+// ---------------------------------------------------------------------------
+
+function buildSweeperOptions(
+  config: DiscordConfig["sweepers"],
+): Record<string, unknown> | undefined {
+  if (!config.messages && !config.threads && !config.users) return undefined;
+
+  const sweepers: Record<string, unknown> = {};
+
+  if (config.messages) {
+    sweepers.messages = {
+      interval: config.messages.interval,
+      lifetime: config.messages.lifetime,
+    };
+  }
+
+  if (config.threads) {
+    sweepers.threads = {
+      interval: config.threads.interval,
+      lifetime: config.threads.lifetime,
+    };
+  }
+
+  if (config.users) {
+    sweepers.users = {
+      interval: config.users.interval,
+      filter:
+        () => (user: { bot: boolean; id: string }, _: unknown, client: { user?: { id: string } }) =>
+          user.bot && user.id !== client.user?.id,
+    };
+  }
+
+  return sweepers;
+}
+
+// ---------------------------------------------------------------------------
+// DiscordChannel adapter
+// ---------------------------------------------------------------------------
+
+/**
+ * Discord channel adapter using discord.js v14.
+ *
+ * Implements the ChannelAdapter interface with:
+ * - Config-driven Gateway connection with tiered defaults
+ * - Lazy-loaded discord.js Client
+ * - Production-safe sweeper defaults for memory management
+ * - Batched message rendering (content + files + components)
+ * - Explicit error handling for common Discord failures
+ */
+export class DiscordChannel implements ChannelAdapter {
+  readonly name = "discord" as const;
+  readonly capabilities: ChannelCapabilities = DISCORD_CAPABILITIES;
+
+  private readonly config: DiscordConfig;
+  private client: DiscordClient | undefined;
+  private connected = false;
+
+  constructor(rawConfig: Readonly<Record<string, unknown>>) {
+    this.config = parseDiscordConfig(rawConfig);
+  }
+
+  async connect(): Promise<void> {
+    if (this.connected) return;
+
+    try {
+      const ClientClass = await loadDiscordClient();
+      const intents = await resolveIntents(this.config.intents);
+      const sweepers = buildSweeperOptions(this.config.sweepers);
+
+      this.client = new ClientClass({
+        intents,
+        ...(sweepers ? { sweepers } : {}),
+        ...(this.config.presence ? { presence: this.config.presence } : {}),
+      });
+
+      await this.client.login(this.config.token);
+      this.connected = true;
+    } catch (error) {
+      if (error instanceof ChannelLoadError) throw error;
+      throw new ChannelLoadError(
+        "discord",
+        `Failed to connect: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  async disconnect(): Promise<void> {
+    if (!this.connected || !this.client) return;
+
+    this.client.destroy();
+    this.client = undefined;
+    this.connected = false;
+  }
+
+  async send(message: OutboundMessage): Promise<void> {
+    if (!this.connected || !this.client) {
+      throw new ChannelSendError(
+        "discord",
+        "Cannot send message: adapter not connected. Call connect() first.",
+      );
+    }
+
+    const channel = await this.client.channels.fetch(message.channelId);
+    if (!channel) {
+      throw new ChannelSendError(
+        "discord",
+        `Channel ${message.channelId} not found or not accessible.`,
+      );
+    }
+
+    await renderMessage(message, channel);
+  }
+
+  onMessage(handler: MessageHandler): void {
+    if (!this.client) {
+      throw new ChannelLoadError("discord", "Cannot register handler: call connect() first.");
+    }
+
+    this.client.on("messageCreate", async (msg: never) => {
+      try {
+        const inbound = normalizeMessage(msg);
+        if (inbound) {
+          await handler(inbound);
+        }
+      } catch (error) {
+        console.error(
+          "[DiscordChannel] Error handling message:",
+          error instanceof Error ? error.message : String(error),
+        );
+      }
+    });
+
+    this.client.on("error", (error: never) => {
+      console.error(
+        "[DiscordChannel] Client error:",
+        (error as unknown as Error).message ?? String(error),
+      );
+    });
+  }
+
+  /**
+   * Get the underlying discord.js Client instance.
+   * Useful for registering slash commands, interaction handlers,
+   * or accessing advanced Discord features beyond the adapter interface.
+   */
+  getClient(): DiscordClient | undefined {
+    return this.client;
+  }
+}

--- a/packages/channel-discord/src/capabilities.ts
+++ b/packages/channel-discord/src/capabilities.ts
@@ -1,0 +1,28 @@
+import type { ChannelCapabilities } from "@templar/core";
+
+/**
+ * Static capability declaration for Discord via discord.js.
+ *
+ * Scope: text (2K), richText, images (25MB), files (25MB),
+ * buttons (25), threads (non-nested), reactions, groups (500K).
+ *
+ * No typingIndicator, voiceMessages, or readReceipts — out of scope
+ * for the base channel adapter (voice is @templar/channel-voice).
+ */
+export const DISCORD_CAPABILITIES: ChannelCapabilities = {
+  text: { supported: true, maxLength: 2000 },
+  richText: {
+    supported: true,
+    formats: ["bold", "italic", "code", "link", "strikethrough", "blockquote"],
+  },
+  images: {
+    supported: true,
+    maxSize: 25_000_000,
+    formats: ["jpeg", "png", "gif", "webp"],
+  },
+  files: { supported: true, maxSize: 25_000_000 },
+  buttons: { supported: true, maxButtons: 25 },
+  threads: { supported: true, nested: false },
+  reactions: { supported: true },
+  groups: { supported: true, maxMembers: 500_000 },
+} as const;

--- a/packages/channel-discord/src/config.ts
+++ b/packages/channel-discord/src/config.ts
@@ -1,0 +1,170 @@
+import { ChannelLoadError } from "@templar/errors";
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// Intent names (string-based to avoid importing discord.js at config time)
+// ---------------------------------------------------------------------------
+
+const VALID_INTENTS = [
+  "Guilds",
+  "GuildMembers",
+  "GuildModeration",
+  "GuildEmojisAndStickers",
+  "GuildIntegrations",
+  "GuildWebhooks",
+  "GuildInvites",
+  "GuildVoiceStates",
+  "GuildPresences",
+  "GuildMessages",
+  "GuildMessageReactions",
+  "GuildMessageTyping",
+  "DirectMessages",
+  "DirectMessageReactions",
+  "DirectMessageTyping",
+  "MessageContent",
+  "GuildScheduledEvents",
+  "AutoModerationConfiguration",
+  "AutoModerationExecution",
+] as const;
+
+export type IntentName = (typeof VALID_INTENTS)[number];
+
+const IntentNameSchema = z.enum(VALID_INTENTS);
+
+// ---------------------------------------------------------------------------
+// Sweeper timing
+// ---------------------------------------------------------------------------
+
+const SweeperTimingSchema = z.object({
+  interval: z.number().int().positive(),
+  lifetime: z.number().int().positive(),
+});
+
+// ---------------------------------------------------------------------------
+// Config types — hand-written to satisfy exactOptionalPropertyTypes
+// ---------------------------------------------------------------------------
+
+export interface SweeperTiming {
+  readonly interval: number;
+  readonly lifetime: number;
+}
+
+export interface SweepersConfig {
+  readonly messages: SweeperTiming | undefined;
+  readonly users: { readonly interval: number } | undefined;
+  readonly threads: SweeperTiming | undefined;
+}
+
+export interface PresenceActivity {
+  readonly name: string;
+  readonly type: number | undefined;
+}
+
+export interface PresenceConfig {
+  readonly status: "online" | "idle" | "dnd" | "invisible" | undefined;
+  readonly activities: readonly PresenceActivity[] | undefined;
+}
+
+export interface DiscordConfig {
+  readonly token: string;
+  readonly intents: readonly IntentName[];
+  readonly sweepers: SweepersConfig;
+  readonly presence: PresenceConfig | undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Defaults
+// ---------------------------------------------------------------------------
+
+export const DEFAULT_INTENTS: readonly IntentName[] = [
+  "Guilds",
+  "GuildMessages",
+  "MessageContent",
+] as const;
+
+export const DEFAULT_SWEEPERS: SweepersConfig = {
+  messages: { interval: 3600, lifetime: 1800 },
+  users: undefined,
+  threads: { interval: 3600, lifetime: 1800 },
+} as const;
+
+// ---------------------------------------------------------------------------
+// Full config schema
+// ---------------------------------------------------------------------------
+
+const SweepersConfigSchema = z
+  .object({
+    messages: SweeperTimingSchema.optional(),
+    users: z.object({ interval: z.number().int().positive() }).optional(),
+    threads: SweeperTimingSchema.optional(),
+  })
+  .optional();
+
+const PresenceConfigSchema = z
+  .object({
+    status: z.enum(["online", "idle", "dnd", "invisible"]).optional(),
+    activities: z
+      .array(
+        z.object({
+          name: z.string().min(1),
+          type: z.number().int().min(0).max(5).optional(),
+        }),
+      )
+      .optional(),
+  })
+  .optional();
+
+const DiscordConfigSchema = z.object({
+  token: z.string().min(1, "Bot token is required"),
+  intents: z.array(IntentNameSchema).optional(),
+  sweepers: SweepersConfigSchema,
+  presence: PresenceConfigSchema,
+});
+
+// ---------------------------------------------------------------------------
+// Parser
+// ---------------------------------------------------------------------------
+
+function toSweepersConfig(raw: unknown): SweepersConfig {
+  if (!raw || typeof raw !== "object") return DEFAULT_SWEEPERS;
+  const obj = raw as Record<string, unknown>;
+  return {
+    messages: (obj.messages as SweeperTiming | undefined) ?? undefined,
+    users: (obj.users as { readonly interval: number } | undefined) ?? undefined,
+    threads: (obj.threads as SweeperTiming | undefined) ?? undefined,
+  };
+}
+
+function toPresenceConfig(raw: unknown): PresenceConfig | undefined {
+  if (!raw || typeof raw !== "object") return undefined;
+  const obj = raw as Record<string, unknown>;
+  const status = (obj.status as PresenceConfig["status"]) ?? undefined;
+  const rawActivities = obj.activities as { name: string; type?: number }[] | undefined;
+  const activities = rawActivities?.map((a) => ({
+    name: a.name,
+    type: a.type ?? (undefined as number | undefined),
+  }));
+  return { status, activities };
+}
+
+/**
+ * Parse and validate raw config into a typed DiscordConfig.
+ * Applies production-safe defaults for intents and sweepers.
+ * Throws ChannelLoadError on validation failure.
+ */
+export function parseDiscordConfig(raw: Readonly<Record<string, unknown>>): DiscordConfig {
+  const result = DiscordConfigSchema.safeParse(raw);
+  if (!result.success) {
+    const issues = result.error.issues.map((i) => `${i.path.join(".")}: ${i.message}`).join("; ");
+    throw new ChannelLoadError("discord", `Invalid config: ${issues}`);
+  }
+
+  const parsed = result.data;
+
+  return {
+    token: parsed.token,
+    intents: parsed.intents ?? DEFAULT_INTENTS,
+    sweepers: toSweepersConfig(parsed.sweepers),
+    presence: toPresenceConfig(parsed.presence),
+  };
+}

--- a/packages/channel-discord/src/index.ts
+++ b/packages/channel-discord/src/index.ts
@@ -1,0 +1,3 @@
+export { DiscordChannel, DiscordChannel as default } from "./adapter.js";
+export { DISCORD_CAPABILITIES } from "./capabilities.js";
+export type { DiscordConfig } from "./config.js";

--- a/packages/channel-discord/src/normalizer.ts
+++ b/packages/channel-discord/src/normalizer.ts
@@ -1,0 +1,148 @@
+import type { ContentBlock, FileBlock, ImageBlock, InboundMessage, TextBlock } from "@templar/core";
+
+// ---------------------------------------------------------------------------
+// Minimal Discord.js types (avoid hard coupling to discord.js at import time)
+// ---------------------------------------------------------------------------
+
+interface DiscordAttachment {
+  readonly id: string;
+  readonly name: string;
+  readonly url: string;
+  readonly contentType: string | null;
+  readonly size: number;
+}
+
+interface DiscordEmbed {
+  readonly description: string | null;
+  readonly fields: readonly { readonly name: string; readonly value: string }[];
+}
+
+interface DiscordChannel {
+  readonly id: string;
+  readonly type: number;
+  isThread(): boolean;
+}
+
+interface DiscordMessage {
+  readonly id: string;
+  readonly content: string | undefined;
+  readonly author: { readonly id: string; readonly bot: boolean };
+  readonly channelId: string;
+  readonly channel: DiscordChannel;
+  readonly attachments: ReadonlyMap<string, DiscordAttachment>;
+  readonly embeds: readonly DiscordEmbed[];
+  readonly createdTimestamp: number;
+}
+
+// ---------------------------------------------------------------------------
+// Content type detection
+// ---------------------------------------------------------------------------
+
+const IMAGE_CONTENT_TYPES = new Set([
+  "image/png",
+  "image/jpeg",
+  "image/gif",
+  "image/webp",
+  "image/avif",
+  "image/svg+xml",
+]);
+
+function isImageContentType(contentType: string | null): boolean {
+  if (!contentType) return false;
+  return IMAGE_CONTENT_TYPES.has(contentType);
+}
+
+// ---------------------------------------------------------------------------
+// Block extractors
+// ---------------------------------------------------------------------------
+
+function extractText(msg: DiscordMessage): TextBlock | undefined {
+  if (!msg.content || msg.content.length === 0) return undefined;
+  return { type: "text", content: msg.content };
+}
+
+function extractAttachments(msg: DiscordMessage): readonly (ImageBlock | FileBlock)[] {
+  const blocks: (ImageBlock | FileBlock)[] = [];
+
+  for (const [, att] of msg.attachments) {
+    if (isImageContentType(att.contentType)) {
+      blocks.push({
+        type: "image",
+        url: att.url,
+        alt: att.name,
+        ...(att.size > 0 ? { size: att.size } : {}),
+      });
+    } else {
+      blocks.push({
+        type: "file",
+        url: att.url,
+        filename: att.name,
+        mimeType: att.contentType ?? "application/octet-stream",
+        ...(att.size > 0 ? { size: att.size } : {}),
+      });
+    }
+  }
+
+  return blocks;
+}
+
+function extractEmbedText(msg: DiscordMessage): readonly TextBlock[] {
+  const blocks: TextBlock[] = [];
+
+  for (const embed of msg.embeds) {
+    const parts: string[] = [];
+
+    if (embed.description) {
+      parts.push(embed.description);
+    }
+
+    if (embed.fields.length > 0) {
+      const fieldText = embed.fields.map((f) => `${f.name}: ${f.value}`).join("\n");
+      parts.push(fieldText);
+    }
+
+    if (parts.length > 0) {
+      blocks.push({ type: "text", content: parts.join("\n") });
+    }
+  }
+
+  return blocks;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalize a Discord Message into an InboundMessage.
+ * Returns undefined for bot messages (prevents infinite loops).
+ */
+export function normalizeMessage(msg: DiscordMessage): InboundMessage | undefined {
+  // Edge case #6: filter bot messages
+  if (msg.author.bot) return undefined;
+
+  const blocks: ContentBlock[] = [];
+
+  const text = extractText(msg);
+  if (text) blocks.push(text);
+
+  const attachments = extractAttachments(msg);
+  blocks.push(...attachments);
+
+  const embedTexts = extractEmbedText(msg);
+  blocks.push(...embedTexts);
+
+  // Edge case #4: thread detection
+  const threadId = msg.channel.isThread() ? msg.channel.id : undefined;
+
+  return {
+    channelType: "discord",
+    channelId: msg.channelId,
+    senderId: msg.author.id,
+    blocks,
+    ...(threadId != null ? { threadId } : {}),
+    timestamp: msg.createdTimestamp,
+    messageId: msg.id,
+    raw: msg,
+  };
+}

--- a/packages/channel-discord/src/renderer.ts
+++ b/packages/channel-discord/src/renderer.ts
@@ -1,0 +1,244 @@
+import { coalesceBlocks, type OutboundMessage, splitText } from "@templar/core";
+import { ChannelSendError } from "@templar/errors";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const MAX_CONTENT_LENGTH = 2000;
+
+// ---------------------------------------------------------------------------
+// Minimal Discord.js types (avoid hard coupling at import time)
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal interface for anything that can send Discord messages.
+ * Satisfied by TextChannel, DMChannel, ThreadChannel, etc.
+ */
+export interface DiscordSendable {
+  send(options: Record<string, unknown>): Promise<unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// Render plan types
+// ---------------------------------------------------------------------------
+
+interface FileData {
+  readonly url: string;
+  readonly filename: string;
+}
+
+interface ActionRowData {
+  readonly type: 1; // ActionRow
+  readonly components: readonly ButtonData[];
+}
+
+interface ButtonData {
+  readonly type: 2; // Button
+  readonly style: number;
+  readonly label: string;
+  readonly custom_id: string;
+}
+
+export interface RenderPlanCall {
+  readonly content: string;
+  readonly files: readonly FileData[];
+  readonly components: readonly ActionRowData[];
+  readonly threadId?: string;
+  readonly replyTo?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Button style mapping
+// ---------------------------------------------------------------------------
+
+function mapButtonStyle(style?: "primary" | "secondary" | "danger"): number {
+  if (style === "primary") return 1;
+  if (style === "danger") return 4;
+  return 2; // Secondary (default)
+}
+
+// ---------------------------------------------------------------------------
+// Render plan builder
+// ---------------------------------------------------------------------------
+
+/**
+ * Build an ordered list of API calls from an OutboundMessage.
+ *
+ * Batching strategy (Decision 14A):
+ * 1. Coalesce all text blocks into a single content string
+ * 2. Collect all image/file blocks into a files array
+ * 3. Build all button blocks into ActionRow components
+ * 4. If content ≤ 2000 → single API call with content + files + components
+ * 5. If content > 2000 → split into chunks:
+ *    - Chunks 1..N-1: text-only calls
+ *    - Chunk N: text + files + components
+ */
+export function buildRenderPlan(message: OutboundMessage): readonly RenderPlanCall[] {
+  const { blocks, threadId, replyTo } = message;
+
+  if (blocks.length === 0) return [];
+
+  // --- Step 1: Coalesce adjacent text blocks ---
+  const coalesced = coalesceBlocks(blocks);
+
+  // --- Step 2: Collect text, files, and components ---
+  let combinedText = "";
+  const files: FileData[] = [];
+  const components: ActionRowData[] = [];
+
+  for (const block of coalesced) {
+    if (block.type === "text") {
+      if (combinedText.length > 0) {
+        combinedText += "\n";
+      }
+      combinedText += block.content;
+      continue;
+    }
+
+    if (block.type === "image") {
+      files.push({
+        url: block.url,
+        filename: block.alt ?? "image.png",
+      });
+      continue;
+    }
+
+    if (block.type === "file") {
+      files.push({
+        url: block.url,
+        filename: block.filename,
+      });
+      continue;
+    }
+
+    if (block.type === "button") {
+      const buttons: ButtonData[] = block.buttons.map((btn, idx) => ({
+        type: 2 as const,
+        style: mapButtonStyle(btn.style),
+        label: btn.label,
+        custom_id: `${btn.action}_${idx}`,
+      }));
+
+      // Discord allows max 5 buttons per ActionRow
+      for (let i = 0; i < buttons.length; i += 5) {
+        components.push({
+          type: 1 as const,
+          components: buttons.slice(i, i + 5),
+        });
+      }
+    }
+  }
+
+  // --- Step 3: Build plan ---
+  const base = {
+    ...(threadId != null ? { threadId } : {}),
+    ...(replyTo != null ? { replyTo } : {}),
+  };
+
+  // If content fits in a single message, batch everything
+  if (combinedText.length <= MAX_CONTENT_LENGTH) {
+    return [
+      {
+        content: combinedText,
+        files,
+        components,
+        ...base,
+      },
+    ];
+  }
+
+  // Content exceeds limit — split into chunks
+  const chunks = splitText(combinedText, MAX_CONTENT_LENGTH);
+  const plan: RenderPlanCall[] = [];
+
+  for (let i = 0; i < chunks.length; i++) {
+    const isLast = i === chunks.length - 1;
+    plan.push({
+      content: chunks[i] ?? "",
+      files: isLast ? files : [],
+      components: isLast ? components : [],
+      ...base,
+    });
+  }
+
+  return plan;
+}
+
+// ---------------------------------------------------------------------------
+// Discord error code handling (Decision 6A)
+// ---------------------------------------------------------------------------
+
+function mapDiscordError(error: unknown, channelId: string): ChannelSendError {
+  if (error instanceof ChannelSendError) return error;
+
+  const code = (error as Record<string, unknown> | null)?.code;
+  const message = error instanceof Error ? error.message : String(error);
+  const cause = error instanceof Error ? error : undefined;
+
+  if (code === 50013) {
+    return new ChannelSendError(
+      "discord",
+      `Bot lacks permission to send in channel ${channelId}. Check that the bot has SendMessages, AttachFiles, and EmbedLinks permissions.`,
+      { cause },
+    );
+  }
+
+  if (code === 50001) {
+    return new ChannelSendError(
+      "discord",
+      `Bot cannot access channel ${channelId}. Verify channel permissions or that the bot is in the guild.`,
+      { cause },
+    );
+  }
+
+  return new ChannelSendError("discord", `Failed to send message: ${message}`, { cause });
+}
+
+// ---------------------------------------------------------------------------
+// Execute render plan
+// ---------------------------------------------------------------------------
+
+/**
+ * Render an OutboundMessage by executing Discord API calls sequentially.
+ * Handles batched sends (content + files + components in one call).
+ */
+export async function renderMessage(
+  message: OutboundMessage,
+  sendable: DiscordSendable,
+): Promise<void> {
+  const plan = buildRenderPlan(message);
+
+  for (const call of plan) {
+    try {
+      const payload: Record<string, unknown> = {};
+
+      if (call.content.length > 0) {
+        payload.content = call.content;
+      }
+
+      if (call.files.length > 0) {
+        payload.files = call.files.map((f) => ({
+          attachment: f.url,
+          name: f.filename,
+        }));
+      }
+
+      if (call.components.length > 0) {
+        payload.components = call.components;
+      }
+
+      if (call.threadId != null) {
+        payload.threadId = call.threadId;
+      }
+
+      if (call.replyTo != null) {
+        payload.reply = { messageReference: call.replyTo };
+      }
+
+      await sendable.send(payload);
+    } catch (error) {
+      throw mapDiscordError(error, message.channelId);
+    }
+  }
+}

--- a/packages/channel-discord/tsconfig.json
+++ b/packages/channel-discord/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": ["node", "vitest/globals"]
+  },
+  "include": ["src/**/*"],
+  "references": [{ "path": "../core" }, { "path": "../errors" }]
+}

--- a/packages/channel-discord/tsup.config.ts
+++ b/packages/channel-discord/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: {
+    compilerOptions: {
+      composite: false,
+    },
+  },
+  clean: true,
+  treeshake: true,
+  target: "node22",
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,6 +49,25 @@ importers:
         specifier: ^25.2.2
         version: 25.2.2
 
+  packages/channel-discord:
+    dependencies:
+      discord.js:
+        specifier: ^14.18.0
+        version: 14.25.1
+      zod:
+        specifier: ^3.24.0
+        version: 3.25.76
+    devDependencies:
+      '@templar/core':
+        specifier: workspace:*
+        version: link:../core
+      '@templar/errors':
+        specifier: workspace:*
+        version: link:../errors
+      '@types/node':
+        specifier: ^25.2.2
+        version: 25.2.2
+
   packages/channel-slack:
     dependencies:
       '@slack/bolt':
@@ -384,6 +403,34 @@ packages:
 
   '@cfworker/json-schema@4.1.1':
     resolution: {integrity: sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==}
+
+  '@discordjs/builders@1.13.1':
+    resolution: {integrity: sha512-cOU0UDHc3lp/5nKByDxkmRiNZBpdp0kx55aarbiAfakfKJHlxv/yFW1zmIqCAmwH5CRlrH9iMFKJMpvW4DPB+w==}
+    engines: {node: '>=16.11.0'}
+
+  '@discordjs/collection@1.5.3':
+    resolution: {integrity: sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ==}
+    engines: {node: '>=16.11.0'}
+
+  '@discordjs/collection@2.1.1':
+    resolution: {integrity: sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==}
+    engines: {node: '>=18'}
+
+  '@discordjs/formatters@0.6.2':
+    resolution: {integrity: sha512-y4UPwWhH6vChKRkGdMB4odasUbHOUwy7KL+OVwF86PvT6QVOwElx+TiI1/6kcmcEe+g5YRXJFiXSXUdabqZOvQ==}
+    engines: {node: '>=16.11.0'}
+
+  '@discordjs/rest@2.6.0':
+    resolution: {integrity: sha512-RDYrhmpB7mTvmCKcpj+pc5k7POKszS4E2O9TYc+U+Y4iaCP+r910QdO43qmpOja8LRr1RJ0b3U+CqVsnPqzf4w==}
+    engines: {node: '>=18'}
+
+  '@discordjs/util@1.2.0':
+    resolution: {integrity: sha512-3LKP7F2+atl9vJFhaBjn4nOaSWahZ/yWjOvA4e5pnXkt2qyXRCHLxoBQy81GFtLGCq7K9lPm9R517M1U+/90Qg==}
+    engines: {node: '>=18'}
+
+  '@discordjs/ws@1.2.3':
+    resolution: {integrity: sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw==}
+    engines: {node: '>=16.11.0'}
 
   '@esbuild/aix-ppc64@0.27.3':
     resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
@@ -784,6 +831,18 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@sapphire/async-queue@1.5.5':
+    resolution: {integrity: sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg==}
+    engines: {node: '>=v14.0.0', npm: '>=7.0.0'}
+
+  '@sapphire/shapeshift@4.0.0':
+    resolution: {integrity: sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg==}
+    engines: {node: '>=v16'}
+
+  '@sapphire/snowflake@3.5.3':
+    resolution: {integrity: sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ==}
+    engines: {node: '>=v14.0.0', npm: '>=7.0.0'}
+
   '@slack/bolt@4.6.0':
     resolution: {integrity: sha512-xPgfUs2+OXSugz54Ky07pA890+Qydk22SYToi8uGpXeHSt1JWwFJkRyd/9Vlg5I1AdfdpGXExDpwnbuN9Q/2dQ==}
     engines: {node: '>=18', npm: '>=8.6.0'}
@@ -910,6 +969,10 @@ packages:
 
   '@vitest/utils@4.0.18':
     resolution: {integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==}
+
+  '@vladfrangu/async_event_emitter@2.4.7':
+    resolution: {integrity: sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g==}
+    engines: {node: '>=v14.0.0', npm: '>=7.0.0'}
 
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
@@ -1091,6 +1154,13 @@ packages:
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
+
+  discord-api-types@0.38.38:
+    resolution: {integrity: sha512-7qcM5IeZrfb+LXW07HvoI5L+j4PQeMZXEkSm1htHAHh4Y9JSMXBWjy/r7zmUCOj4F7zNjMcm7IMWr131MT2h0Q==}
+
+  discord.js@14.25.1:
+    resolution: {integrity: sha512-2l0gsPOLPs5t6GFZfQZKnL1OJNYFcuC/ETWsW4VtKVD/tg4ICa9x+jb9bkPffkMdRpRpuUaO/fKkHCBeiCKh8g==}
+    engines: {node: '>=18'}
 
   double-ended-queue@2.1.0-0:
     resolution: {integrity: sha512-+BNfZ+deCo8hMNpDqDnvT+c0XpJ5cUa6mqYq89bho2Ifze4URTqRkcwR399hWoTrTkbZ/XJYDgP6rc7pRgffEQ==}
@@ -1431,6 +1501,15 @@ packages:
 
   lodash.once@4.1.1:
     resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
+
+  lodash.snakecase@4.1.1:
+    resolution: {integrity: sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==}
+
+  lodash@4.17.23:
+    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
+
+  magic-bytes.js@1.13.0:
+    resolution: {integrity: sha512-afO2mnxW7GDTXMm5/AoN1WuOcdoKhtgXjIvHmobqTD1grNplhGdv3PFOyjCVmrnOZBIT/gD/koDKpYG+0mvHcg==}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -1796,6 +1875,9 @@ packages:
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
+  ts-mixer@6.0.4:
+    resolution: {integrity: sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -1873,6 +1955,10 @@ packages:
 
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
+  undici@6.21.3:
+    resolution: {integrity: sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==}
+    engines: {node: '>=18.17'}
 
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
@@ -2082,6 +2168,55 @@ snapshots:
   '@bufbuild/protobuf@2.11.0': {}
 
   '@cfworker/json-schema@4.1.1': {}
+
+  '@discordjs/builders@1.13.1':
+    dependencies:
+      '@discordjs/formatters': 0.6.2
+      '@discordjs/util': 1.2.0
+      '@sapphire/shapeshift': 4.0.0
+      discord-api-types: 0.38.38
+      fast-deep-equal: 3.1.3
+      ts-mixer: 6.0.4
+      tslib: 2.8.1
+
+  '@discordjs/collection@1.5.3': {}
+
+  '@discordjs/collection@2.1.1': {}
+
+  '@discordjs/formatters@0.6.2':
+    dependencies:
+      discord-api-types: 0.38.38
+
+  '@discordjs/rest@2.6.0':
+    dependencies:
+      '@discordjs/collection': 2.1.1
+      '@discordjs/util': 1.2.0
+      '@sapphire/async-queue': 1.5.5
+      '@sapphire/snowflake': 3.5.3
+      '@vladfrangu/async_event_emitter': 2.4.7
+      discord-api-types: 0.38.38
+      magic-bytes.js: 1.13.0
+      tslib: 2.8.1
+      undici: 6.21.3
+
+  '@discordjs/util@1.2.0':
+    dependencies:
+      discord-api-types: 0.38.38
+
+  '@discordjs/ws@1.2.3':
+    dependencies:
+      '@discordjs/collection': 2.1.1
+      '@discordjs/rest': 2.6.0
+      '@discordjs/util': 1.2.0
+      '@sapphire/async-queue': 1.5.5
+      '@types/ws': 8.18.1
+      '@vladfrangu/async_event_emitter': 2.4.7
+      discord-api-types: 0.38.38
+      tslib: 2.8.1
+      ws: 8.19.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   '@esbuild/aix-ppc64@0.27.3':
     optional: true
@@ -2398,6 +2533,15 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.57.1':
     optional: true
 
+  '@sapphire/async-queue@1.5.5': {}
+
+  '@sapphire/shapeshift@4.0.0':
+    dependencies:
+      fast-deep-equal: 3.1.3
+      lodash: 4.17.23
+
+  '@sapphire/snowflake@3.5.3': {}
+
   '@slack/bolt@4.6.0(@types/express@5.0.6)':
     dependencies:
       '@slack/logger': 4.0.0
@@ -2589,6 +2733,8 @@ snapshots:
       '@vitest/pretty-format': 4.0.18
       tinyrainbow: 3.0.3
 
+  '@vladfrangu/async_event_emitter@2.4.7': {}
+
   abort-controller@3.0.0:
     dependencies:
       event-target-shim: 5.0.1
@@ -2763,6 +2909,27 @@ snapshots:
   delayed-stream@1.0.0: {}
 
   depd@2.0.0: {}
+
+  discord-api-types@0.38.38: {}
+
+  discord.js@14.25.1:
+    dependencies:
+      '@discordjs/builders': 1.13.1
+      '@discordjs/collection': 1.5.3
+      '@discordjs/formatters': 0.6.2
+      '@discordjs/rest': 2.6.0
+      '@discordjs/util': 1.2.0
+      '@discordjs/ws': 1.2.3
+      '@sapphire/snowflake': 3.5.3
+      discord-api-types: 0.38.38
+      fast-deep-equal: 3.1.3
+      lodash.snakecase: 4.1.1
+      magic-bytes.js: 1.13.0
+      tslib: 2.8.1
+      undici: 6.21.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   double-ended-queue@2.1.0-0: {}
 
@@ -3138,6 +3305,12 @@ snapshots:
 
   lodash.once@4.1.1: {}
 
+  lodash.snakecase@4.1.1: {}
+
+  lodash@4.17.23: {}
+
+  magic-bytes.js@1.13.0: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -3491,6 +3664,8 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
+  ts-mixer@6.0.4: {}
+
   tslib@2.8.1: {}
 
   tsscmp@1.0.6: {}
@@ -3563,6 +3738,8 @@ snapshots:
   undici-types@6.21.0: {}
 
   undici-types@7.16.0: {}
+
+  undici@6.21.3: {}
 
   unpipe@1.0.0: {}
 


### PR DESCRIPTION
## Summary
- Implements `@templar/channel-discord` adapter using discord.js v14, following the established patterns from Slack and Telegram adapters (#36)
- Tiered config with Zod validation, production-safe sweeper defaults, lazy-loaded SDK, batched message rendering (content + files + components), auto-split at 2000 chars
- 95 tests across 6 files (unit + integration), clean lint, clean typecheck, clean build

## Files
| File | Purpose |
|------|---------|
| `src/adapter.ts` | Main `DiscordChannel` class — connect/disconnect/send/onMessage + getClient() |
| `src/capabilities.ts` | Static `DISCORD_CAPABILITIES` (text, richText, images, files, buttons, threads, reactions, groups) |
| `src/config.ts` | Zod-validated config with tiered defaults (intents, sweepers, presence) |
| `src/normalizer.ts` | Discord Message → InboundMessage (text, attachments, embeds, threads, bot filtering) |
| `src/renderer.ts` | OutboundMessage → batched Discord API calls (auto-split, error mapping) |
| `src/index.ts` | Public exports |

## Key Decisions (from interactive review)
- **SDK**: Full discord.js v14 with sweepers (not lightweight REST)
- **Events**: messageCreate + getClient() escape hatch for slash commands
- **Config**: Tiered defaults — works with just `{ token }`, customizable for production
- **Rendering**: Single batched API call (content + files + components), auto-split at 2000 chars
- **Loading**: Lazy `import("discord.js")` on connect() for fast registration
- **Errors**: Explicit mapping for Discord codes 50013 (permissions) and 50001 (access)
- **Tests**: Unit + mock-based integration (no live bot required)

## Test plan
- [x] 95 tests passing (12 capabilities + 15 config + 19 normalizer + 20 renderer + 24 adapter + 5 integration)
- [x] Biome lint clean
- [x] TypeScript typecheck clean
- [x] Package build (138.72 KB ESM + 3.34 KB DTS)
- [x] Full workspace build (18 packages)

Closes #36