### PR TITLE
feat(identity): add Zod validation schema and harden resolver

### DIFF
--- a/packages/identity/package.json
+++ b/packages/identity/package.json
@@ -16,6 +16,9 @@
     "lint": "biome check .",
     "test": "vitest run"
   },
+  "dependencies": {
+    "zod": "^3.24.0"
+  },
   "devDependencies": {
     "@templar/core": "workspace:*"
   }

--- a/packages/identity/src/__tests__/unit/resolver.test.ts
+++ b/packages/identity/src/__tests__/unit/resolver.test.ts
@@ -181,6 +181,15 @@ describe("resolveIdentity", () => {
     };
     expect(resolveIdentity(config, "slack")).toBeUndefined();
   });
+
+  // #19 — Both default and channel override are empty objects
+  it("returns undefined when both default and channel are empty objects", () => {
+    const config: IdentityConfig = {
+      default: {},
+      channels: { slack: {} },
+    };
+    expect(resolveIdentity(config, "slack")).toBeUndefined();
+  });
 });
 
 describe("resolveChannelIdentity", () => {

--- a/packages/identity/src/__tests__/unit/schema.test.ts
+++ b/packages/identity/src/__tests__/unit/schema.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from "vitest";
+import { ChannelIdentityConfigSchema, IdentityConfigSchema } from "../../schema.js";
+
+describe("ChannelIdentityConfigSchema", () => {
+  it("accepts valid identity config", () => {
+    const result = ChannelIdentityConfigSchema.parse({
+      name: "Bot",
+      avatar: "https://cdn.example.com/bot.png",
+      bio: "A helpful assistant",
+      systemPromptPrefix: "You are a friendly bot.",
+    });
+    expect(result.name).toBe("Bot");
+    expect(result.avatar).toBe("https://cdn.example.com/bot.png");
+  });
+
+  it("accepts empty object (all fields optional)", () => {
+    const result = ChannelIdentityConfigSchema.parse({});
+    expect(result).toEqual({});
+  });
+
+  it("accepts partial fields", () => {
+    const result = ChannelIdentityConfigSchema.parse({ name: "Bot" });
+    expect(result).toEqual({ name: "Bot" });
+  });
+
+  it("rejects name exceeding 80 characters", () => {
+    const result = ChannelIdentityConfigSchema.safeParse({
+      name: "a".repeat(81),
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.at(0)?.message).toContain("80");
+    }
+  });
+
+  it("accepts name at exactly 80 characters", () => {
+    const result = ChannelIdentityConfigSchema.safeParse({
+      name: "a".repeat(80),
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects invalid avatar URL", () => {
+    const result = ChannelIdentityConfigSchema.safeParse({
+      avatar: "not-a-url",
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.at(0)?.message).toContain("URL");
+    }
+  });
+
+  it("rejects javascript: avatar URL", () => {
+    const result = ChannelIdentityConfigSchema.safeParse({
+      avatar: "javascript:alert(1)",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects data: avatar URL", () => {
+    const result = ChannelIdentityConfigSchema.safeParse({
+      avatar: "data:image/png;base64,iVBORw0KGgo=",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects ftp: avatar URL", () => {
+    const result = ChannelIdentityConfigSchema.safeParse({
+      avatar: "ftp://example.com/avatar.png",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts valid HTTPS avatar URL", () => {
+    const result = ChannelIdentityConfigSchema.safeParse({
+      avatar: "https://cdn.example.com/avatar.png",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects bio exceeding 512 characters", () => {
+    const result = ChannelIdentityConfigSchema.safeParse({
+      bio: "a".repeat(513),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects systemPromptPrefix exceeding 4096 characters", () => {
+    const result = ChannelIdentityConfigSchema.safeParse({
+      systemPromptPrefix: "a".repeat(4097),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects unknown fields (strict mode)", () => {
+    const result = ChannelIdentityConfigSchema.safeParse({
+      name: "Bot",
+      unknownField: "value",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts empty string name (intentional override)", () => {
+    const result = ChannelIdentityConfigSchema.safeParse({ name: "" });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("IdentityConfigSchema", () => {
+  it("accepts full identity config with default and channels", () => {
+    const result = IdentityConfigSchema.parse({
+      default: { name: "Bot", avatar: "https://a.png" },
+      channels: {
+        slack: { name: "Slack Bot", avatar: "https://slack.png" },
+        whatsapp: { name: "WA Bot", bio: "Hello from WhatsApp" },
+      },
+    });
+    expect(result.default?.name).toBe("Bot");
+    expect(result.channels?.slack?.name).toBe("Slack Bot");
+  });
+
+  it("accepts empty object", () => {
+    const result = IdentityConfigSchema.parse({});
+    expect(result).toEqual({});
+  });
+
+  it("accepts default only", () => {
+    const result = IdentityConfigSchema.parse({
+      default: { name: "Bot" },
+    });
+    expect(result.default?.name).toBe("Bot");
+  });
+
+  it("accepts channels only", () => {
+    const result = IdentityConfigSchema.parse({
+      channels: { slack: { name: "Slack Bot" } },
+    });
+    expect(result.channels?.slack?.name).toBe("Slack Bot");
+  });
+
+  it("rejects invalid channel identity config", () => {
+    const result = IdentityConfigSchema.safeParse({
+      channels: { slack: { avatar: "not-a-url" } },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects unknown top-level fields (strict mode)", () => {
+    const result = IdentityConfigSchema.safeParse({
+      default: { name: "Bot" },
+      extra: "field",
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/identity/src/index.ts
+++ b/packages/identity/src/index.ts
@@ -1,1 +1,7 @@
 export { resolveChannelIdentity, resolveIdentity } from "./resolver.js";
+export {
+  ChannelIdentityConfigSchema,
+  IdentityConfigSchema,
+  type ValidatedChannelIdentityConfig,
+  type ValidatedIdentityConfig,
+} from "./schema.js";

--- a/packages/identity/src/resolver.ts
+++ b/packages/identity/src/resolver.ts
@@ -1,6 +1,17 @@
 import type { ChannelIdentity, ChannelIdentityConfig, IdentityConfig } from "@templar/core";
 
 /**
+ * Remove keys with undefined values and freeze the result.
+ * Accepts a Record where values may be undefined (from pick()),
+ * strips them, and returns a frozen object typed as T.
+ */
+function freezeWithoutUndefined<T extends object>(obj: Record<string, unknown>): T {
+  return Object.freeze(
+    Object.fromEntries(Object.entries(obj).filter(([, v]) => v !== undefined)),
+  ) as T;
+}
+
+/**
  * Pick the channel-level value if defined, otherwise fall back to default.
  * Empty strings are intentional overrides (not fallback triggers).
  */
@@ -33,13 +44,12 @@ function mergeIdentityConfig(
     return undefined;
   }
 
-  const result: Record<string, unknown> = {};
-  if (name !== undefined) result.name = name;
-  if (avatar !== undefined) result.avatar = avatar;
-  if (bio !== undefined) result.bio = bio;
-  if (systemPromptPrefix !== undefined) result.systemPromptPrefix = systemPromptPrefix;
-
-  return Object.freeze(result) as ChannelIdentityConfig;
+  return freezeWithoutUndefined<ChannelIdentityConfig>({
+    name,
+    avatar,
+    bio,
+    systemPromptPrefix,
+  });
 }
 
 /**
@@ -79,10 +89,9 @@ export function resolveChannelIdentity(
     return undefined;
   }
 
-  const result: Record<string, unknown> = {};
-  if (full.name !== undefined) result.name = full.name;
-  if (full.avatar !== undefined) result.avatar = full.avatar;
-  if (full.bio !== undefined) result.bio = full.bio;
-
-  return Object.freeze(result) as ChannelIdentity;
+  return freezeWithoutUndefined<ChannelIdentity>({
+    name: full.name,
+    avatar: full.avatar,
+    bio: full.bio,
+  });
 }

--- a/packages/identity/src/schema.ts
+++ b/packages/identity/src/schema.ts
@@ -1,0 +1,34 @@
+import { z } from "zod";
+
+/**
+ * Zod schema for a single channel's identity config.
+ * Loose constraints — platform-specific limits belong in channel adapters.
+ */
+export const ChannelIdentityConfigSchema = z
+  .object({
+    name: z.string().max(80, "name must be at most 80 characters").optional(),
+    avatar: z
+      .string()
+      .url("avatar must be a valid URL")
+      .refine((url) => /^https?:\/\//i.test(url), "avatar must use http or https protocol")
+      .optional(),
+    bio: z.string().max(512, "bio must be at most 512 characters").optional(),
+    systemPromptPrefix: z
+      .string()
+      .max(4096, "systemPromptPrefix must be at most 4096 characters")
+      .optional(),
+  })
+  .strict();
+
+/**
+ * Zod schema for the top-level identity config with 2-level cascade.
+ */
+export const IdentityConfigSchema = z
+  .object({
+    default: ChannelIdentityConfigSchema.optional(),
+    channels: z.record(z.string(), ChannelIdentityConfigSchema).optional(),
+  })
+  .strict();
+
+export type ValidatedIdentityConfig = z.infer<typeof IdentityConfigSchema>;
+export type ValidatedChannelIdentityConfig = z.infer<typeof ChannelIdentityConfigSchema>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -204,6 +204,10 @@ importers:
         version: 4.0.18(@types/node@22.19.11)(yaml@2.8.2)
 
   packages/identity:
+    dependencies:
+      zod:
+        specifier: ^3.24.0
+        version: 3.25.76
     devDependencies:
       '@templar/core':
         specifier: workspace:*


### PR DESCRIPTION
## Summary

- **Add Zod validation schemas** (`IdentityConfigSchema`, `ChannelIdentityConfigSchema`) for runtime validation of identity config with:
  - `name`: max 80 chars
  - `avatar`: valid URL, http/https protocol only (blocks `javascript:`, `data:`, `ftp:`)
  - `bio`: max 512 chars  
  - `systemPromptPrefix`: max 4096 chars
  - `.strict()` mode rejects unknown fields
- **Refactor resolver** to eliminate `Record<string, unknown>` + unsafe `as` casts — replaced with `freezeWithoutUndefined<T>()` helper (single justified cast in one utility)
- **Add 21 new tests** (20 schema validation + 1 missing edge case for empty-object configs)

## Test plan

- [x] All 42 tests pass (22 resolver + 20 schema)
- [x] 100% coverage (statements, branches, functions, lines)
- [x] Build passes (ESM + DTS)
- [x] Biome check clean
- [x] Nexus identity e2e tests pass (15/15, FastAPI with permissions enabled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)