### PR TITLE
feat(manifest): quick-start templates with sugar syntax (#64)

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -74,6 +74,8 @@ export interface AgentManifest {
   middleware?: MiddlewareConfig[];
   permissions?: PermissionConfig;
   identity?: IdentityConfig;
+  schedule?: string;
+  prompt?: string;
 }
 
 /**

--- a/packages/manifest/package.json
+++ b/packages/manifest/package.json
@@ -17,6 +17,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "cron-parser": "^4.9.0",
     "yaml": "^2.8.0",
     "zod": "^3.24.0"
   },

--- a/packages/manifest/src/__tests__/helpers/fixtures.ts
+++ b/packages/manifest/src/__tests__/helpers/fixtures.ts
@@ -74,3 +74,56 @@ export const YAML_MISSING_REQUIRED = `
 name: ""
 version: not-semver
 `;
+
+// ---------------------------------------------------------------------------
+// Sugar syntax fixtures
+// ---------------------------------------------------------------------------
+
+export const YAML_WITH_MODEL_STRING = `
+name: sugar-model
+version: 1.0.0
+description: Model as slash string
+model: anthropic/claude-sonnet-4-5
+`;
+
+export const YAML_WITH_MODEL_INFERRED = `
+name: sugar-model-inferred
+version: 1.0.0
+description: Model with inferred provider
+model: claude-sonnet-4-5
+`;
+
+export const YAML_WITH_CHANNELS_ARRAY = `
+name: sugar-channels
+version: 1.0.0
+description: Channels as string array
+channels:
+  - slack
+  - telegram
+`;
+
+export const YAML_WITH_PROMPT = `
+name: sugar-prompt
+version: 1.0.0
+description: Top-level prompt sugar
+prompt: You are a helpful assistant that summarizes documents.
+`;
+
+export const YAML_WITH_SCHEDULE = `
+name: sugar-schedule
+version: 1.0.0
+description: Scheduled agent
+schedule: "0 9 * * 1-5"
+`;
+
+export const YAML_WITH_ALL_SUGAR = `
+name: sugar-all
+version: 1.0.0
+description: All sugar syntax combined
+model: anthropic/claude-sonnet-4-5
+channels:
+  - slack
+  - email
+prompt: You are a helpful assistant.
+schedule: "0 8 * * *"
+`;

--- a/packages/manifest/src/__tests__/integration/templates.test.ts
+++ b/packages/manifest/src/__tests__/integration/templates.test.ts
@@ -1,0 +1,37 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { parseManifestYaml } from "../../parser.js";
+
+const templatesDir = resolve(__dirname, "../../../../../templates");
+
+const templateDirs = readdirSync(templatesDir, { withFileTypes: true })
+  .filter((d) => d.isDirectory())
+  .map((d) => d.name);
+
+describe("template validation", () => {
+  it("discovers at least 5 templates", () => {
+    expect(templateDirs.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it.each(templateDirs)("templates/%s/templar.yaml validates", (name) => {
+    const yamlPath = join(templatesDir, name, "templar.yaml");
+    const yaml = readFileSync(yamlPath, "utf-8");
+    const manifest = parseManifestYaml(yaml, { skipInterpolation: true });
+    expect(manifest.name).toBe(name);
+  });
+
+  it.each(templateDirs)("templates/%s has required files", (name) => {
+    const dir = join(templatesDir, name);
+    expect(existsSync(join(dir, "templar.yaml"))).toBe(true);
+    expect(existsSync(join(dir, ".env.example"))).toBe(true);
+    expect(existsSync(join(dir, "README.md"))).toBe(true);
+  });
+
+  it.each(templateDirs)("templates/%s has a description", (name) => {
+    const yamlPath = join(templatesDir, name, "templar.yaml");
+    const yaml = readFileSync(yamlPath, "utf-8");
+    const manifest = parseManifestYaml(yaml, { skipInterpolation: true });
+    expect(manifest.description.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/manifest/src/__tests__/unit/normalize.test.ts
+++ b/packages/manifest/src/__tests__/unit/normalize.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from "vitest";
+import { normalizeManifest } from "../../normalize.js";
+
+const minimal = {
+  name: "test-agent",
+  version: "1.0.0",
+  description: "A test agent",
+};
+
+describe("normalizeManifest", () => {
+  describe("model normalization", () => {
+    it("splits slash format into provider and name", () => {
+      const raw = { ...minimal, model: "anthropic/claude-sonnet-4-5" };
+      const result = normalizeManifest(raw);
+      expect(result.model).toEqual({ provider: "anthropic", name: "claude-sonnet-4-5" });
+    });
+
+    it("infers anthropic provider for claude- prefix", () => {
+      const raw = { ...minimal, model: "claude-sonnet-4-5" };
+      const result = normalizeManifest(raw);
+      expect(result.model).toEqual({ provider: "anthropic", name: "claude-sonnet-4-5" });
+    });
+
+    it("infers openai provider for gpt- prefix", () => {
+      const raw = { ...minimal, model: "gpt-4o" };
+      const result = normalizeManifest(raw);
+      expect(result.model).toEqual({ provider: "openai", name: "gpt-4o" });
+    });
+
+    it("infers openai provider for o1- prefix", () => {
+      const raw = { ...minimal, model: "o1-mini" };
+      const result = normalizeManifest(raw);
+      expect(result.model).toEqual({ provider: "openai", name: "o1-mini" });
+    });
+
+    it("infers openai provider for o3- prefix", () => {
+      const raw = { ...minimal, model: "o3-mini" };
+      const result = normalizeManifest(raw);
+      expect(result.model).toEqual({ provider: "openai", name: "o3-mini" });
+    });
+
+    it("infers google provider for gemini- prefix", () => {
+      const raw = { ...minimal, model: "gemini-pro" };
+      const result = normalizeManifest(raw);
+      expect(result.model).toEqual({ provider: "google", name: "gemini-pro" });
+    });
+
+    it("passes through object model unchanged", () => {
+      const model = { provider: "anthropic", name: "claude-3" };
+      const raw = { ...minimal, model };
+      const result = normalizeManifest(raw);
+      expect(result.model).toEqual(model);
+    });
+
+    it("leaves model undefined when not present", () => {
+      const result = normalizeManifest({ ...minimal });
+      expect(result.model).toBeUndefined();
+    });
+
+    it("throws for unknown model prefix without slash", () => {
+      const raw = { ...minimal, model: "unknown-xyz" };
+      expect(() => normalizeManifest(raw)).toThrow("Cannot infer provider");
+    });
+  });
+
+  describe("channels normalization", () => {
+    it("converts string array to ChannelConfig array", () => {
+      const raw = { ...minimal, channels: ["slack", "telegram"] };
+      const result = normalizeManifest(raw);
+      expect(result.channels).toEqual([
+        { type: "slack", config: {} },
+        { type: "telegram", config: {} },
+      ]);
+    });
+
+    it("passes through object channels unchanged", () => {
+      const channels = [{ type: "slack", config: { token: "x" } }];
+      const raw = { ...minimal, channels };
+      const result = normalizeManifest(raw);
+      expect(result.channels).toEqual(channels);
+    });
+
+    it("leaves channels undefined when not present", () => {
+      const result = normalizeManifest({ ...minimal });
+      expect(result.channels).toBeUndefined();
+    });
+  });
+
+  describe("prompt normalization", () => {
+    it("maps prompt to identity.default.systemPromptPrefix", () => {
+      const raw = { ...minimal, prompt: "You are helpful" };
+      const result = normalizeManifest(raw);
+      expect(result.identity).toEqual({
+        default: { systemPromptPrefix: "You are helpful" },
+      });
+      expect(result.prompt).toBeUndefined();
+    });
+
+    it("merges prompt with existing identity.default fields", () => {
+      const raw = {
+        ...minimal,
+        prompt: "You are helpful",
+        identity: { default: { bio: "A bot" } },
+      };
+      const result = normalizeManifest(raw);
+      expect(result.identity).toEqual({
+        default: { bio: "A bot", systemPromptPrefix: "You are helpful" },
+      });
+    });
+
+    it("prompt overwrites existing systemPromptPrefix", () => {
+      const raw = {
+        ...minimal,
+        prompt: "New prompt",
+        identity: { default: { systemPromptPrefix: "Old prompt" } },
+      };
+      const result = normalizeManifest(raw);
+      expect(result.identity).toEqual({
+        default: { systemPromptPrefix: "New prompt" },
+      });
+    });
+
+    it("preserves identity.channels when prompt is set", () => {
+      const raw = {
+        ...minimal,
+        prompt: "You are helpful",
+        identity: {
+          channels: { slack: { name: "Slack Bot" } },
+        },
+      };
+      const result = normalizeManifest(raw);
+      expect(result.identity).toEqual({
+        default: { systemPromptPrefix: "You are helpful" },
+        channels: { slack: { name: "Slack Bot" } },
+      });
+    });
+  });
+
+  describe("pass-through and immutability", () => {
+    it("returns a new object for non-sugar manifest", () => {
+      const raw = { ...minimal };
+      const result = normalizeManifest(raw);
+      expect(result).toEqual(raw);
+      expect(result).not.toBe(raw);
+    });
+
+    it("normalizes all sugar fields together", () => {
+      const raw = {
+        ...minimal,
+        model: "anthropic/claude-sonnet-4-5",
+        channels: ["slack", "email"],
+        prompt: "You are helpful",
+        schedule: "0 9 * * 1-5",
+      };
+      const result = normalizeManifest(raw);
+      expect(result.model).toEqual({ provider: "anthropic", name: "claude-sonnet-4-5" });
+      expect(result.channels).toEqual([
+        { type: "slack", config: {} },
+        { type: "email", config: {} },
+      ]);
+      expect(result.identity).toEqual({
+        default: { systemPromptPrefix: "You are helpful" },
+      });
+      expect(result.schedule).toBe("0 9 * * 1-5");
+      expect(result.prompt).toBeUndefined();
+    });
+
+    it("does not mutate the input object", () => {
+      const raw = {
+        ...minimal,
+        model: "gpt-4o",
+        identity: { default: { bio: "A bot" } },
+      };
+      const rawCopy = JSON.parse(JSON.stringify(raw));
+      normalizeManifest(raw);
+      expect(raw).toEqual(rawCopy);
+    });
+  });
+});

--- a/packages/manifest/src/index.ts
+++ b/packages/manifest/src/index.ts
@@ -11,6 +11,7 @@
 // ============================================================================
 
 export { type LoadManifestOptions, loadManifest } from "./loader.js";
+export { normalizeManifest } from "./normalize.js";
 export { type ParseManifestOptions, parseManifestYaml } from "./parser.js";
 
 // ============================================================================
@@ -21,6 +22,8 @@ export {
   AgentManifestSchema,
   ChannelIdentityConfigSchema,
   IdentityConfigSchema,
+  PromptSchema,
+  ScheduleSchema,
 } from "./schema.js";
 
 // ============================================================================

--- a/packages/manifest/src/normalize.ts
+++ b/packages/manifest/src/normalize.ts
@@ -1,0 +1,150 @@
+/**
+ * Sugar syntax normalizer for agent manifests.
+ *
+ * Transforms shorthand YAML fields (string model, string[] channels,
+ * top-level prompt) into the full structured form expected by the Zod schema.
+ * Always returns a new object — never mutates the input.
+ */
+
+/** Maps model-name prefixes to their provider */
+const PROVIDER_PREFIX_MAP: ReadonlyArray<readonly [string, string]> = [
+  ["claude-", "anthropic"],
+  ["claude3", "anthropic"],
+  ["gpt-", "openai"],
+  ["o1-", "openai"],
+  ["o3-", "openai"],
+  ["o4-", "openai"],
+  ["gemini-", "google"],
+  ["gemini2", "google"],
+  ["command-", "cohere"],
+  ["mistral-", "mistral"],
+  ["mixtral-", "mistral"],
+  ["llama-", "meta"],
+  ["llama3", "meta"],
+];
+
+function inferProvider(modelName: string): string {
+  for (const [prefix, provider] of PROVIDER_PREFIX_MAP) {
+    if (modelName.startsWith(prefix)) {
+      return provider;
+    }
+  }
+  throw new Error(
+    `Cannot infer provider for model "${modelName}". Use "provider/model" format (e.g. "anthropic/${modelName}").`,
+  );
+}
+
+interface ModelConfig {
+  readonly provider: string;
+  readonly name: string;
+  readonly temperature?: number;
+  readonly maxTokens?: number;
+}
+
+function normalizeModel(model: unknown): ModelConfig | undefined {
+  if (model === undefined || model === null) {
+    return undefined;
+  }
+  if (typeof model === "string") {
+    const slashIndex = model.indexOf("/");
+    if (slashIndex > 0) {
+      return {
+        provider: model.slice(0, slashIndex),
+        name: model.slice(slashIndex + 1),
+      };
+    }
+    return {
+      provider: inferProvider(model),
+      name: model,
+    };
+  }
+  // Object form — pass through as-is
+  return model as ModelConfig;
+}
+
+interface ChannelConfig {
+  readonly type: string;
+  readonly config: Record<string, unknown>;
+}
+
+function normalizeChannels(channels: unknown): ChannelConfig[] | undefined {
+  if (channels === undefined || channels === null) {
+    return undefined;
+  }
+  if (!Array.isArray(channels)) {
+    return channels as ChannelConfig[];
+  }
+  return channels.map((ch) => {
+    if (typeof ch === "string") {
+      return { type: ch, config: {} };
+    }
+    return ch as ChannelConfig;
+  });
+}
+
+interface ChannelIdentityConfig {
+  readonly name?: string;
+  readonly avatar?: string;
+  readonly bio?: string;
+  readonly systemPromptPrefix?: string;
+}
+
+interface IdentityConfig {
+  readonly default?: ChannelIdentityConfig;
+  readonly channels?: Record<string, ChannelIdentityConfig>;
+}
+
+function normalizeIdentity(prompt: unknown, identity: unknown): IdentityConfig | undefined {
+  if (prompt === undefined || prompt === null || typeof prompt !== "string") {
+    return identity as IdentityConfig | undefined;
+  }
+
+  const existing = (identity as IdentityConfig | undefined) ?? {};
+  const existingDefault = existing.default ?? {};
+
+  // Top-level `prompt` sugar takes precedence over identity.default.systemPromptPrefix
+  return {
+    ...existing,
+    default: {
+      ...existingDefault,
+      systemPromptPrefix: prompt,
+    },
+  };
+}
+
+/**
+ * Normalizes sugar syntax in a raw manifest object into the full structured
+ * form expected by the Zod schema.
+ *
+ * - `model: "provider/name"` → `model: { provider, name }`
+ * - `model: "claude-sonnet-4-5"` → `model: { provider: "anthropic", name: "claude-sonnet-4-5" }`
+ * - `channels: ["slack"]` → `channels: [{ type: "slack", config: {} }]`
+ * - `prompt: "..."` → `identity.default.systemPromptPrefix: "..."`
+ * - `schedule` passes through unchanged
+ *
+ * Always returns a **new object** — never mutates the input.
+ */
+export function normalizeManifest(raw: Record<string, unknown>): Record<string, unknown> {
+  const { model, channels, prompt, ...rest } = raw;
+
+  const normalized: Record<string, unknown> = { ...rest };
+
+  const normalizedModel = normalizeModel(model);
+  if (normalizedModel !== undefined) {
+    normalized.model = normalizedModel;
+  }
+
+  const normalizedChannels = normalizeChannels(channels);
+  if (normalizedChannels !== undefined) {
+    normalized.channels = normalizedChannels;
+  }
+
+  const normalizedIdentity = normalizeIdentity(prompt, rest.identity);
+  if (normalizedIdentity !== undefined) {
+    normalized.identity = normalizedIdentity;
+  }
+
+  // prompt is consumed by normalizeIdentity — do not carry it forward
+
+  return normalized;
+}

--- a/packages/manifest/src/schema.ts
+++ b/packages/manifest/src/schema.ts
@@ -4,6 +4,7 @@
  */
 
 import type { AgentManifest } from "@templar/core";
+import { parseExpression } from "cron-parser";
 import { z } from "zod";
 
 export const ModelConfigSchema = z.object({
@@ -57,6 +58,23 @@ export const IdentityConfigSchema = z.object({
   channels: z.record(z.string(), ChannelIdentityConfigSchema).optional(),
 });
 
+export const ScheduleSchema = z
+  .string()
+  .min(1)
+  .refine(
+    (expr) => {
+      try {
+        parseExpression(expr);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    { message: "Invalid cron expression" },
+  );
+
+export const PromptSchema = z.string().min(1).max(10_000);
+
 export const AgentManifestSchema = z.object({
   name: z.string().min(1),
   version: z.string().regex(/^\d+\.\d+\.\d+/, 'Must follow semver (e.g. "1.0.0")'),
@@ -67,6 +85,8 @@ export const AgentManifestSchema = z.object({
   middleware: z.array(MiddlewareConfigSchema).optional(),
   permissions: PermissionConfigSchema.optional(),
   identity: IdentityConfigSchema.optional(),
+  schedule: ScheduleSchema.optional(),
+  prompt: PromptSchema.optional(),
 });
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -215,6 +215,9 @@ importers:
 
   packages/manifest:
     dependencies:
+      cron-parser:
+        specifier: ^4.9.0
+        version: 4.9.0
       yaml:
         specifier: ^2.8.0
         version: 2.8.2
@@ -1460,6 +1463,10 @@ packages:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
     engines: {node: '>= 0.10'}
 
+  cron-parser@4.9.0:
+    resolution: {integrity: sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==}
+    engines: {node: '>=12.0.0'}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -2005,6 +2012,10 @@ packages:
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
+  luxon@3.7.2:
+    resolution: {integrity: sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==}
+    engines: {node: '>=12'}
 
   magic-bytes.js@1.13.0:
     resolution: {integrity: sha512-afO2mnxW7GDTXMm5/AoN1WuOcdoKhtgXjIvHmobqTD1grNplhGdv3PFOyjCVmrnOZBIT/gD/koDKpYG+0mvHcg==}
@@ -3901,6 +3912,10 @@ snapshots:
       object-assign: 4.1.1
       vary: 1.1.2
 
+  cron-parser@4.9.0:
+    dependencies:
+      luxon: 3.7.2
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -4501,6 +4516,8 @@ snapshots:
   long@5.3.2: {}
 
   lru-cache@10.4.3: {}
+
+  luxon@3.7.2: {}
 
   magic-bytes.js@1.13.0: {}
 

--- a/templates/code-builder/.env.example
+++ b/templates/code-builder/.env.example
@@ -1,0 +1,8 @@
+# Slack Bot Token — required for the slack channel adapter
+SLACK_BOT_TOKEN=xoxb-your-token-here
+
+# Anthropic API Key — required for the model
+ANTHROPIC_API_KEY=sk-ant-your-key-here
+
+# Path to the project to build (defaults to current directory)
+PROJECT_PATH=.

--- a/templates/code-builder/README.md
+++ b/templates/code-builder/README.md
@@ -1,0 +1,16 @@
+# Code Builder
+
+A scheduled agent that runs nightly builds and test suites, then reports results to Slack.
+
+## Setup
+
+1. Copy `.env.example` to `.env` and fill in your tokens
+2. Copy `templar.yaml` to your project root
+3. Run `templar start`
+
+## What it does
+
+- Runs every night at 2:00 AM UTC
+- Executes the project build and test suite
+- Reports results to Slack with failure context
+- Suggests fixes for common build errors

--- a/templates/code-builder/templar.yaml
+++ b/templates/code-builder/templar.yaml
@@ -1,0 +1,27 @@
+name: code-builder
+version: 1.0.0
+description: Overnight CI agent that builds, tests, and reports results
+
+model: anthropic/claude-sonnet-4-5
+channels:
+  - slack
+
+schedule: "0 2 * * *"
+prompt: >
+  You are a CI/CD assistant. Run the project build and test suite,
+  then report the results. Highlight any failures with relevant
+  error context. Suggest fixes for common build errors when possible.
+
+tools:
+  - name: shell_exec
+    description: Execute shell commands for building and testing
+    parameters:
+      allowedCommands:
+        - npm test
+        - npm run build
+        - npm run lint
+
+identity:
+  default:
+    name: Code Builder
+    bio: Nightly builds and test reports at 2 AM

--- a/templates/daily-digest/.env.example
+++ b/templates/daily-digest/.env.example
@@ -1,0 +1,5 @@
+# Slack Bot Token — required for the slack channel adapter
+SLACK_BOT_TOKEN=xoxb-your-token-here
+
+# Anthropic API Key — required for the model
+ANTHROPIC_API_KEY=sk-ant-your-key-here

--- a/templates/daily-digest/README.md
+++ b/templates/daily-digest/README.md
@@ -1,0 +1,16 @@
+# Daily Digest
+
+A scheduled agent that delivers a morning summary of activity across your Slack workspace.
+
+## Setup
+
+1. Copy `.env.example` to `.env` and fill in your tokens
+2. Copy `templar.yaml` to your project root
+3. Run `templar start`
+
+## What it does
+
+- Runs every morning at 8:00 AM UTC
+- Collects messages from the past 24 hours
+- Groups updates by channel and priority
+- Posts a concise summary to Slack

--- a/templates/daily-digest/templar.yaml
+++ b/templates/daily-digest/templar.yaml
@@ -1,0 +1,18 @@
+name: daily-digest
+version: 1.0.0
+description: Summarizes key updates from connected channels on a daily schedule
+
+model: anthropic/claude-sonnet-4-5
+channels:
+  - slack
+
+schedule: "0 8 * * *"
+prompt: >
+  You are a daily digest bot. Each morning, collect the most important
+  messages, threads, and updates from the previous 24 hours. Produce a
+  concise, scannable summary grouped by channel and priority.
+
+identity:
+  default:
+    name: Daily Digest
+    bio: Your morning briefing, every day at 8 AM

--- a/templates/inbox-assistant/.env.example
+++ b/templates/inbox-assistant/.env.example
@@ -1,0 +1,7 @@
+# Email credentials — required for the email channel adapter
+EMAIL_HOST=imap.gmail.com
+EMAIL_USER=you@example.com
+EMAIL_PASSWORD=your-app-password
+
+# Anthropic API Key — required for the model
+ANTHROPIC_API_KEY=sk-ant-your-key-here

--- a/templates/inbox-assistant/README.md
+++ b/templates/inbox-assistant/README.md
@@ -1,0 +1,16 @@
+# Inbox Assistant
+
+A scheduled agent that triages your email inbox and drafts replies for action items.
+
+## Setup
+
+1. Copy `.env.example` to `.env` and fill in your credentials
+2. Copy `templar.yaml` to your project root
+3. Run `templar start`
+
+## What it does
+
+- Checks for new emails every 30 minutes
+- Categorizes each email by priority level
+- Drafts reply suggestions for action-required items
+- Never sends emails automatically (human-in-the-loop)

--- a/templates/inbox-assistant/templar.yaml
+++ b/templates/inbox-assistant/templar.yaml
@@ -1,0 +1,26 @@
+name: inbox-assistant
+version: 1.0.0
+description: Email triage agent that categorizes and drafts replies
+
+model: anthropic/claude-sonnet-4-5
+channels:
+  - email
+
+schedule: "*/30 * * * *"
+prompt: >
+  You are an email triage assistant. Categorize incoming emails as
+  urgent, action-required, informational, or low-priority. Draft
+  concise reply suggestions for action-required items. Never send
+  replies automatically — always present drafts for human approval.
+
+permissions:
+  allowed:
+    - email_read
+    - email_draft
+  denied:
+    - email_send
+
+identity:
+  default:
+    name: Inbox Assistant
+    bio: Smart email triage every 30 minutes

--- a/templates/knowledge-base/.env.example
+++ b/templates/knowledge-base/.env.example
@@ -1,0 +1,5 @@
+# Slack Bot Token — required for the slack channel adapter
+SLACK_BOT_TOKEN=xoxb-your-token-here
+
+# Anthropic API Key — required for the model
+ANTHROPIC_API_KEY=sk-ant-your-key-here

--- a/templates/knowledge-base/README.md
+++ b/templates/knowledge-base/README.md
@@ -1,0 +1,17 @@
+# Knowledge Base
+
+A conversational agent that answers questions from your indexed documents using RAG (retrieval-augmented generation).
+
+## Setup
+
+1. Copy `.env.example` to `.env` and fill in your tokens
+2. Copy `templar.yaml` to your project root
+3. Place documents in `./data/` and build the index
+4. Run `templar start`
+
+## What it does
+
+- Listens for questions in Slack
+- Searches indexed documents for relevant context
+- Provides cited answers with source references
+- Remembers conversation context per user

--- a/templates/knowledge-base/templar.yaml
+++ b/templates/knowledge-base/templar.yaml
@@ -1,0 +1,25 @@
+name: knowledge-base
+version: 1.0.0
+description: Personal knowledge assistant with RAG-powered document retrieval
+
+model: anthropic/claude-sonnet-4-5
+channels:
+  - slack
+
+prompt: >
+  You are a knowledge base assistant. When users ask questions, search
+  the indexed documents and provide accurate, cited answers. Always
+  include the source document name and section in your responses.
+
+middleware:
+  - name: memory
+    config:
+      scope: per-user
+  - name: rag
+    config:
+      indexPath: ./data/index
+
+identity:
+  default:
+    name: Knowledge Bot
+    bio: Ask me anything about your documents

--- a/templates/research-tracker/.env.example
+++ b/templates/research-tracker/.env.example
@@ -1,0 +1,10 @@
+# Email credentials — required for the email channel adapter
+EMAIL_HOST=imap.gmail.com
+EMAIL_USER=you@example.com
+EMAIL_PASSWORD=your-app-password
+
+# Discord Bot Token — required for the discord channel adapter
+DISCORD_BOT_TOKEN=your-discord-token-here
+
+# Anthropic API Key — required for the model
+ANTHROPIC_API_KEY=sk-ant-your-key-here

--- a/templates/research-tracker/README.md
+++ b/templates/research-tracker/README.md
@@ -1,0 +1,16 @@
+# Research Tracker
+
+A scheduled agent that monitors new research publications and delivers summaries via email and Discord.
+
+## Setup
+
+1. Copy `.env.example` to `.env` and fill in your credentials
+2. Copy `templar.yaml` to your project root
+3. Run `templar start`
+
+## What it does
+
+- Checks for new publications every 6 hours
+- Searches configured research topics and keywords
+- Summarizes papers in 2-3 sentences with key findings
+- Delivers updates via email and Discord

--- a/templates/research-tracker/templar.yaml
+++ b/templates/research-tracker/templar.yaml
@@ -1,0 +1,24 @@
+name: research-tracker
+version: 1.0.0
+description: Monitors research publications and reports new findings
+
+model: anthropic/claude-sonnet-4-5
+channels:
+  - email
+  - discord
+
+schedule: "0 */6 * * *"
+prompt: >
+  You are a research monitoring agent. Track new publications and
+  preprints matching the configured topics. Summarize each paper in
+  2-3 sentences, highlight key findings, and flag papers that are
+  highly relevant to the user's research interests.
+
+tools:
+  - name: web_search
+    description: Search the web for new research publications
+
+identity:
+  default:
+    name: Research Tracker
+    bio: Monitoring new publications every 6 hours


### PR DESCRIPTION
## Summary

- Add `normalizeManifest()` that expands shorthand YAML sugar into full structured form before Zod validation
- Support model strings (`"anthropic/claude-sonnet-4-5"` or prefix-inferred `"claude-sonnet-4-5"`), channel string arrays (`["slack"]`), top-level `prompt` (maps to `identity.default.systemPromptPrefix`), and `schedule` (cron expression validated via `cron-parser`)
- Add 5 copy-paste quick-start templates: `daily-digest`, `knowledge-base`, `inbox-assistant`, `code-builder`, `research-tracker`
- Each template includes `templar.yaml`, `.env.example`, and `README.md`

Closes #64

## Changes

### New files (18)
- `packages/manifest/src/normalize.ts` — sugar syntax normalizer (always returns new object, immutable)
- `packages/manifest/src/__tests__/unit/normalize.test.ts` — 19 unit tests
- `packages/manifest/src/__tests__/integration/templates.test.ts` — 16 parameterized template validation tests
- 5 × `templates/{name}/templar.yaml` + `.env.example` + `README.md`

### Modified files (8)
- `packages/core/src/types.ts` — added `schedule?: string` and `prompt?: string` to `AgentManifest`
- `packages/manifest/package.json` — added `cron-parser ^4.9.0`
- `packages/manifest/src/schema.ts` — added `ScheduleSchema` (cron validation) and `PromptSchema` (1–10K chars)
- `packages/manifest/src/parser.ts` — inserted `normalizeManifest()` between YAML parse and Zod validate
- `packages/manifest/src/index.ts` — exported `normalizeManifest`, `ScheduleSchema`, `PromptSchema`
- `packages/manifest/src/__tests__/helpers/fixtures.ts` — 6 sugar syntax fixtures
- `packages/manifest/src/__tests__/unit/schema.test.ts` — 17 new schedule/prompt tests
- `packages/manifest/src/__tests__/unit/parser.test.ts` — 7 new sugar syntax parser tests

## Test plan

- [x] 145 tests pass in `@templar/manifest` (8 test files)
- [x] 220 tests pass in `@templar/core` (no regression)
- [x] 73 tests pass in `@templar/errors` (no regression)
- [x] TypeScript typecheck clean for core + manifest
- [x] Biome lint clean
- [x] All 3 packages build successfully
- [x] Performance benchmarks show no regression (~2.9M agents/sec)
- [x] All 5 templates validate through full parser pipeline (normalize → Zod → freeze)