### PR TITLE
feat(hooks): harden @templar/hooks — 18 events, match/once, bridge adapter

### DIFF
--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -13,9 +13,12 @@
     "build": "tsup",
     "typecheck": "tsc --noEmit",
     "lint": "biome check .",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
+    "bench": "vitest bench"
   },
   "dependencies": {
+    "@templar/core": "workspace:*",
     "@templar/errors": "workspace:*"
   },
   "devDependencies": {

--- a/packages/hooks/src/__tests__/bench.bench.ts
+++ b/packages/hooks/src/__tests__/bench.bench.ts
@@ -1,0 +1,98 @@
+import { bench, describe } from "vitest";
+import { CONTINUE_RESULT } from "../constants.js";
+import { HookRegistry } from "../registry.js";
+import { makePostToolUseData, makePreToolUseData } from "./helpers.js";
+
+// ---------------------------------------------------------------------------
+// Interceptor emit benchmarks
+// ---------------------------------------------------------------------------
+
+describe("Interceptor emit", () => {
+  bench("0 handlers", async () => {
+    const registry = new HookRegistry();
+    await registry.emit("PreToolUse", makePreToolUseData());
+  });
+
+  bench("1 handler", async () => {
+    const registry = new HookRegistry();
+    registry.on("PreToolUse", () => CONTINUE_RESULT);
+    await registry.emit("PreToolUse", makePreToolUseData());
+  });
+
+  bench("10 handlers", async () => {
+    const registry = new HookRegistry();
+    for (let i = 0; i < 10; i++) {
+      registry.on("PreToolUse", () => CONTINUE_RESULT);
+    }
+    await registry.emit("PreToolUse", makePreToolUseData());
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Observer emit benchmarks
+// ---------------------------------------------------------------------------
+
+describe("Observer emit", () => {
+  bench("0 handlers", async () => {
+    const registry = new HookRegistry();
+    await registry.emit("PostToolUse", makePostToolUseData());
+  });
+
+  bench("1 handler", async () => {
+    const registry = new HookRegistry();
+    registry.on("PostToolUse", () => {});
+    await registry.emit("PostToolUse", makePostToolUseData());
+  });
+
+  bench("10 handlers", async () => {
+    const registry = new HookRegistry();
+    for (let i = 0; i < 10; i++) {
+      registry.on("PostToolUse", () => {});
+    }
+    await registry.emit("PostToolUse", makePostToolUseData());
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Waterfall benchmark
+// ---------------------------------------------------------------------------
+
+describe("Waterfall", () => {
+  bench("5 modifiers", async () => {
+    const registry = new HookRegistry();
+    for (let i = 0; i < 5; i++) {
+      registry.on("PreToolUse", (data) => ({
+        action: "modify" as const,
+        data: { ...data, toolName: `${data.toolName}-${i}` },
+      }));
+    }
+    await registry.emit("PreToolUse", makePreToolUseData());
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Concurrent observer emits
+// ---------------------------------------------------------------------------
+
+describe("Concurrent", () => {
+  bench("10 concurrent observer emits", async () => {
+    const registry = new HookRegistry();
+    registry.on("PostToolUse", () => {});
+    await Promise.all(
+      Array.from({ length: 10 }, () => registry.emit("PostToolUse", makePostToolUseData())),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// On + emit + dispose cycle
+// ---------------------------------------------------------------------------
+
+describe("Lifecycle", () => {
+  bench("on + emit + dispose", async () => {
+    const registry = new HookRegistry();
+    const dispose = registry.on("PreToolUse", () => CONTINUE_RESULT);
+    await registry.emit("PreToolUse", makePreToolUseData());
+    dispose();
+  });
+});

--- a/packages/hooks/src/__tests__/bridge.test.ts
+++ b/packages/hooks/src/__tests__/bridge.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "vitest";
+import { createHookMiddleware } from "../bridge.js";
+import { HookRegistry } from "../registry.js";
+
+describe("createHookMiddleware", () => {
+  it("has name '@templar/hooks/bridge'", () => {
+    const registry = new HookRegistry();
+    const middleware = createHookMiddleware(registry);
+    expect(middleware.name).toBe("@templar/hooks/bridge");
+  });
+
+  it("onSessionStart emits SessionStart event", async () => {
+    const registry = new HookRegistry();
+    let received: unknown;
+
+    registry.on("SessionStart", (data) => {
+      received = data;
+    });
+
+    const middleware = createHookMiddleware(registry);
+    await middleware.onSessionStart?.({
+      sessionId: "s1",
+      agentId: "agent-1",
+      userId: "user-1",
+    });
+
+    expect(received).toEqual({
+      sessionId: "s1",
+      agentId: "agent-1",
+      userId: "user-1",
+    });
+  });
+
+  it("onSessionStart defaults agentId and userId to 'unknown'", async () => {
+    const registry = new HookRegistry();
+    let received: unknown;
+
+    registry.on("SessionStart", (data) => {
+      received = data;
+    });
+
+    const middleware = createHookMiddleware(registry);
+    await middleware.onSessionStart?.({ sessionId: "s1" });
+
+    expect(received).toEqual({
+      sessionId: "s1",
+      agentId: "unknown",
+      userId: "unknown",
+    });
+  });
+
+  it("onBeforeTurn emits PreMessage event", async () => {
+    const registry = new HookRegistry();
+    let received: unknown;
+
+    registry.on("PreMessage", (data) => {
+      received = data;
+      return { action: "continue" as const };
+    });
+
+    const middleware = createHookMiddleware(registry);
+    await middleware.onBeforeTurn?.({
+      sessionId: "s1",
+      turnNumber: 1,
+      input: "hello",
+    });
+
+    expect(received).toEqual({
+      message: { content: "hello" },
+      channelId: "lifecycle",
+      sessionId: "s1",
+    });
+  });
+
+  it("onBeforeTurn with no input emits empty message", async () => {
+    const registry = new HookRegistry();
+    let received: unknown;
+
+    registry.on("PreMessage", (data) => {
+      received = data;
+      return { action: "continue" as const };
+    });
+
+    const middleware = createHookMiddleware(registry);
+    await middleware.onBeforeTurn?.({
+      sessionId: "s1",
+      turnNumber: 1,
+    });
+
+    expect(received).toEqual({
+      message: {},
+      channelId: "lifecycle",
+      sessionId: "s1",
+    });
+  });
+
+  it("onAfterTurn emits PostMessage event", async () => {
+    const registry = new HookRegistry();
+    let received: unknown;
+
+    registry.on("PostMessage", (data) => {
+      received = data;
+    });
+
+    const middleware = createHookMiddleware(registry);
+    await middleware.onAfterTurn?.({
+      sessionId: "s1",
+      turnNumber: 3,
+      output: "response",
+    });
+
+    expect(received).toEqual({
+      message: { content: "response" },
+      channelId: "lifecycle",
+      messageId: "turn-3",
+      sessionId: "s1",
+    });
+  });
+
+  it("onSessionEnd emits SessionEnd event", async () => {
+    const registry = new HookRegistry();
+    let received: unknown;
+
+    registry.on("SessionEnd", (data) => {
+      received = data;
+    });
+
+    const middleware = createHookMiddleware(registry);
+    await middleware.onSessionEnd?.({
+      sessionId: "s1",
+      agentId: "agent-1",
+      userId: "user-1",
+    });
+
+    expect(received).toEqual({
+      sessionId: "s1",
+      agentId: "agent-1",
+      userId: "user-1",
+      durationMs: 0,
+      turnCount: 0,
+    });
+  });
+
+  it("onSessionEnd defaults agentId and userId to 'unknown'", async () => {
+    const registry = new HookRegistry();
+    let received: unknown;
+
+    registry.on("SessionEnd", (data) => {
+      received = data;
+    });
+
+    const middleware = createHookMiddleware(registry);
+    await middleware.onSessionEnd?.({ sessionId: "s1" });
+
+    expect(received).toEqual({
+      sessionId: "s1",
+      agentId: "unknown",
+      userId: "unknown",
+      durationMs: 0,
+      turnCount: 0,
+    });
+  });
+});

--- a/packages/hooks/src/__tests__/helpers.ts
+++ b/packages/hooks/src/__tests__/helpers.ts
@@ -1,0 +1,217 @@
+import type {
+  BudgetExhaustedData,
+  BudgetWarningData,
+  ContextPressureData,
+  ErrorOccurredData,
+  NodeConnectedData,
+  NodeDisconnectedData,
+  PostMessageData,
+  PostModelCallData,
+  PostToolUseData,
+  PreCompactData,
+  PreMessageData,
+  PreModelCallData,
+  PreModelSelectData,
+  PreToolUseData,
+  SessionEndData,
+  SessionStartData,
+  SubagentEndData,
+  SubagentStartData,
+} from "../types.js";
+
+// ---------------------------------------------------------------------------
+// Interceptor event data factories
+// ---------------------------------------------------------------------------
+
+export function makePreToolUseData(overrides?: Partial<PreToolUseData>): PreToolUseData {
+  return {
+    toolName: "test-tool",
+    args: { key: "value" },
+    sessionId: "session-1",
+    ...overrides,
+  };
+}
+
+export function makePreModelCallData(overrides?: Partial<PreModelCallData>): PreModelCallData {
+  return {
+    model: "test-model",
+    messages: [{ role: "user", content: "hello" }],
+    config: { temperature: 0.7 },
+    sessionId: "session-1",
+    ...overrides,
+  };
+}
+
+export function makePreModelSelectData(
+  overrides?: Partial<PreModelSelectData>,
+): PreModelSelectData {
+  return {
+    candidates: ["model-a", "model-b"],
+    context: { taskType: "generation" },
+    sessionId: "session-1",
+    ...overrides,
+  };
+}
+
+export function makePreMessageData(overrides?: Partial<PreMessageData>): PreMessageData {
+  return {
+    message: { text: "hello" },
+    channelId: "channel-1",
+    sessionId: "session-1",
+    ...overrides,
+  };
+}
+
+export function makeBudgetExhaustedData(
+  overrides?: Partial<BudgetExhaustedData>,
+): BudgetExhaustedData {
+  return {
+    budget: 100,
+    spent: 100,
+    remaining: 0,
+    agentId: "agent-1",
+    ...overrides,
+  };
+}
+
+export function makePreCompactData(overrides?: Partial<PreCompactData>): PreCompactData {
+  return {
+    sessionId: "session-1",
+    currentTokens: 8000,
+    maxTokens: 10000,
+    preservedIds: ["msg-1", "msg-2"],
+    injections: [{ type: "system", content: "context" }],
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Observer event data factories
+// ---------------------------------------------------------------------------
+
+export function makePostToolUseData(overrides?: Partial<PostToolUseData>): PostToolUseData {
+  return {
+    toolName: "test-tool",
+    args: { key: "value" },
+    result: "ok",
+    durationMs: 100,
+    sessionId: "session-1",
+    ...overrides,
+  };
+}
+
+export function makePostModelCallData(overrides?: Partial<PostModelCallData>): PostModelCallData {
+  return {
+    model: "test-model",
+    response: { text: "response" },
+    usage: { promptTokens: 100, completionTokens: 50 },
+    durationMs: 200,
+    sessionId: "session-1",
+    ...overrides,
+  };
+}
+
+export function makePostMessageData(overrides?: Partial<PostMessageData>): PostMessageData {
+  return {
+    message: { text: "hello" },
+    channelId: "channel-1",
+    messageId: "msg-1",
+    sessionId: "session-1",
+    ...overrides,
+  };
+}
+
+export function makeSessionStartData(overrides?: Partial<SessionStartData>): SessionStartData {
+  return {
+    sessionId: "session-1",
+    agentId: "agent-1",
+    userId: "user-1",
+    ...overrides,
+  };
+}
+
+export function makeSessionEndData(overrides?: Partial<SessionEndData>): SessionEndData {
+  return {
+    sessionId: "session-1",
+    agentId: "agent-1",
+    userId: "user-1",
+    durationMs: 5000,
+    turnCount: 3,
+    ...overrides,
+  };
+}
+
+export function makeBudgetWarningData(overrides?: Partial<BudgetWarningData>): BudgetWarningData {
+  return {
+    budget: 100,
+    spent: 80,
+    remaining: 20,
+    threshold: 0.8,
+    agentId: "agent-1",
+    ...overrides,
+  };
+}
+
+export function makeErrorOccurredData(overrides?: Partial<ErrorOccurredData>): ErrorOccurredData {
+  return {
+    error: new Error("test error"),
+    sessionId: "session-1",
+    ...overrides,
+  };
+}
+
+export function makeContextPressureData(
+  overrides?: Partial<ContextPressureData>,
+): ContextPressureData {
+  return {
+    used: 8000,
+    total: 10000,
+    percentage: 80,
+    sessionId: "session-1",
+    ...overrides,
+  };
+}
+
+export function makeNodeConnectedData(overrides?: Partial<NodeConnectedData>): NodeConnectedData {
+  return {
+    nodeId: "node-1",
+    sessionId: "session-1",
+    capabilities: { compute: true },
+    ...overrides,
+  };
+}
+
+export function makeNodeDisconnectedData(
+  overrides?: Partial<NodeDisconnectedData>,
+): NodeDisconnectedData {
+  return {
+    nodeId: "node-1",
+    sessionId: "session-1",
+    reason: "timeout",
+    ...overrides,
+  };
+}
+
+export function makeSubagentStartData(overrides?: Partial<SubagentStartData>): SubagentStartData {
+  return {
+    subagentId: "sub-1",
+    parentSessionId: "session-1",
+    sessionId: "sub-session-1",
+    task: "research",
+    model: "test-model",
+    ...overrides,
+  };
+}
+
+export function makeSubagentEndData(overrides?: Partial<SubagentEndData>): SubagentEndData {
+  return {
+    subagentId: "sub-1",
+    parentSessionId: "session-1",
+    sessionId: "sub-session-1",
+    task: "research",
+    result: { summary: "done" },
+    durationMs: 3000,
+    exitReason: "completed",
+    ...overrides,
+  };
+}

--- a/packages/hooks/src/__tests__/match.test.ts
+++ b/packages/hooks/src/__tests__/match.test.ts
@@ -1,0 +1,179 @@
+import { HookExecutionError } from "@templar/errors";
+import { describe, expect, it, vi } from "vitest";
+import { CONTINUE_RESULT, HOOK_PRIORITY } from "../constants.js";
+import { HookRegistry } from "../registry.js";
+import type { PreToolUseData } from "../types.js";
+import { makePostToolUseData, makePreToolUseData } from "./helpers.js";
+
+describe("HookRegistry — match predicate (interceptor)", () => {
+  it("handler called when match returns true", async () => {
+    const registry = new HookRegistry();
+    let called = false;
+
+    registry.on(
+      "PreToolUse",
+      () => {
+        called = true;
+        return CONTINUE_RESULT;
+      },
+      { match: () => true },
+    );
+
+    await registry.emit("PreToolUse", makePreToolUseData());
+    expect(called).toBe(true);
+  });
+
+  it("handler skipped when match returns false", async () => {
+    const registry = new HookRegistry();
+    let called = false;
+
+    registry.on(
+      "PreToolUse",
+      () => {
+        called = true;
+        return CONTINUE_RESULT;
+      },
+      { match: () => false },
+    );
+
+    const result = await registry.emit("PreToolUse", makePreToolUseData());
+    expect(called).toBe(false);
+    expect(result).toEqual({ action: "continue" });
+  });
+
+  it("match receives current (waterfalled) data", async () => {
+    const registry = new HookRegistry();
+    let matchReceivedData: unknown;
+
+    registry.on(
+      "PreToolUse",
+      (data) => ({
+        action: "modify" as const,
+        data: { ...data, toolName: "modified-tool" },
+      }),
+      { priority: HOOK_PRIORITY.HIGH },
+    );
+
+    registry.on("PreToolUse", () => CONTINUE_RESULT, {
+      priority: HOOK_PRIORITY.LOW,
+      match: (data) => {
+        matchReceivedData = data;
+        return true;
+      },
+    });
+
+    await registry.emit("PreToolUse", makePreToolUseData());
+    expect((matchReceivedData as PreToolUseData).toolName).toBe("modified-tool");
+  });
+
+  it("no match option means handler always called", async () => {
+    const registry = new HookRegistry();
+    let called = false;
+
+    registry.on("PreToolUse", () => {
+      called = true;
+      return CONTINUE_RESULT;
+    });
+
+    await registry.emit("PreToolUse", makePreToolUseData());
+    expect(called).toBe(true);
+  });
+
+  it("match predicate throwing wraps in HookExecutionError", async () => {
+    const registry = new HookRegistry();
+
+    registry.on("PreToolUse", () => CONTINUE_RESULT, {
+      match: () => {
+        throw new Error("match boom");
+      },
+    });
+
+    await expect(registry.emit("PreToolUse", makePreToolUseData())).rejects.toThrow(
+      HookExecutionError,
+    );
+    await expect(registry.emit("PreToolUse", makePreToolUseData())).rejects.toThrow(
+      /match predicate threw/,
+    );
+  });
+});
+
+describe("HookRegistry — match predicate (observer)", () => {
+  it("handler called when match returns true", async () => {
+    const registry = new HookRegistry();
+    let called = false;
+
+    registry.on(
+      "PostToolUse",
+      () => {
+        called = true;
+      },
+      { match: () => true },
+    );
+
+    await registry.emit("PostToolUse", makePostToolUseData());
+    expect(called).toBe(true);
+  });
+
+  it("handler skipped when match returns false", async () => {
+    const registry = new HookRegistry();
+    let called = false;
+
+    registry.on(
+      "PostToolUse",
+      () => {
+        called = true;
+      },
+      { match: () => false },
+    );
+
+    await registry.emit("PostToolUse", makePostToolUseData());
+    expect(called).toBe(false);
+  });
+
+  it("match predicate throwing reports via onObserverError", async () => {
+    const errors: Error[] = [];
+    const registry = new HookRegistry({
+      onObserverError: (_event, error) => {
+        errors.push(error);
+      },
+    });
+
+    registry.on(
+      "PostToolUse",
+      () => {
+        // should not be called
+      },
+      {
+        match: () => {
+          throw new Error("match boom");
+        },
+      },
+    );
+
+    await registry.emit("PostToolUse", makePostToolUseData());
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.message).toBe("match boom");
+  });
+
+  it("match predicate throwing without callback logs to console.warn", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const registry = new HookRegistry();
+
+    registry.on(
+      "PostToolUse",
+      () => {
+        // should not be called
+      },
+      {
+        match: () => {
+          throw new Error("match boom");
+        },
+      },
+    );
+
+    await registry.emit("PostToolUse", makePostToolUseData());
+    expect(warnSpy).toHaveBeenCalledOnce();
+    expect(warnSpy.mock.calls[0]?.[0]).toContain("match predicate error");
+    warnSpy.mockRestore();
+  });
+});

--- a/packages/hooks/src/__tests__/once.test.ts
+++ b/packages/hooks/src/__tests__/once.test.ts
@@ -1,0 +1,219 @@
+import { HookExecutionError, HookReentrancyError } from "@templar/errors";
+import { describe, expect, it } from "vitest";
+import { CONTINUE_RESULT, HOOK_PRIORITY } from "../constants.js";
+import { HookRegistry } from "../registry.js";
+import { makePostToolUseData, makePreToolUseData } from "./helpers.js";
+
+describe("HookRegistry — once() interceptor", () => {
+  it("fires once then is removed", async () => {
+    const registry = new HookRegistry();
+    let callCount = 0;
+
+    registry.once("PreToolUse", () => {
+      callCount++;
+      return CONTINUE_RESULT;
+    });
+
+    await registry.emit("PreToolUse", makePreToolUseData());
+    await registry.emit("PreToolUse", makePreToolUseData());
+
+    expect(callCount).toBe(1);
+    expect(registry.handlerCount("PreToolUse")).toBe(0);
+  });
+
+  it("disposer before fire prevents execution", async () => {
+    const registry = new HookRegistry();
+    let called = false;
+
+    const dispose = registry.once("PreToolUse", () => {
+      called = true;
+      return CONTINUE_RESULT;
+    });
+
+    dispose();
+    await registry.emit("PreToolUse", makePreToolUseData());
+
+    expect(called).toBe(false);
+    expect(registry.handlerCount("PreToolUse")).toBe(0);
+  });
+
+  it("coexists with on() handlers", async () => {
+    const registry = new HookRegistry();
+    const calls: string[] = [];
+
+    registry.on("PreToolUse", () => {
+      calls.push("persistent");
+      return CONTINUE_RESULT;
+    });
+    registry.once("PreToolUse", () => {
+      calls.push("once");
+      return CONTINUE_RESULT;
+    });
+
+    await registry.emit("PreToolUse", makePreToolUseData());
+    expect(calls).toEqual(["persistent", "once"]);
+
+    calls.length = 0;
+    await registry.emit("PreToolUse", makePreToolUseData());
+    expect(calls).toEqual(["persistent"]);
+    expect(registry.handlerCount("PreToolUse")).toBe(1);
+  });
+
+  it("respects priority ordering", async () => {
+    const registry = new HookRegistry();
+    const order: string[] = [];
+
+    registry.once(
+      "PreToolUse",
+      () => {
+        order.push("once-low");
+        return CONTINUE_RESULT;
+      },
+      { priority: HOOK_PRIORITY.LOW },
+    );
+    registry.once(
+      "PreToolUse",
+      () => {
+        order.push("once-high");
+        return CONTINUE_RESULT;
+      },
+      { priority: HOOK_PRIORITY.HIGH },
+    );
+
+    await registry.emit("PreToolUse", makePreToolUseData());
+    expect(order).toEqual(["once-high", "once-low"]);
+  });
+
+  it("once + match: not consumed when match returns false", async () => {
+    const registry = new HookRegistry();
+    let callCount = 0;
+
+    registry.once(
+      "PreToolUse",
+      () => {
+        callCount++;
+        return CONTINUE_RESULT;
+      },
+      { match: (data) => data.toolName === "target-tool" },
+    );
+
+    // First emit: match=false, handler not consumed
+    await registry.emit("PreToolUse", makePreToolUseData({ toolName: "other-tool" }));
+    expect(callCount).toBe(0);
+    expect(registry.handlerCount("PreToolUse")).toBe(1);
+
+    // Second emit: match=true, handler fires and is removed
+    await registry.emit("PreToolUse", makePreToolUseData({ toolName: "target-tool" }));
+    expect(callCount).toBe(1);
+    expect(registry.handlerCount("PreToolUse")).toBe(0);
+  });
+
+  it("once + throw: handler is still removed", async () => {
+    const registry = new HookRegistry();
+
+    registry.once("PreToolUse", () => {
+      throw new Error("boom");
+    });
+
+    await expect(registry.emit("PreToolUse", makePreToolUseData())).rejects.toThrow(
+      HookExecutionError,
+    );
+    expect(registry.handlerCount("PreToolUse")).toBe(0);
+  });
+
+  it("multiple once handlers all fire and are removed", async () => {
+    const registry = new HookRegistry();
+    let count = 0;
+
+    registry.once("PreToolUse", () => {
+      count++;
+      return CONTINUE_RESULT;
+    });
+    registry.once("PreToolUse", () => {
+      count++;
+      return CONTINUE_RESULT;
+    });
+    registry.once("PreToolUse", () => {
+      count++;
+      return CONTINUE_RESULT;
+    });
+
+    await registry.emit("PreToolUse", makePreToolUseData());
+    expect(count).toBe(3);
+    expect(registry.handlerCount("PreToolUse")).toBe(0);
+  });
+});
+
+describe("HookRegistry — once() observer", () => {
+  it("fires once then is removed", async () => {
+    const registry = new HookRegistry();
+    let callCount = 0;
+
+    registry.once("PostToolUse", () => {
+      callCount++;
+    });
+
+    await registry.emit("PostToolUse", makePostToolUseData());
+    await registry.emit("PostToolUse", makePostToolUseData());
+
+    expect(callCount).toBe(1);
+    expect(registry.handlerCount("PostToolUse")).toBe(0);
+  });
+
+  it("once observer + throw: handler is still removed", async () => {
+    const errors: Error[] = [];
+    const registry = new HookRegistry({
+      onObserverError: (_event, error) => {
+        errors.push(error);
+      },
+    });
+
+    registry.once("PostToolUse", () => {
+      throw new Error("observer boom");
+    });
+
+    await registry.emit("PostToolUse", makePostToolUseData());
+    expect(errors).toHaveLength(1);
+    expect(registry.handlerCount("PostToolUse")).toBe(0);
+
+    // Second emit: handler gone, no error
+    errors.length = 0;
+    await registry.emit("PostToolUse", makePostToolUseData());
+    expect(errors).toHaveLength(0);
+  });
+
+  it("once + match: not consumed when match returns false", async () => {
+    const registry = new HookRegistry();
+    let callCount = 0;
+
+    registry.once(
+      "PostToolUse",
+      () => {
+        callCount++;
+      },
+      { match: (data) => data.toolName === "target" },
+    );
+
+    await registry.emit("PostToolUse", makePostToolUseData({ toolName: "other" }));
+    expect(callCount).toBe(0);
+    expect(registry.handlerCount("PostToolUse")).toBe(1);
+
+    await registry.emit("PostToolUse", makePostToolUseData({ toolName: "target" }));
+    expect(callCount).toBe(1);
+    expect(registry.handlerCount("PostToolUse")).toBe(0);
+  });
+
+  it("once observer + re-entrancy error: handler is still removed", async () => {
+    const registry = new HookRegistry({ maxDepth: 1 });
+
+    registry.once("PostToolUse", async () => {
+      // Re-entrant emit at depth 2 exceeds maxDepth 1
+      await registry.emit("PostToolUse", makePostToolUseData());
+    });
+
+    await expect(registry.emit("PostToolUse", makePostToolUseData())).rejects.toThrow(
+      HookReentrancyError,
+    );
+    expect(registry.handlerCount("PostToolUse")).toBe(0);
+  });
+});

--- a/packages/hooks/src/__tests__/smoke.test.ts
+++ b/packages/hooks/src/__tests__/smoke.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import { CONTINUE_RESULT } from "../constants.js";
+import { HookRegistry } from "../registry.js";
+import type { InterceptorEvent, ObserverEvent } from "../types.js";
+import {
+  makeBudgetExhaustedData,
+  makeBudgetWarningData,
+  makeContextPressureData,
+  makeErrorOccurredData,
+  makeNodeConnectedData,
+  makeNodeDisconnectedData,
+  makePostMessageData,
+  makePostModelCallData,
+  makePostToolUseData,
+  makePreCompactData,
+  makePreMessageData,
+  makePreModelCallData,
+  makePreModelSelectData,
+  makePreToolUseData,
+  makeSessionEndData,
+  makeSessionStartData,
+  makeSubagentEndData,
+  makeSubagentStartData,
+} from "./helpers.js";
+
+// ---------------------------------------------------------------------------
+// Interceptor event smoke tests
+// ---------------------------------------------------------------------------
+
+const interceptorCases: Array<{ event: InterceptorEvent; factory: () => unknown }> = [
+  { event: "PreToolUse", factory: makePreToolUseData },
+  { event: "PreModelCall", factory: makePreModelCallData },
+  { event: "PreModelSelect", factory: makePreModelSelectData },
+  { event: "PreMessage", factory: makePreMessageData },
+  { event: "BudgetExhausted", factory: makeBudgetExhaustedData },
+  { event: "PreCompact", factory: makePreCompactData },
+];
+
+describe("Smoke — interceptor events", () => {
+  it.each(interceptorCases)("$event: register, emit, verify HookResult", async ({
+    event,
+    factory,
+  }) => {
+    const registry = new HookRegistry();
+    let called = false;
+
+    // biome-ignore lint/suspicious/noExplicitAny: dynamic event registration
+    registry.on(event as any, () => {
+      called = true;
+      return CONTINUE_RESULT;
+    });
+
+    // biome-ignore lint/suspicious/noExplicitAny: dynamic event emit
+    const result = await registry.emit(event as any, factory() as any);
+    expect(called).toBe(true);
+    expect(result).toEqual({ action: "continue" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Observer event smoke tests
+// ---------------------------------------------------------------------------
+
+const observerCases: Array<{ event: ObserverEvent; factory: () => unknown }> = [
+  { event: "PostToolUse", factory: makePostToolUseData },
+  { event: "PostModelCall", factory: makePostModelCallData },
+  { event: "PostMessage", factory: makePostMessageData },
+  { event: "SessionStart", factory: makeSessionStartData },
+  { event: "SessionEnd", factory: makeSessionEndData },
+  { event: "BudgetWarning", factory: makeBudgetWarningData },
+  { event: "ErrorOccurred", factory: makeErrorOccurredData },
+  { event: "ContextPressure", factory: makeContextPressureData },
+  { event: "NodeConnected", factory: makeNodeConnectedData },
+  { event: "NodeDisconnected", factory: makeNodeDisconnectedData },
+  { event: "SubagentStart", factory: makeSubagentStartData },
+  { event: "SubagentEnd", factory: makeSubagentEndData },
+];
+
+describe("Smoke — observer events", () => {
+  it.each(observerCases)("$event: register, emit, verify void", async ({ event, factory }) => {
+    const registry = new HookRegistry();
+    let called = false;
+
+    // biome-ignore lint/suspicious/noExplicitAny: dynamic event registration
+    registry.on(event as any, () => {
+      called = true;
+    });
+
+    // biome-ignore lint/suspicious/noExplicitAny: dynamic event emit
+    const result = await registry.emit(event as any, factory() as any);
+    expect(called).toBe(true);
+    expect(result).toBeUndefined();
+  });
+});

--- a/packages/hooks/src/__tests__/validation.test.ts
+++ b/packages/hooks/src/__tests__/validation.test.ts
@@ -1,0 +1,95 @@
+import { HookExecutionError } from "@templar/errors";
+import { describe, expect, it } from "vitest";
+import { CONTINUE_RESULT } from "../constants.js";
+import { HookRegistry } from "../registry.js";
+import { makePreToolUseData } from "./helpers.js";
+
+describe("HookRegistry — interceptor return validation", () => {
+  it("handler returning null throws HookExecutionError", async () => {
+    const registry = new HookRegistry();
+    // biome-ignore lint/suspicious/noExplicitAny: testing invalid return
+    registry.on("PreToolUse", () => null as any);
+
+    await expect(registry.emit("PreToolUse", makePreToolUseData())).rejects.toThrow(
+      HookExecutionError,
+    );
+    await expect(registry.emit("PreToolUse", makePreToolUseData())).rejects.toThrow(/null/);
+  });
+
+  it("handler returning undefined throws HookExecutionError", async () => {
+    const registry = new HookRegistry();
+    // biome-ignore lint/suspicious/noExplicitAny: testing invalid return
+    registry.on("PreToolUse", () => undefined as any);
+
+    await expect(registry.emit("PreToolUse", makePreToolUseData())).rejects.toThrow(
+      HookExecutionError,
+    );
+    await expect(registry.emit("PreToolUse", makePreToolUseData())).rejects.toThrow(/undefined/);
+  });
+
+  it("handler returning a string throws HookExecutionError", async () => {
+    const registry = new HookRegistry();
+    // biome-ignore lint/suspicious/noExplicitAny: testing invalid return
+    registry.on("PreToolUse", () => "invalid" as any);
+
+    await expect(registry.emit("PreToolUse", makePreToolUseData())).rejects.toThrow(
+      HookExecutionError,
+    );
+    await expect(registry.emit("PreToolUse", makePreToolUseData())).rejects.toThrow(
+      /non-HookResult/,
+    );
+  });
+
+  it("handler returning object without action throws HookExecutionError", async () => {
+    const registry = new HookRegistry();
+    // biome-ignore lint/suspicious/noExplicitAny: testing invalid return
+    registry.on("PreToolUse", () => ({ foo: "bar" }) as any);
+
+    await expect(registry.emit("PreToolUse", makePreToolUseData())).rejects.toThrow(
+      HookExecutionError,
+    );
+  });
+
+  it("handler returning unknown action throws HookExecutionError", async () => {
+    const registry = new HookRegistry();
+    // biome-ignore lint/suspicious/noExplicitAny: testing invalid return
+    registry.on("PreToolUse", () => ({ action: "unknown" }) as any);
+
+    await expect(registry.emit("PreToolUse", makePreToolUseData())).rejects.toThrow(
+      HookExecutionError,
+    );
+    await expect(registry.emit("PreToolUse", makePreToolUseData())).rejects.toThrow(
+      /unknown action/,
+    );
+  });
+
+  it("valid continue result passes", async () => {
+    const registry = new HookRegistry();
+    registry.on("PreToolUse", () => CONTINUE_RESULT);
+
+    const result = await registry.emit("PreToolUse", makePreToolUseData());
+    expect(result).toEqual({ action: "continue" });
+  });
+
+  it("valid block result passes", async () => {
+    const registry = new HookRegistry();
+    registry.on("PreToolUse", () => ({ action: "block" as const, reason: "test" }));
+
+    const result = await registry.emit("PreToolUse", makePreToolUseData());
+    expect(result).toEqual({ action: "block", reason: "test" });
+  });
+
+  it("valid modify result passes", async () => {
+    const registry = new HookRegistry();
+    registry.on("PreToolUse", (data) => ({
+      action: "modify" as const,
+      data: { ...data, toolName: "modified" },
+    }));
+
+    const result = await registry.emit("PreToolUse", makePreToolUseData());
+    expect(result).toEqual({
+      action: "modify",
+      data: expect.objectContaining({ toolName: "modified" }),
+    });
+  });
+});

--- a/packages/hooks/src/__tests__/waterfall.test.ts
+++ b/packages/hooks/src/__tests__/waterfall.test.ts
@@ -1,20 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { CONTINUE_RESULT, HOOK_PRIORITY } from "../constants.js";
 import { HookRegistry } from "../registry.js";
-import type { PreToolUseData } from "../types.js";
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function makePreToolUseData(overrides?: Partial<PreToolUseData>): PreToolUseData {
-  return {
-    toolName: "test-tool",
-    args: { key: "value" },
-    sessionId: "session-1",
-    ...overrides,
-  };
-}
+import { makePreToolUseData } from "./helpers.js";
 
 // ---------------------------------------------------------------------------
 // Waterfall modify chain
@@ -66,7 +53,7 @@ describe("HookRegistry — waterfall modify chain", () => {
 
   it("modify then block — block receives modified data", async () => {
     const registry = new HookRegistry();
-    let blockReceivedData: PreToolUseData | undefined;
+    let blockReceivedData: unknown;
 
     registry.on(
       "PreToolUse",
@@ -88,7 +75,7 @@ describe("HookRegistry — waterfall modify chain", () => {
 
     const result = await registry.emit("PreToolUse", makePreToolUseData());
     expect(result).toEqual({ action: "block", reason: "blocked" });
-    expect(blockReceivedData?.toolName).toBe("modified");
+    expect((blockReceivedData as { toolName: string }).toolName).toBe("modified");
   });
 
   it("block then modify — second hook never runs (short-circuit)", async () => {

--- a/packages/hooks/src/bridge.ts
+++ b/packages/hooks/src/bridge.ts
@@ -1,0 +1,52 @@
+import type { SessionContext, TemplarMiddleware, TurnContext } from "@templar/core";
+import type { HookRegistry } from "./registry.js";
+
+/**
+ * Creates a TemplarMiddleware that bridges lifecycle events into the HookRegistry.
+ *
+ * Mapping:
+ * - `onSessionStart` → emit `SessionStart`
+ * - `onBeforeTurn`   → emit `PreMessage` (thin default mapping)
+ * - `onAfterTurn`    → emit `PostMessage`
+ * - `onSessionEnd`   → emit `SessionEnd`
+ */
+export function createHookMiddleware(registry: HookRegistry): TemplarMiddleware {
+  return {
+    name: "@templar/hooks/bridge",
+
+    async onSessionStart(context: SessionContext): Promise<void> {
+      await registry.emit("SessionStart", {
+        sessionId: context.sessionId,
+        agentId: context.agentId ?? "unknown",
+        userId: context.userId ?? "unknown",
+      });
+    },
+
+    async onBeforeTurn(context: TurnContext): Promise<void> {
+      await registry.emit("PreMessage", {
+        message: context.input != null ? { content: context.input } : {},
+        channelId: "lifecycle",
+        sessionId: context.sessionId,
+      });
+    },
+
+    async onAfterTurn(context: TurnContext): Promise<void> {
+      await registry.emit("PostMessage", {
+        message: context.output != null ? { content: context.output } : {},
+        channelId: "lifecycle",
+        messageId: `turn-${String(context.turnNumber)}`,
+        sessionId: context.sessionId,
+      });
+    },
+
+    async onSessionEnd(context: SessionContext): Promise<void> {
+      await registry.emit("SessionEnd", {
+        sessionId: context.sessionId,
+        agentId: context.agentId ?? "unknown",
+        userId: context.userId ?? "unknown",
+        durationMs: 0,
+        turnCount: 0,
+      });
+    },
+  };
+}

--- a/packages/hooks/src/constants.ts
+++ b/packages/hooks/src/constants.ts
@@ -8,12 +8,12 @@ export const HOOK_PRIORITY = {
   CRITICAL: 0,
   /** Priority 25 — runs early, for important interceptors */
   HIGH: 25,
-  /** Priority 50 — default priority */
-  NORMAL: 50,
-  /** Priority 75 — runs late, for non-critical observers */
-  LOW: 75,
-  /** Priority 100 — runs last, for monitoring/logging */
-  MONITOR: 100,
+  /** Priority 100 — default priority */
+  NORMAL: 100,
+  /** Priority 200 — runs late, for non-critical observers */
+  LOW: 200,
+  /** Priority 500 — runs last, for monitoring/logging */
+  MONITOR: 500,
 } as const;
 
 /** Default timeout for hook handlers in milliseconds */
@@ -34,4 +34,5 @@ export const INTERCEPTOR_EVENTS = [
   "PreModelSelect",
   "PreMessage",
   "BudgetExhausted",
+  "PreCompact",
 ] as const;

--- a/packages/hooks/src/index.ts
+++ b/packages/hooks/src/index.ts
@@ -1,5 +1,7 @@
 export const PACKAGE_NAME = "@templar/hooks" as const;
 
+// Bridge
+export { createHookMiddleware } from "./bridge.js";
 // Constants
 export {
   CONTINUE_RESULT,
@@ -34,10 +36,13 @@ export type {
   PostMessageData,
   PostModelCallData,
   PostToolUseData,
+  PreCompactData,
   PreMessageData,
   PreModelCallData,
   PreModelSelectData,
   PreToolUseData,
   SessionEndData,
   SessionStartData,
+  SubagentEndData,
+  SubagentStartData,
 } from "./types.js";

--- a/packages/hooks/src/types.ts
+++ b/packages/hooks/src/types.ts
@@ -34,6 +34,14 @@ export interface BudgetExhaustedData {
   readonly agentId: string;
 }
 
+export interface PreCompactData {
+  readonly sessionId: string;
+  readonly currentTokens: number;
+  readonly maxTokens: number;
+  readonly preservedIds: readonly string[];
+  readonly injections: readonly Record<string, unknown>[];
+}
+
 // ---------------------------------------------------------------------------
 // Observer Event Data (observe only)
 // ---------------------------------------------------------------------------
@@ -108,6 +116,24 @@ export interface NodeDisconnectedData {
   readonly reason: string;
 }
 
+export interface SubagentStartData {
+  readonly subagentId: string;
+  readonly parentSessionId: string;
+  readonly sessionId: string;
+  readonly task: string;
+  readonly model: string;
+}
+
+export interface SubagentEndData {
+  readonly subagentId: string;
+  readonly parentSessionId: string;
+  readonly sessionId: string;
+  readonly task: string;
+  readonly result: unknown;
+  readonly durationMs: number;
+  readonly exitReason: string;
+}
+
 // ---------------------------------------------------------------------------
 // Event Maps
 // ---------------------------------------------------------------------------
@@ -119,6 +145,7 @@ export interface InterceptorEventMap {
   readonly PreModelSelect: PreModelSelectData;
   readonly PreMessage: PreMessageData;
   readonly BudgetExhausted: BudgetExhaustedData;
+  readonly PreCompact: PreCompactData;
 }
 
 /** Events that are observe-only (no blocking or modification) */
@@ -133,9 +160,11 @@ export interface ObserverEventMap {
   readonly ContextPressure: ContextPressureData;
   readonly NodeConnected: NodeConnectedData;
   readonly NodeDisconnected: NodeDisconnectedData;
+  readonly SubagentStart: SubagentStartData;
+  readonly SubagentEnd: SubagentEndData;
 }
 
-/** Combined event map — all 15 hook events */
+/** Combined event map — all 18 hook events */
 export type HookEventMap = InterceptorEventMap & ObserverEventMap;
 
 /** All hook event names */
@@ -167,9 +196,10 @@ export interface HookContext {
 }
 
 /** Options for hook registration */
-export interface HookOptions {
+export interface HookOptions<T = unknown> {
   readonly priority?: number;
   readonly timeout?: number;
+  readonly match?: (data: T) => boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -195,7 +225,7 @@ export interface HookRegistryConfig {
   readonly maxDepth?: number;
   /** Default timeout for hook handlers in ms (default: 30_000) */
   readonly defaultTimeout?: number;
-  /** Callback invoked when an observer handler throws (instead of console.error) */
+  /** Callback invoked when an observer handler throws (instead of console.warn) */
   readonly onObserverError?: (event: string, error: Error) => void;
 }
 
@@ -208,4 +238,6 @@ export interface HandlerEntry {
   readonly handler: InterceptorHandler<unknown> | ObserverHandler<unknown>;
   readonly priority: number;
   readonly timeout: number;
+  readonly once: boolean;
+  readonly match?: (data: unknown) => boolean;
 }

--- a/packages/hooks/tsconfig.json
+++ b/packages/hooks/tsconfig.json
@@ -6,5 +6,5 @@
     "types": ["node"]
   },
   "include": ["src"],
-  "references": [{ "path": "../errors" }]
+  "references": [{ "path": "../errors" }, { "path": "../core" }]
 }

--- a/packages/hooks/vitest.config.ts
+++ b/packages/hooks/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: "v8",
+      include: ["src/**/*.ts"],
+      exclude: ["src/**/__tests__/**", "src/**/index.ts"],
+      thresholds: {
+        branches: 80,
+        functions: 80,
+        lines: 80,
+        statements: 80,
+      },
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -192,6 +192,9 @@ importers:
 
   packages/hooks:
     dependencies:
+      '@templar/core':
+        specifier: workspace:*
+        version: link:../core
       '@templar/errors':
         specifier: workspace:*
         version: link:../errors


### PR DESCRIPTION
## Summary

- **3 new event types**: `PreCompact` (interceptor), `SubagentStart`/`SubagentEnd` (observer) — 18 total events (6 interceptor + 12 observer)
- **`match` predicate** on `HookOptions` — filter handler execution by data content; waterfalled data in interceptors
- **`once()` method** — auto-removed after first fire, respects match predicates, cleanup on throw via `try/finally`
- **Runtime validation** of interceptor handler returns (null, undefined, non-object, unknown action → `HookExecutionError`)
- **`console.warn` default** for unhandled observer errors (previously silently swallowed)
- **Bridge adapter** (`createHookMiddleware`) — connects `TemplarMiddleware` lifecycle hooks to `HookRegistry` events
- **Priority bands widened**: `NORMAL:100`, `LOW:200`, `MONITOR:500` (was 50/75/100)
- **Shared test helpers** — 18 factory functions extracted to `helpers.ts`
- **Parameterized smoke tests** for all 18 events via `it.each`
- **Vitest benchmarks** — emit 0/1/10 handlers, waterfall, concurrent, lifecycle
- **`vitest.config.ts`** with v8 coverage provider and 80% thresholds

### New files (9)
`vitest.config.ts`, `bridge.ts`, `helpers.ts`, `smoke.test.ts`, `match.test.ts`, `once.test.ts`, `validation.test.ts`, `bridge.test.ts`, `bench.bench.ts`

### Modified files (10)
`types.ts`, `constants.ts`, `registry.ts`, `index.ts`, `package.json`, `tsconfig.json`, `registry.test.ts`, `edge-cases.test.ts`, `waterfall.test.ts`, `pnpm-lock.yaml`

## Test plan

- [x] 128/128 tests pass across 9 test files
- [x] 99.37% statement coverage, 96.03% branch, 100% functions, 100% lines
- [x] TypeScript strict mode clean (`exactOptionalPropertyTypes`, `isolatedDeclarations`)
- [x] Biome lint clean (0 errors, 0 warnings)
- [x] Full monorepo build passes (20/20 tasks)
- [x] Benchmarks run: ~2.2M ops/s zero-handler, ~64K ops/s 10-handler, ~341K ops/s lifecycle cycle
- [ ] Verify no downstream consumers break (no consumers yet — this is the cheapest time for breaking changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)