### PR TITLE
feat(telemetry): add OTel distributed tracing

### DIFF
--- a/packages/middleware/package.json
+++ b/packages/middleware/package.json
@@ -32,11 +32,14 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@opentelemetry/api": "^1.9.0",
     "@templar/core": "workspace:*",
     "@nexus/sdk": "workspace:*",
     "@templar/errors": "workspace:*"
   },
   "devDependencies": {
+    "@opentelemetry/sdk-trace-base": "^1.30.0",
+    "@opentelemetry/sdk-trace-node": "^1.30.0",
     "@templar/test-utils": "workspace:*",
     "@types/node": "^25.2.2"
   }

--- a/packages/middleware/src/audit/types.ts
+++ b/packages/middleware/src/audit/types.ts
@@ -192,8 +192,10 @@ interface BaseAuditEvent {
   readonly timestamp: string;
   /** Session this event belongs to */
   readonly sessionId: string;
-  /** Boundary tracing span ID (correlates before/after turn) */
+  /** Boundary tracing span ID (correlates before/after turn, or OTel spanId when available) */
   readonly spanId: string;
+  /** OTel trace ID for distributed tracing (present when OTel is active) */
+  readonly traceId?: string;
   /** Agent that generated the event */
   readonly agentId?: string;
 }

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@templar/telemetry",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check .",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/sdk-node": "^0.57.0",
+    "@opentelemetry/sdk-trace-base": "^1.30.0",
+    "@opentelemetry/sdk-trace-node": "^1.30.0",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.57.0",
+    "@opentelemetry/instrumentation-undici": "^0.10.0",
+    "@opentelemetry/resources": "^1.30.0",
+    "@opentelemetry/semantic-conventions": "^1.28.0"
+  },
+  "peerDependencies": {
+    "@templar/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@templar/test-utils": "workspace:*",
+    "@types/node": "^25.2.2"
+  }
+}

--- a/packages/telemetry/src/__tests__/integration.test.ts
+++ b/packages/telemetry/src/__tests__/integration.test.ts
@@ -1,0 +1,150 @@
+import { SpanStatusCode, trace } from "@opentelemetry/api";
+import { InMemorySpanExporter, SimpleSpanProcessor } from "@opentelemetry/sdk-trace-base";
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
+import type { TemplarMiddleware } from "@templar/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { withSpan } from "../span-helpers.js";
+import { withTracing } from "../traced-middleware.js";
+
+describe("integration: span hierarchy", () => {
+  let exporter: InMemorySpanExporter;
+  let provider: NodeTracerProvider;
+
+  beforeEach(() => {
+    exporter = new InMemorySpanExporter();
+    provider = new NodeTracerProvider();
+    provider.addSpanProcessor(new SimpleSpanProcessor(exporter));
+    trace.disable(); // Clear any previous global provider
+    provider.register();
+  });
+
+  afterEach(async () => {
+    trace.disable();
+    exporter.reset();
+    await provider.shutdown();
+  });
+
+  it("should create a full agent turn span hierarchy", async () => {
+    // Simulate: agent.turn → middleware.session_start → middleware.before_turn → middleware.after_turn
+
+    const middleware: TemplarMiddleware = {
+      name: "audit",
+      async onSessionStart() {},
+      async onBeforeTurn() {},
+      async onAfterTurn() {},
+      async onSessionEnd() {},
+    };
+
+    const traced = withTracing(middleware);
+
+    await withSpan("templar.agent.turn", { "agent.type": "high" }, async () => {
+      await traced.onSessionStart!({ sessionId: "s-1" });
+      await traced.onBeforeTurn!({ sessionId: "s-1", turnNumber: 1 });
+      await traced.onAfterTurn!({ sessionId: "s-1", turnNumber: 1 });
+      await traced.onSessionEnd!({ sessionId: "s-1" });
+    });
+
+    const spans = exporter.getFinishedSpans();
+    expect(spans).toHaveLength(5);
+
+    // All middleware spans should be children of the agent turn span
+    const agentSpan = spans.find((s) => s.name === "templar.agent.turn");
+    expect(agentSpan).toBeDefined();
+    expect(agentSpan!.attributes["agent.type"]).toBe("high");
+
+    const middlewareSpans = spans.filter((s) => s.name.startsWith("templar.middleware."));
+    expect(middlewareSpans).toHaveLength(4);
+
+    for (const ms of middlewareSpans) {
+      expect(ms.parentSpanId).toBe(agentSpan!.spanContext().spanId);
+    }
+
+    // All spans share the same traceId
+    const traceId = agentSpan!.spanContext().traceId;
+    for (const span of spans) {
+      expect(span.spanContext().traceId).toBe(traceId);
+    }
+  });
+
+  it("should preserve span attributes across the hierarchy", async () => {
+    const middleware: TemplarMiddleware = {
+      name: "memory",
+      async onBeforeTurn() {},
+    };
+
+    const traced = withTracing(middleware);
+
+    await withSpan("templar.session", { "session.id": "s-42" }, async () => {
+      await traced.onBeforeTurn!({ sessionId: "s-42", turnNumber: 7 });
+    });
+
+    const spans = exporter.getFinishedSpans();
+    const sessionSpan = spans.find((s) => s.name === "templar.session");
+    const turnSpan = spans.find((s) => s.name === "templar.middleware.memory.before_turn");
+
+    expect(sessionSpan!.attributes["session.id"]).toBe("s-42");
+    expect(turnSpan!.attributes["session.id"]).toBe("s-42");
+    expect(turnSpan!.attributes["turn.number"]).toBe(7);
+  });
+
+  it("should export all spans to the in-memory exporter", async () => {
+    await withSpan("span.1", {}, async () => {
+      await withSpan("span.2", {}, async () => {
+        await withSpan("span.3", {}, async () => {});
+      });
+    });
+
+    const spans = exporter.getFinishedSpans();
+    expect(spans).toHaveLength(3);
+    expect(spans.map((s) => s.name).sort()).toEqual(["span.1", "span.2", "span.3"]);
+  });
+
+  it("should correctly record errors at any level of the hierarchy", async () => {
+    try {
+      await withSpan("outer", {}, async () => {
+        await withSpan("inner", {}, async () => {
+          throw new Error("deep failure");
+        });
+      });
+    } catch {
+      // expected
+    }
+
+    const spans = exporter.getFinishedSpans();
+    const inner = spans.find((s) => s.name === "inner");
+    const outer = spans.find((s) => s.name === "outer");
+
+    expect(inner!.status.code).toBe(SpanStatusCode.ERROR);
+    expect(inner!.status.message).toBe("deep failure");
+    expect(outer!.status.code).toBe(SpanStatusCode.ERROR);
+  });
+
+  it("should handle multiple traced middleware in sequence", async () => {
+    const mw1: TemplarMiddleware = {
+      name: "audit",
+      async onBeforeTurn() {},
+    };
+    const mw2: TemplarMiddleware = {
+      name: "memory",
+      async onBeforeTurn() {},
+    };
+
+    const traced1 = withTracing(mw1);
+    const traced2 = withTracing(mw2);
+
+    await withSpan("templar.turn", {}, async () => {
+      await traced1.onBeforeTurn!({ sessionId: "s-1", turnNumber: 1 });
+      await traced2.onBeforeTurn!({ sessionId: "s-1", turnNumber: 1 });
+    });
+
+    const spans = exporter.getFinishedSpans();
+    expect(spans).toHaveLength(3);
+
+    const auditSpan = spans.find((s) => s.name === "templar.middleware.audit.before_turn");
+    const memorySpan = spans.find((s) => s.name === "templar.middleware.memory.before_turn");
+    const turnSpan = spans.find((s) => s.name === "templar.turn");
+
+    expect(auditSpan!.parentSpanId).toBe(turnSpan!.spanContext().spanId);
+    expect(memorySpan!.parentSpanId).toBe(turnSpan!.spanContext().spanId);
+  });
+});

--- a/packages/telemetry/src/__tests__/setup.test.ts
+++ b/packages/telemetry/src/__tests__/setup.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { isTelemetryEnabled, setupTelemetry, shutdownTelemetry } from "../setup.js";
+
+describe("isTelemetryEnabled", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("should return false when OTEL_ENABLED is not set", () => {
+    delete process.env.OTEL_ENABLED;
+    expect(isTelemetryEnabled()).toBe(false);
+  });
+
+  it('should return true when OTEL_ENABLED is "true"', () => {
+    process.env.OTEL_ENABLED = "true";
+    expect(isTelemetryEnabled()).toBe(true);
+  });
+
+  it('should return true when OTEL_ENABLED is "1"', () => {
+    process.env.OTEL_ENABLED = "1";
+    expect(isTelemetryEnabled()).toBe(true);
+  });
+
+  it('should return false when OTEL_ENABLED is "false"', () => {
+    process.env.OTEL_ENABLED = "false";
+    expect(isTelemetryEnabled()).toBe(false);
+  });
+
+  it("should return false when OTEL_ENABLED is empty string", () => {
+    process.env.OTEL_ENABLED = "";
+    expect(isTelemetryEnabled()).toBe(false);
+  });
+
+  it('should return false when OTEL_ENABLED is "0"', () => {
+    process.env.OTEL_ENABLED = "0";
+    expect(isTelemetryEnabled()).toBe(false);
+  });
+});
+
+describe("setupTelemetry", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(async () => {
+    await shutdownTelemetry();
+    process.env = originalEnv;
+  });
+
+  it("should return false when OTEL_ENABLED is not set", async () => {
+    delete process.env.OTEL_ENABLED;
+    const result = await setupTelemetry();
+    expect(result).toBe(false);
+  });
+
+  it("should return true when OTEL_ENABLED=true", async () => {
+    process.env.OTEL_ENABLED = "true";
+    const result = await setupTelemetry({ endpoint: "http://localhost:4318" });
+    expect(result).toBe(true);
+  });
+
+  it("should return false on second call (idempotent)", async () => {
+    process.env.OTEL_ENABLED = "true";
+    const first = await setupTelemetry({ endpoint: "http://localhost:4318" });
+    const second = await setupTelemetry({ endpoint: "http://localhost:4318" });
+    expect(first).toBe(true);
+    expect(second).toBe(false);
+  });
+
+  it("should respect config overrides", async () => {
+    process.env.OTEL_ENABLED = "true";
+    const result = await setupTelemetry({
+      serviceName: "test-service",
+      endpoint: "http://localhost:9999",
+      sampleRatio: 0.5,
+      environment: "test",
+    });
+    expect(result).toBe(true);
+  });
+});
+
+describe("shutdownTelemetry", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(async () => {
+    await shutdownTelemetry();
+    process.env = originalEnv;
+  });
+
+  it("should be safe to call when not initialized", async () => {
+    await expect(shutdownTelemetry()).resolves.toBeUndefined();
+  });
+
+  it("should allow re-initialization after shutdown", async () => {
+    process.env.OTEL_ENABLED = "true";
+    const first = await setupTelemetry({ endpoint: "http://localhost:4318" });
+    expect(first).toBe(true);
+
+    await shutdownTelemetry();
+
+    const second = await setupTelemetry({ endpoint: "http://localhost:4318" });
+    expect(second).toBe(true);
+  });
+});

--- a/packages/telemetry/src/__tests__/span-helpers.test.ts
+++ b/packages/telemetry/src/__tests__/span-helpers.test.ts
@@ -1,0 +1,126 @@
+import { SpanStatusCode, trace } from "@opentelemetry/api";
+import { InMemorySpanExporter, SimpleSpanProcessor } from "@opentelemetry/sdk-trace-base";
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { withSpan } from "../span-helpers.js";
+
+describe("withSpan", () => {
+  let exporter: InMemorySpanExporter;
+  let provider: NodeTracerProvider;
+
+  beforeEach(() => {
+    exporter = new InMemorySpanExporter();
+    provider = new NodeTracerProvider();
+    provider.addSpanProcessor(new SimpleSpanProcessor(exporter));
+    trace.disable(); // Clear any previous global provider
+    provider.register();
+  });
+
+  afterEach(async () => {
+    trace.disable();
+    exporter.reset();
+    await provider.shutdown();
+  });
+
+  it("should create a named span with attributes", async () => {
+    await withSpan("test.operation", { "test.key": "value", "test.num": 42 }, async () => {
+      // no-op
+    });
+
+    const spans = exporter.getFinishedSpans();
+    expect(spans).toHaveLength(1);
+    expect(spans[0]!.name).toBe("test.operation");
+    expect(spans[0]!.attributes["test.key"]).toBe("value");
+    expect(spans[0]!.attributes["test.num"]).toBe(42);
+  });
+
+  it("should set OK status on success", async () => {
+    await withSpan("test.ok", {}, async () => "result");
+
+    const spans = exporter.getFinishedSpans();
+    expect(spans[0]!.status.code).toBe(SpanStatusCode.OK);
+  });
+
+  it("should return the function's return value", async () => {
+    const result = await withSpan("test.return", {}, async () => 42);
+    expect(result).toBe(42);
+  });
+
+  it("should record exception and set ERROR status on failure", async () => {
+    const error = new Error("test failure");
+
+    await expect(
+      withSpan("test.error", {}, async () => {
+        throw error;
+      }),
+    ).rejects.toThrow("test failure");
+
+    const spans = exporter.getFinishedSpans();
+    expect(spans[0]!.status.code).toBe(SpanStatusCode.ERROR);
+    expect(spans[0]!.status.message).toBe("test failure");
+    expect(spans[0]!.events).toHaveLength(1);
+    expect(spans[0]!.events[0]!.name).toBe("exception");
+  });
+
+  it("should handle non-Error throws", async () => {
+    await expect(
+      withSpan("test.string-error", {}, async () => {
+        throw "string error";
+      }),
+    ).rejects.toBe("string error");
+
+    const spans = exporter.getFinishedSpans();
+    expect(spans[0]!.status.code).toBe(SpanStatusCode.ERROR);
+    expect(spans[0]!.status.message).toBe("string error");
+  });
+
+  it("should always end the span even on error", async () => {
+    try {
+      await withSpan("test.always-end", {}, async () => {
+        throw new Error("fail");
+      });
+    } catch {
+      // expected
+    }
+
+    const spans = exporter.getFinishedSpans();
+    expect(spans).toHaveLength(1);
+    // If the span is in getFinishedSpans, it has been ended
+  });
+
+  it("should nest spans correctly (parent-child)", async () => {
+    await withSpan("parent", { level: "outer" }, async () => {
+      await withSpan("child", { level: "inner" }, async () => {
+        // no-op
+      });
+    });
+
+    const spans = exporter.getFinishedSpans();
+    expect(spans).toHaveLength(2);
+
+    const child = spans.find((s) => s.name === "child");
+    const parent = spans.find((s) => s.name === "parent");
+
+    expect(child).toBeDefined();
+    expect(parent).toBeDefined();
+    // Child's parent span ID should match parent's span ID
+    expect(child!.parentSpanId).toBe(parent!.spanContext().spanId);
+  });
+
+  it("should set boolean attributes", async () => {
+    await withSpan("test.bool", { "test.flag": true }, async () => {});
+
+    const spans = exporter.getFinishedSpans();
+    expect(spans[0]!.attributes["test.flag"]).toBe(true);
+  });
+});
+
+describe("withSpan (no provider)", () => {
+  it("should execute function with zero overhead when no provider is registered", async () => {
+    // Reset to default no-op provider
+    trace.disable();
+
+    const result = await withSpan("test.noop", { key: "value" }, async () => "works");
+    expect(result).toBe("works");
+  });
+});

--- a/packages/telemetry/src/__tests__/traced-middleware.test.ts
+++ b/packages/telemetry/src/__tests__/traced-middleware.test.ts
@@ -1,0 +1,195 @@
+import { trace } from "@opentelemetry/api";
+import { InMemorySpanExporter, SimpleSpanProcessor } from "@opentelemetry/sdk-trace-base";
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
+import type { SessionContext, TemplarMiddleware, TurnContext } from "@templar/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { withTracing } from "../traced-middleware.js";
+
+function createSessionContext(overrides: Partial<SessionContext> = {}): SessionContext {
+  return {
+    sessionId: "test-session-1",
+    agentId: "test-agent",
+    ...overrides,
+  };
+}
+
+function createTurnContext(turnNumber: number, overrides: Partial<TurnContext> = {}): TurnContext {
+  return {
+    sessionId: "test-session-1",
+    turnNumber,
+    ...overrides,
+  };
+}
+
+describe("withTracing", () => {
+  let exporter: InMemorySpanExporter;
+  let provider: NodeTracerProvider;
+
+  beforeEach(() => {
+    exporter = new InMemorySpanExporter();
+    provider = new NodeTracerProvider();
+    provider.addSpanProcessor(new SimpleSpanProcessor(exporter));
+    trace.disable(); // Clear any previous global provider
+    provider.register();
+  });
+
+  afterEach(async () => {
+    trace.disable();
+    exporter.reset();
+    await provider.shutdown();
+  });
+
+  it("should preserve the middleware name", () => {
+    const inner: TemplarMiddleware = {
+      name: "test-middleware",
+      async onSessionStart() {},
+    };
+
+    const traced = withTracing(inner);
+    expect(traced.name).toBe("test-middleware");
+  });
+
+  it("should create span for onSessionStart", async () => {
+    const onSessionStart = vi.fn();
+    const inner: TemplarMiddleware = {
+      name: "audit",
+      onSessionStart,
+    };
+
+    const traced = withTracing(inner);
+    await traced.onSessionStart!(createSessionContext());
+
+    expect(onSessionStart).toHaveBeenCalledOnce();
+    const spans = exporter.getFinishedSpans();
+    expect(spans).toHaveLength(1);
+    expect(spans[0]!.name).toBe("templar.middleware.audit.session_start");
+    expect(spans[0]!.attributes["session.id"]).toBe("test-session-1");
+  });
+
+  it("should create span for onBeforeTurn", async () => {
+    const onBeforeTurn = vi.fn();
+    const inner: TemplarMiddleware = {
+      name: "memory",
+      onBeforeTurn,
+    };
+
+    const traced = withTracing(inner);
+    await traced.onBeforeTurn!(createTurnContext(3));
+
+    expect(onBeforeTurn).toHaveBeenCalledOnce();
+    const spans = exporter.getFinishedSpans();
+    expect(spans).toHaveLength(1);
+    expect(spans[0]!.name).toBe("templar.middleware.memory.before_turn");
+    expect(spans[0]!.attributes["session.id"]).toBe("test-session-1");
+    expect(spans[0]!.attributes["turn.number"]).toBe(3);
+  });
+
+  it("should create span for onAfterTurn", async () => {
+    const onAfterTurn = vi.fn();
+    const inner: TemplarMiddleware = {
+      name: "pay",
+      onAfterTurn,
+    };
+
+    const traced = withTracing(inner);
+    await traced.onAfterTurn!(createTurnContext(5));
+
+    const spans = exporter.getFinishedSpans();
+    expect(spans).toHaveLength(1);
+    expect(spans[0]!.name).toBe("templar.middleware.pay.after_turn");
+    expect(spans[0]!.attributes["turn.number"]).toBe(5);
+  });
+
+  it("should create span for onSessionEnd", async () => {
+    const onSessionEnd = vi.fn();
+    const inner: TemplarMiddleware = {
+      name: "audit",
+      onSessionEnd,
+    };
+
+    const traced = withTracing(inner);
+    await traced.onSessionEnd!(createSessionContext({ sessionId: "s-42" }));
+
+    const spans = exporter.getFinishedSpans();
+    expect(spans).toHaveLength(1);
+    expect(spans[0]!.name).toBe("templar.middleware.audit.session_end");
+    expect(spans[0]!.attributes["session.id"]).toBe("s-42");
+  });
+
+  it("should pass through undefined hooks", () => {
+    const inner: TemplarMiddleware = {
+      name: "minimal",
+      // No hooks defined
+    };
+
+    const traced = withTracing(inner);
+    expect(traced.onSessionStart).toBeUndefined();
+    expect(traced.onBeforeTurn).toBeUndefined();
+    expect(traced.onAfterTurn).toBeUndefined();
+    expect(traced.onSessionEnd).toBeUndefined();
+  });
+
+  it("should propagate errors through wrapper", async () => {
+    const error = new Error("BudgetExhaustedError");
+    const inner: TemplarMiddleware = {
+      name: "pay",
+      async onAfterTurn() {
+        throw error;
+      },
+    };
+
+    const traced = withTracing(inner);
+    await expect(traced.onAfterTurn!(createTurnContext(1))).rejects.toThrow("BudgetExhaustedError");
+
+    const spans = exporter.getFinishedSpans();
+    expect(spans).toHaveLength(1);
+    expect(spans[0]!.events[0]!.name).toBe("exception");
+  });
+
+  it("should maintain parent-child span relationships", async () => {
+    const inner: TemplarMiddleware = {
+      name: "test",
+      async onSessionStart() {},
+      async onBeforeTurn() {},
+    };
+
+    const traced = withTracing(inner);
+
+    // Simulate a parent span wrapping both calls
+    const tracer = trace.getTracer("test");
+    await tracer.startActiveSpan("parent.span", async (parentSpan) => {
+      await traced.onSessionStart!(createSessionContext());
+      await traced.onBeforeTurn!(createTurnContext(1));
+      parentSpan.end();
+    });
+
+    const spans = exporter.getFinishedSpans();
+    expect(spans).toHaveLength(3);
+
+    const parentSpan = spans.find((s) => s.name === "parent.span");
+    const sessionSpan = spans.find((s) => s.name === "templar.middleware.test.session_start");
+    const turnSpan = spans.find((s) => s.name === "templar.middleware.test.before_turn");
+
+    expect(parentSpan).toBeDefined();
+    expect(sessionSpan!.parentSpanId).toBe(parentSpan!.spanContext().spanId);
+    expect(turnSpan!.parentSpanId).toBe(parentSpan!.spanContext().spanId);
+  });
+
+  it("should pass context through to inner middleware", async () => {
+    const ctx = createTurnContext(1, { metadata: { existing: "data" } });
+    let capturedCtx: TurnContext | undefined;
+
+    const inner: TemplarMiddleware = {
+      name: "capture",
+      async onBeforeTurn(c) {
+        capturedCtx = c;
+      },
+    };
+
+    const traced = withTracing(inner);
+    await traced.onBeforeTurn!(ctx);
+
+    expect(capturedCtx).toBe(ctx);
+    expect((capturedCtx!.metadata as Record<string, unknown>)?.existing).toBe("data");
+  });
+});

--- a/packages/telemetry/src/index.ts
+++ b/packages/telemetry/src/index.ts
@@ -1,0 +1,20 @@
+/**
+ * @templar/telemetry — OpenTelemetry distributed tracing for Templar runtime.
+ *
+ * Public API:
+ * - setupTelemetry() / shutdownTelemetry() — SDK lifecycle
+ * - isTelemetryEnabled() — check OTEL_ENABLED env var
+ * - withSpan() — DRY span creation helper
+ * - withTracing() — middleware wrapper
+ * - agentOperations / agentLatency — OTel metrics
+ *
+ * Selective OTel API re-exports for advanced users.
+ */
+
+// Selective OTel re-exports for advanced users
+export { context, SpanStatusCode, trace } from "@opentelemetry/api";
+export { getAgentLatency, getAgentOperations } from "./metrics.js";
+export { isTelemetryEnabled, setupTelemetry, shutdownTelemetry } from "./setup.js";
+export { withSpan } from "./span-helpers.js";
+export { withTracing } from "./traced-middleware.js";
+export type { SpanAttributes, SpanAttributeValue, TelemetryConfig } from "./types.js";

--- a/packages/telemetry/src/metrics.ts
+++ b/packages/telemetry/src/metrics.ts
@@ -1,0 +1,42 @@
+/**
+ * OTel metrics for Templar agent operations.
+ *
+ * Provides counters and histograms for monitoring agent performance.
+ * Lazily initialized — meters are only created on first access.
+ * When no meter provider is registered, these return no-op instruments.
+ */
+
+import type { Counter, Histogram } from "@opentelemetry/api";
+import { metrics } from "@opentelemetry/api";
+
+const METER_NAME = "templar";
+
+let _agentOperations: Counter | undefined;
+let _agentLatency: Histogram | undefined;
+
+/**
+ * Get the counter for total agent operations (turns, tool calls, etc.).
+ * Lazily creates the counter on first access.
+ */
+export function getAgentOperations(): Counter {
+  if (_agentOperations === undefined) {
+    _agentOperations = metrics.getMeter(METER_NAME).createCounter("templar.agent.operations", {
+      description: "Total agent operations",
+    });
+  }
+  return _agentOperations;
+}
+
+/**
+ * Get the histogram for operation latency in milliseconds.
+ * Lazily creates the histogram on first access.
+ */
+export function getAgentLatency(): Histogram {
+  if (_agentLatency === undefined) {
+    _agentLatency = metrics.getMeter(METER_NAME).createHistogram("templar.agent.latency_ms", {
+      description: "Operation latency in milliseconds",
+      unit: "ms",
+    });
+  }
+  return _agentLatency;
+}

--- a/packages/telemetry/src/setup.ts
+++ b/packages/telemetry/src/setup.ts
@@ -1,0 +1,113 @@
+/**
+ * OTel SDK initialization — matches Nexus `telemetry.py` pattern.
+ *
+ * Lazy-loaded: OTel SDK packages are only imported when OTEL_ENABLED=true.
+ * This ensures zero overhead when telemetry is disabled.
+ */
+
+import { registerMiddlewareWrapper, unregisterMiddlewareWrapper } from "@templar/core";
+import { withTracing } from "./traced-middleware.js";
+import type { TelemetryConfig } from "./types.js";
+
+/** Internal state: tracks whether telemetry has been initialized */
+let initialized = false;
+
+/** Reference to the NodeSDK for shutdown */
+let sdkInstance: { shutdown(): Promise<void> } | undefined;
+
+/**
+ * Check if telemetry is enabled via the OTEL_ENABLED env var.
+ *
+ * Returns true only when OTEL_ENABLED is explicitly set to "true" or "1".
+ */
+export function isTelemetryEnabled(): boolean {
+  const value = process.env.OTEL_ENABLED;
+  return value === "true" || value === "1";
+}
+
+/**
+ * Initialize OpenTelemetry SDK with distributed tracing.
+ *
+ * Configures:
+ * - TracerProvider with BatchSpanProcessor + OTLP HTTP exporter
+ * - UndiciInstrumentation (auto-instruments Node fetch / @nexus/sdk calls)
+ * - ParentBasedTraceIdRatio sampler (matching Nexus Python)
+ * - Resource with service.name, service.version, deployment.environment
+ * - Registers middleware wrapper with @templar/core for auto-instrumentation
+ *
+ * @param config - Optional overrides (env vars are used as defaults)
+ * @returns true if telemetry was initialized, false if disabled or already initialized
+ */
+export async function setupTelemetry(config?: TelemetryConfig): Promise<boolean> {
+  if (!isTelemetryEnabled()) {
+    return false;
+  }
+
+  if (initialized) {
+    return false;
+  }
+
+  // Dynamic imports — only loaded when telemetry is enabled
+  const { NodeSDK } = await import("@opentelemetry/sdk-node");
+  const { OTLPTraceExporter } = await import("@opentelemetry/exporter-trace-otlp-http");
+  const { UndiciInstrumentation } = await import("@opentelemetry/instrumentation-undici");
+  const { ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION } = await import(
+    "@opentelemetry/semantic-conventions"
+  );
+  const { Resource } = await import("@opentelemetry/resources");
+  const { ParentBasedSampler, TraceIdRatioBasedSampler } = await import(
+    "@opentelemetry/sdk-trace-base"
+  );
+
+  const serviceName = config?.serviceName ?? process.env.OTEL_SERVICE_NAME ?? "templar";
+  const endpoint =
+    config?.endpoint ?? process.env.OTEL_EXPORTER_OTLP_ENDPOINT ?? "http://localhost:4318";
+  const rawRatio = config?.sampleRatio ?? parseFloat(process.env.OTEL_TRACES_SAMPLER_ARG ?? "1.0");
+  const sampleRatio = Number.isNaN(rawRatio) ? 1.0 : Math.max(0, Math.min(1, rawRatio));
+  const environment = config?.environment ?? process.env.OTEL_ENVIRONMENT ?? "development";
+
+  const resource = new Resource({
+    [ATTR_SERVICE_NAME]: serviceName,
+    [ATTR_SERVICE_VERSION]: process.env.npm_package_version ?? "0.0.0",
+    "deployment.environment": environment,
+  });
+
+  const traceExporter = new OTLPTraceExporter({
+    url: `${endpoint}/v1/traces`,
+  });
+
+  const sampler = new ParentBasedSampler({
+    root: new TraceIdRatioBasedSampler(sampleRatio),
+  });
+
+  const sdk = new NodeSDK({
+    resource,
+    traceExporter,
+    sampler,
+    instrumentations: [new UndiciInstrumentation()],
+  });
+
+  sdk.start();
+
+  // Register middleware wrapper with @templar/core for auto-instrumentation
+  registerMiddlewareWrapper(withTracing);
+
+  sdkInstance = sdk;
+  initialized = true;
+
+  return true;
+}
+
+/**
+ * Gracefully shut down the OTel SDK, flushing any pending spans.
+ *
+ * Safe to call even if telemetry was never initialized.
+ */
+export async function shutdownTelemetry(): Promise<void> {
+  if (sdkInstance !== undefined) {
+    await sdkInstance.shutdown();
+    unregisterMiddlewareWrapper();
+    sdkInstance = undefined;
+    initialized = false;
+  }
+}

--- a/packages/telemetry/src/span-helpers.ts
+++ b/packages/telemetry/src/span-helpers.ts
@@ -1,0 +1,60 @@
+/**
+ * Span helper utilities — DRY span creation with error handling.
+ *
+ * Wraps OpenTelemetry's tracer.startActiveSpan with automatic:
+ * - Attribute setting
+ * - Error recording + status propagation
+ * - Span ending (even on error)
+ */
+
+import { SpanStatusCode, trace } from "@opentelemetry/api";
+import type { SpanAttributes } from "./types.js";
+
+const TRACER_NAME = "templar";
+
+/**
+ * Execute an async function within a named OTel span.
+ *
+ * - Sets provided attributes on the span
+ * - Records exceptions and sets ERROR status on failure
+ * - Sets OK status on success
+ * - Always ends the span (even on error)
+ * - Returns the function's return value
+ *
+ * When no tracer provider is registered (OTel disabled), the function
+ * still executes with a no-op span (zero overhead from OTel API).
+ *
+ * @param name - Span name (e.g., "templar.middleware.audit.session_start")
+ * @param attributes - Key-value pairs to set on the span
+ * @param fn - Async function to execute within the span
+ * @returns The function's return value
+ * @throws Re-throws any error from fn after recording it on the span
+ */
+export async function withSpan<T>(
+  name: string,
+  attributes: SpanAttributes,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const tracer = trace.getTracer(TRACER_NAME);
+  return tracer.startActiveSpan(name, async (span) => {
+    try {
+      for (const [key, value] of Object.entries(attributes)) {
+        span.setAttribute(key, value);
+      }
+      const result = await fn();
+      span.setStatus({ code: SpanStatusCode.OK });
+      return result;
+    } catch (error) {
+      if (error instanceof Error) {
+        span.recordException(error);
+      }
+      span.setStatus({
+        code: SpanStatusCode.ERROR,
+        message: error instanceof Error ? error.message : String(error),
+      });
+      throw error;
+    } finally {
+      span.end();
+    }
+  });
+}

--- a/packages/telemetry/src/traced-middleware.ts
+++ b/packages/telemetry/src/traced-middleware.ts
@@ -1,0 +1,60 @@
+/**
+ * TracedMiddleware wrapper — non-invasive OTel instrumentation for TemplarMiddleware.
+ *
+ * Wraps each lifecycle hook in a span without modifying the original middleware.
+ * Span names follow: `templar.middleware.{name}.{hook}`
+ */
+
+import type { SessionContext, TemplarMiddleware, TurnContext } from "@templar/core";
+import { withSpan } from "./span-helpers.js";
+
+/**
+ * Wrap a TemplarMiddleware with OpenTelemetry tracing.
+ *
+ * Each lifecycle hook (onSessionStart, onBeforeTurn, onAfterTurn, onSessionEnd)
+ * is wrapped in a span. Undefined hooks are not included in the result.
+ *
+ * Errors propagate unchanged — the wrapper only adds observability.
+ *
+ * @param middleware - The middleware to wrap
+ * @returns A new middleware with tracing added to each hook
+ */
+export function withTracing(middleware: TemplarMiddleware): TemplarMiddleware {
+  const baseName = `templar.middleware.${middleware.name}`;
+
+  const result: TemplarMiddleware = { name: middleware.name };
+
+  if (middleware.onSessionStart) {
+    const original = middleware.onSessionStart.bind(middleware);
+    (result as { onSessionStart: (ctx: SessionContext) => Promise<void> }).onSessionStart = (ctx) =>
+      withSpan(`${baseName}.session_start`, { "session.id": ctx.sessionId }, () => original(ctx));
+  }
+
+  if (middleware.onBeforeTurn) {
+    const original = middleware.onBeforeTurn.bind(middleware);
+    (result as { onBeforeTurn: (ctx: TurnContext) => Promise<void> }).onBeforeTurn = (ctx) =>
+      withSpan(
+        `${baseName}.before_turn`,
+        { "session.id": ctx.sessionId, "turn.number": ctx.turnNumber },
+        () => original(ctx),
+      );
+  }
+
+  if (middleware.onAfterTurn) {
+    const original = middleware.onAfterTurn.bind(middleware);
+    (result as { onAfterTurn: (ctx: TurnContext) => Promise<void> }).onAfterTurn = (ctx) =>
+      withSpan(
+        `${baseName}.after_turn`,
+        { "session.id": ctx.sessionId, "turn.number": ctx.turnNumber },
+        () => original(ctx),
+      );
+  }
+
+  if (middleware.onSessionEnd) {
+    const original = middleware.onSessionEnd.bind(middleware);
+    (result as { onSessionEnd: (ctx: SessionContext) => Promise<void> }).onSessionEnd = (ctx) =>
+      withSpan(`${baseName}.session_end`, { "session.id": ctx.sessionId }, () => original(ctx));
+  }
+
+  return result;
+}

--- a/packages/telemetry/src/types.ts
+++ b/packages/telemetry/src/types.ts
@@ -1,0 +1,31 @@
+/**
+ * Telemetry configuration types.
+ *
+ * Matches the Nexus Python telemetry pattern: env-var driven,
+ * sensible defaults, explicit opt-in via OTEL_ENABLED.
+ */
+
+/**
+ * Configuration for OpenTelemetry setup.
+ * All fields are optional — defaults are resolved from env vars or sensible values.
+ */
+export interface TelemetryConfig {
+  /** Service name for resource identification (default: "templar") */
+  serviceName?: string;
+  /** OTLP exporter endpoint (default: from OTEL_EXPORTER_OTLP_ENDPOINT or "http://localhost:4318") */
+  endpoint?: string;
+  /** Trace sampling ratio 0.0-1.0 (default: from OTEL_TRACES_SAMPLER_ARG or 1.0) */
+  sampleRatio?: number;
+  /** Deployment environment (default: from OTEL_ENVIRONMENT or "development") */
+  environment?: string;
+}
+
+/**
+ * Standard span attribute types accepted by OpenTelemetry.
+ */
+export type SpanAttributeValue = string | number | boolean;
+
+/**
+ * Record of span attributes.
+ */
+export type SpanAttributes = Record<string, SpanAttributeValue>;

--- a/packages/telemetry/tsconfig.json
+++ b/packages/telemetry/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "references": [{ "path": "../core" }]
+}

--- a/packages/telemetry/tsup.config.ts
+++ b/packages/telemetry/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: {
+    compilerOptions: {
+      composite: false,
+    },
+  },
+  clean: true,
+  treeshake: true,
+  target: "node22",
+});

--- a/packages/telemetry/vitest.config.ts
+++ b/packages/telemetry/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+    exclude: ["**/node_modules/**", "**/dist/**"],
+    testTimeout: 10_000,
+    hookTimeout: 10_000,
+    coverage: {
+      provider: "v8",
+      include: ["src/**/*.ts"],
+      exclude: ["src/**/*.test.ts", "src/**/__tests__/**"],
+      reporter: ["text", "json", "clover"],
+      reportsDirectory: "coverage",
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
         version: 2.3.14
       '@vitest/coverage-v8':
         specifier: ^4.0.18
-        version: 4.0.18(vitest@4.0.18(@types/node@25.2.2)(yaml@2.8.2))
+        version: 4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.2.2)(yaml@2.8.2))
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(postcss@8.5.6)(typescript@5.9.3)(yaml@2.8.2)
@@ -25,7 +25,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@types/node@25.2.2)(yaml@2.8.2)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.2.2)(yaml@2.8.2)
 
   packages/agui:
     dependencies:
@@ -138,7 +138,7 @@ importers:
         version: 0.1.9
       deepagents:
         specifier: ^1.0.0
-        version: 1.7.2(zod-to-json-schema@3.25.1(zod@4.3.6))
+        version: 1.7.2(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(zod-to-json-schema@3.25.1(zod@4.3.6))
     devDependencies:
       '@nexus/sdk':
         specifier: workspace:*
@@ -201,7 +201,7 @@ importers:
         version: 22.19.11
       vitest:
         specifier: ^4.0.0
-        version: 4.0.18(@types/node@22.19.11)(yaml@2.8.2)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(yaml@2.8.2)
 
   packages/identity:
     dependencies:
@@ -256,6 +256,9 @@ importers:
       '@nexus/sdk':
         specifier: workspace:*
         version: link:../nexus-sdk
+      '@opentelemetry/api':
+        specifier: ^1.9.0
+        version: 1.9.0
       '@templar/core':
         specifier: workspace:*
         version: link:../core
@@ -263,6 +266,12 @@ importers:
         specifier: workspace:*
         version: link:../errors
     devDependencies:
+      '@opentelemetry/sdk-trace-base':
+        specifier: ^1.30.0
+        version: 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-node':
+        specifier: ^1.30.0
+        version: 1.30.1(@opentelemetry/api@1.9.0)
       '@templar/test-utils':
         specifier: workspace:*
         version: link:../test-utils
@@ -331,7 +340,44 @@ importers:
         version: 22.19.11
       vitest:
         specifier: ^4.0.0
-        version: 4.0.18(@types/node@22.19.11)(yaml@2.8.2)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(yaml@2.8.2)
+
+  packages/telemetry:
+    dependencies:
+      '@opentelemetry/api':
+        specifier: ^1.9.0
+        version: 1.9.0
+      '@opentelemetry/exporter-trace-otlp-http':
+        specifier: ^0.57.0
+        version: 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-undici':
+        specifier: ^0.10.0
+        version: 0.10.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources':
+        specifier: ^1.30.0
+        version: 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-node':
+        specifier: ^0.57.0
+        version: 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base':
+        specifier: ^1.30.0
+        version: 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-node':
+        specifier: ^1.30.0
+        version: 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions':
+        specifier: ^1.28.0
+        version: 1.39.0
+      '@templar/core':
+        specifier: workspace:*
+        version: link:../core
+    devDependencies:
+      '@templar/test-utils':
+        specifier: workspace:*
+        version: link:../test-utils
+      '@types/node':
+        specifier: ^25.2.2
+        version: 25.2.2
 
   packages/test-utils:
     dependencies:
@@ -346,7 +392,7 @@ importers:
         version: link:../errors
       vitest:
         specifier: '>=4.0.0'
-        version: 4.0.18(@types/node@25.2.2)(yaml@2.8.2)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.2.2)(yaml@2.8.2)
 
 packages:
 
@@ -686,6 +732,15 @@ packages:
   '@grammyjs/types@3.24.0':
     resolution: {integrity: sha512-qQIEs4lN5WqUdr4aT8MeU6UFpMbGYAvcvYSW1A4OO1PABGJQHz/KLON6qvpf+5RxaNDQBxiY2k2otIhg/AG7RQ==}
 
+  '@grpc/grpc-js@1.14.3':
+    resolution: {integrity: sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==}
+    engines: {node: '>=12.10.0'}
+
+  '@grpc/proto-loader@0.8.0':
+    resolution: {integrity: sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==}
+    engines: {node: '>=6'}
+    hasBin: true
+
   '@hapi/boom@10.0.1':
     resolution: {integrity: sha512-ERcCZaEjdH3OgSJlyjVk8pHIFeus91CjKP3v+MpgBNp5IvGzP2l/bRiD78nqYcKPaZdbKkK5vDBVPd2ohHBlsA==}
 
@@ -732,6 +787,9 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@js-sdsl/ordered-map@4.4.2':
+    resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
 
   '@keyv/bigmap@1.3.1':
     resolution: {integrity: sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ==}
@@ -827,6 +885,178 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@opentelemetry/api-logs@0.57.2':
+    resolution: {integrity: sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==}
+    engines: {node: '>=14'}
+
+  '@opentelemetry/api@1.9.0':
+    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/context-async-hooks@1.30.1':
+    resolution: {integrity: sha512-s5vvxXPVdjqS3kTLKMeBMvop9hbWkwzBpu+mUO2M7sZtlkyDJGwFe33wRKnbaYDo8ExRVBIIdwIGrqpxHuKttA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/core@1.30.1':
+    resolution: {integrity: sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/exporter-logs-otlp-grpc@0.57.2':
+    resolution: {integrity: sha512-eovEy10n3umjKJl2Ey6TLzikPE+W4cUQ4gCwgGP1RqzTGtgDra0WjIqdy29ohiUKfvmbiL3MndZww58xfIvyFw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-logs-otlp-http@0.57.2':
+    resolution: {integrity: sha512-0rygmvLcehBRp56NQVLSleJ5ITTduq/QfU7obOkyWgPpFHulwpw2LYTqNIz5TczKZuy5YY+5D3SDnXZL1tXImg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-logs-otlp-proto@0.57.2':
+    resolution: {integrity: sha512-ta0ithCin0F8lu9eOf4lEz9YAScecezCHkMMyDkvd9S7AnZNX5ikUmC5EQOQADU+oCcgo/qkQIaKcZvQ0TYKDw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-metrics-otlp-grpc@0.57.2':
+    resolution: {integrity: sha512-r70B8yKR41F0EC443b5CGB4rUaOMm99I5N75QQt6sHKxYDzSEc6gm48Diz1CI1biwa5tDPznpylTrywO/pT7qw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-metrics-otlp-http@0.57.2':
+    resolution: {integrity: sha512-ttb9+4iKw04IMubjm3t0EZsYRNWr3kg44uUuzfo9CaccYlOh8cDooe4QObDUkvx9d5qQUrbEckhrWKfJnKhemA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-metrics-otlp-proto@0.57.2':
+    resolution: {integrity: sha512-HX068Q2eNs38uf7RIkNN9Hl4Ynl+3lP0++KELkXMCpsCbFO03+0XNNZ1SkwxPlP9jrhQahsMPMkzNXpq3fKsnw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-prometheus@0.57.2':
+    resolution: {integrity: sha512-VqIqXnuxWMWE/1NatAGtB1PvsQipwxDcdG4RwA/umdBcW3/iOHp0uejvFHTRN2O78ZPged87ErJajyUBPUhlDQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-trace-otlp-grpc@0.57.2':
+    resolution: {integrity: sha512-gHU1vA3JnHbNxEXg5iysqCWxN9j83d7/epTYBZflqQnTyCC4N7yZXn/dMM+bEmyhQPGjhCkNZLx4vZuChH1PYw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-trace-otlp-http@0.57.2':
+    resolution: {integrity: sha512-sB/gkSYFu+0w2dVQ0PWY9fAMl172PKMZ/JrHkkW8dmjCL0CYkmXeE+ssqIL/yBUTPOvpLIpenX5T9RwXRBW/3g==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-trace-otlp-proto@0.57.2':
+    resolution: {integrity: sha512-awDdNRMIwDvUtoRYxRhja5QYH6+McBLtoz1q9BeEsskhZcrGmH/V1fWpGx8n+Rc+542e8pJA6y+aullbIzQmlw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-zipkin@1.30.1':
+    resolution: {integrity: sha512-6S2QIMJahIquvFaaxmcwpvQQRD/YFaMTNoIxrfPIPOeITN+a8lfEcPDxNxn8JDAaxkg+4EnXhz8upVDYenoQjA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+
+  '@opentelemetry/instrumentation-undici@0.10.1':
+    resolution: {integrity: sha512-rkOGikPEyRpMCmNu9AQuV5dtRlDmJp2dK5sw8roVshAGoB6hH/3QjDtRhdwd75SsJwgynWUNRUYe0wAkTo16tQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.7.0
+
+  '@opentelemetry/instrumentation@0.57.2':
+    resolution: {integrity: sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-exporter-base@0.57.2':
+    resolution: {integrity: sha512-XdxEzL23Urhidyebg5E6jZoaiW5ygP/mRjxLHixogbqwDy2Faduzb5N0o/Oi+XTIJu+iyxXdVORjXax+Qgfxag==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-grpc-exporter-base@0.57.2':
+    resolution: {integrity: sha512-USn173KTWy0saqqRB5yU9xUZ2xdgb1Rdu5IosJnm9aV4hMTuFFRTUsQxbgc24QxpCHeoKzzCSnS/JzdV0oM2iQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-transformer@0.57.2':
+    resolution: {integrity: sha512-48IIRj49gbQVK52jYsw70+Jv+JbahT8BqT2Th7C4H7RCM9d0gZ5sgNPoMpWldmfjvIsSgiGJtjfk9MeZvjhoig==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/propagator-b3@1.30.1':
+    resolution: {integrity: sha512-oATwWWDIJzybAZ4pO76ATN5N6FFbOA1otibAVlS8v90B4S1wClnhRUk7K+2CHAwN1JKYuj4jh/lpCEG5BAqFuQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/propagator-jaeger@1.30.1':
+    resolution: {integrity: sha512-Pj/BfnYEKIOImirH76M4hDaBSx6HyZ2CXUqk+Kj02m6BB80c/yo4BdWkn/1gDFfU+YPY+bPR2U0DKBfdxCKwmg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/resources@1.30.1':
+    resolution: {integrity: sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/sdk-logs@0.57.2':
+    resolution: {integrity: sha512-TXFHJ5c+BKggWbdEQ/inpgIzEmS2BGQowLE9UhsMd7YYlUfBQJ4uax0VF/B5NYigdM/75OoJGhAV3upEhK+3gg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.4.0 <1.10.0'
+
+  '@opentelemetry/sdk-metrics@1.30.1':
+    resolution: {integrity: sha512-q9zcZ0Okl8jRgmy7eNW3Ku1XSgg3sDLa5evHZpCwjspw7E8Is4K/haRPDJrBcX3YSn/Y7gUvFnByNYEKQNbNog==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-node@0.57.2':
+    resolution: {integrity: sha512-8BaeqZyN5sTuPBtAoY+UtKwXBdqyuRKmekN5bFzAO40CgbGzAxfTpiL3PBerT7rhZ7p2nBdq7FaMv/tBQgHE4A==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@1.30.1':
+    resolution: {integrity: sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-node@1.30.1':
+    resolution: {integrity: sha512-cBjYOINt1JxXdpw1e5MlHmFRc5fgj4GW/86vsKFxJCJ8AL4PdVtYH41gWwl4qd4uQjqEL1oJVrXkSy5cnduAnQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/semantic-conventions@1.28.0':
+    resolution: {integrity: sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==}
+    engines: {node: '>=14'}
+
+  '@opentelemetry/semantic-conventions@1.39.0':
+    resolution: {integrity: sha512-R5R9tb2AXs2IRLNKLBJDynhkfmx7mX0vi8NkhZb3gUkPWHn6HXk5J8iQ/dql0U3ApfWym4kXXmBDRGO+oeOfjg==}
+    engines: {node: '>=14'}
 
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
@@ -1102,6 +1332,9 @@ packages:
   '@types/serve-static@2.2.0':
     resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
 
+  '@types/shimmer@1.2.0':
+    resolution: {integrity: sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==}
+
   '@types/uuid@10.0.0':
     resolution: {integrity: sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==}
 
@@ -1258,6 +1491,11 @@ packages:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
 
+  acorn-import-attributes@1.9.5:
+    resolution: {integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==}
+    peerDependencies:
+      acorn: ^8
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -1281,6 +1519,10 @@ packages:
 
   ajv@8.17.1:
     resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
 
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
@@ -1405,6 +1647,13 @@ packages:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
     engines: {node: '>= 20.19.0'}
 
+  cjs-module-lexer@1.4.3:
+    resolution: {integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==}
+
+  cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
+
   codec-parser@2.5.0:
     resolution: {integrity: sha512-Ru9t80fV8B0ZiixQl8xhMTLru+dzuis/KQld32/x5T/+3LwZb0/YvQdSKytX9JqCnRdiupvAvyYJINKrXieziQ==}
 
@@ -1514,6 +1763,9 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
@@ -1541,6 +1793,10 @@ packages:
     resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
     engines: {node: '>=18'}
     hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
 
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
@@ -1726,6 +1982,10 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
@@ -1807,6 +2067,9 @@ packages:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
 
+  import-in-the-middle@1.15.0:
+    resolution: {integrity: sha512-bpQy+CrsRmYmoPMAE/0G33iwRqwW4ouqdRg8jgbH3aKuCtOc8lxgmYXg2dMM92CRiGP660EtBcymH/eVUpCSaA==}
+
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
@@ -1822,12 +2085,20 @@ packages:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
 
+  is-core-module@2.16.1:
+    resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
+    engines: {node: '>= 0.4'}
+
   is-electron@2.2.2:
     resolution: {integrity: sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg==}
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
 
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
@@ -1964,6 +2235,9 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  lodash.camelcase@4.3.0:
+    resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
+
   lodash.clonedeep@4.5.0:
     resolution: {integrity: sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==}
 
@@ -2064,6 +2338,9 @@ packages:
 
   mlly@1.8.0:
     resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
+
+  module-details-from-path@1.0.4:
+    resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
 
   mpg123-decoder@1.0.3:
     resolution: {integrity: sha512-+fjxnWigodWJm3+4pndi+KUg9TBojgn31DPk85zEsim7C6s0X5Ztc/hQYdytXkwuGXH+aB0/aEkG40Emukv6oQ==}
@@ -2190,6 +2467,9 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  path-parse@1.0.7:
+    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
   path-to-regexp@8.3.0:
     resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
@@ -2334,9 +2614,17 @@ packages:
     resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
     engines: {node: '>= 12.13.0'}
 
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
+
+  require-in-the-middle@7.5.2:
+    resolution: {integrity: sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ==}
+    engines: {node: '>=8.6.0'}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -2345,6 +2633,11 @@ packages:
   resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
+
+  resolve@1.22.11:
+    resolution: {integrity: sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==}
+    engines: {node: '>= 0.4'}
+    hasBin: true
 
   retry@0.13.1:
     resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
@@ -2403,6 +2696,9 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  shimmer@1.2.1:
+    resolution: {integrity: sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==}
+
   side-channel-list@1.0.0:
     resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
     engines: {node: '>= 0.4'}
@@ -2453,8 +2749,16 @@ packages:
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
 
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
@@ -2472,6 +2776,10 @@ packages:
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
+
+  supports-preserve-symlinks-flag@1.0.0:
+    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
+    engines: {node: '>= 0.4'}
 
   thenify-all@1.6.0:
     resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
@@ -2731,6 +3039,10 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
@@ -2746,10 +3058,22 @@ packages:
       utf-8-validate:
         optional: true
 
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
   yaml@2.8.2:
     resolution: {integrity: sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==}
     engines: {node: '>= 14.6'}
     hasBin: true
+
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
+  yargs@17.7.2:
+    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
+    engines: {node: '>=12'}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -3042,6 +3366,18 @@ snapshots:
 
   '@grammyjs/types@3.24.0': {}
 
+  '@grpc/grpc-js@1.14.3':
+    dependencies:
+      '@grpc/proto-loader': 0.8.0
+      '@js-sdsl/ordered-map': 4.4.2
+
+  '@grpc/proto-loader@0.8.0':
+    dependencies:
+      lodash.camelcase: 4.3.0
+      long: 5.3.2
+      protobufjs: 7.5.4
+      yargs: 17.7.2
+
   '@hapi/boom@10.0.1':
     dependencies:
       '@hapi/hoek': 11.0.7
@@ -3083,6 +3419,8 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@js-sdsl/ordered-map@4.4.2': {}
+
   '@keyv/bigmap@1.3.1(keyv@5.6.0)':
     dependencies:
       hashery: 1.4.0
@@ -3107,14 +3445,14 @@ snapshots:
     transitivePeerDependencies:
       - openai
 
-  '@langchain/core@1.1.19':
+  '@langchain/core@1.1.19(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))':
     dependencies:
       '@cfworker/json-schema': 4.1.1
       ansi-styles: 5.2.0
       camelcase: 6.3.0
       decamelize: 1.2.0
       js-tiktoken: 1.0.21
-      langsmith: 0.4.12
+      langsmith: 0.4.12(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))
       mustache: 4.2.0
       p-queue: 6.6.2
       uuid: 10.0.0
@@ -3135,19 +3473,19 @@ snapshots:
       '@langchain/core': 0.2.36
       uuid: 10.0.0
 
-  '@langchain/langgraph-checkpoint@1.0.0(@langchain/core@1.1.19)':
+  '@langchain/langgraph-checkpoint@1.0.0(@langchain/core@1.1.19(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0)))':
     dependencies:
-      '@langchain/core': 1.1.19
+      '@langchain/core': 1.1.19(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))
       uuid: 10.0.0
 
-  '@langchain/langgraph-sdk@1.6.0(@langchain/core@1.1.19)':
+  '@langchain/langgraph-sdk@1.6.0(@langchain/core@1.1.19(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0)))':
     dependencies:
       '@types/json-schema': 7.0.15
       p-queue: 9.1.0
       p-retry: 7.1.1
       uuid: 13.0.0
     optionalDependencies:
-      '@langchain/core': 1.1.19
+      '@langchain/core': 1.1.19(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))
 
   '@langchain/langgraph@0.1.9':
     dependencies:
@@ -3160,11 +3498,11 @@ snapshots:
     transitivePeerDependencies:
       - openai
 
-  '@langchain/langgraph@1.1.4(@langchain/core@1.1.19)(zod-to-json-schema@3.25.1(zod@4.3.6))(zod@3.25.76)':
+  '@langchain/langgraph@1.1.4(@langchain/core@1.1.19(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0)))(zod-to-json-schema@3.25.1(zod@4.3.6))(zod@3.25.76)':
     dependencies:
-      '@langchain/core': 1.1.19
-      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@1.1.19)
-      '@langchain/langgraph-sdk': 1.6.0(@langchain/core@1.1.19)
+      '@langchain/core': 1.1.19(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))
+      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@1.1.19(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0)))
+      '@langchain/langgraph-sdk': 1.6.0(@langchain/core@1.1.19(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0)))
       '@standard-schema/spec': 1.1.0
       uuid: 10.0.0
       zod: 3.25.76
@@ -3174,11 +3512,11 @@ snapshots:
       - react
       - react-dom
 
-  '@langchain/langgraph@1.1.4(@langchain/core@1.1.19)(zod-to-json-schema@3.25.1(zod@4.3.6))(zod@4.3.6)':
+  '@langchain/langgraph@1.1.4(@langchain/core@1.1.19(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0)))(zod-to-json-schema@3.25.1(zod@4.3.6))(zod@4.3.6)':
     dependencies:
-      '@langchain/core': 1.1.19
-      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@1.1.19)
-      '@langchain/langgraph-sdk': 1.6.0(@langchain/core@1.1.19)
+      '@langchain/core': 1.1.19(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))
+      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@1.1.19(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0)))
+      '@langchain/langgraph-sdk': 1.6.0(@langchain/core@1.1.19(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0)))
       '@standard-schema/spec': 1.1.0
       uuid: 10.0.0
       zod: 4.3.6
@@ -3223,6 +3561,247 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
+
+  '@opentelemetry/api-logs@0.57.2':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+
+  '@opentelemetry/api@1.9.0': {}
+
+  '@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+
+  '@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/semantic-conventions': 1.28.0
+
+  '@opentelemetry/exporter-logs-otlp-grpc@0.57.2(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@grpc/grpc-js': 1.14.3
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-grpc-exporter-base': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-logs': 0.57.2(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/exporter-logs-otlp-http@0.57.2(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.57.2
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-logs': 0.57.2(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/exporter-logs-otlp-proto@0.57.2(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.57.2
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-logs': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/exporter-metrics-otlp-grpc@0.57.2(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@grpc/grpc-js': 1.14.3
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-metrics-otlp-http': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-grpc-exporter-base': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-metrics': 1.30.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/exporter-metrics-otlp-http@0.57.2(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-metrics': 1.30.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/exporter-metrics-otlp-proto@0.57.2(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-metrics-otlp-http': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-metrics': 1.30.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/exporter-prometheus@0.57.2(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-metrics': 1.30.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/exporter-trace-otlp-grpc@0.57.2(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@grpc/grpc-js': 1.14.3
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-grpc-exporter-base': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/exporter-trace-otlp-http@0.57.2(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/exporter-zipkin@1.30.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.28.0
+
+  '@opentelemetry/instrumentation-undici@0.10.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.57.2
+      '@types/shimmer': 1.2.0
+      import-in-the-middle: 1.15.0
+      require-in-the-middle: 7.5.2
+      semver: 7.7.4
+      shimmer: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/otlp-exporter-base@0.57.2(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.57.2(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/otlp-grpc-exporter-base@0.57.2(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@grpc/grpc-js': 1.14.3
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.57.2(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/otlp-transformer@0.57.2(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.57.2
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-logs': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-metrics': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.0)
+      protobufjs: 7.5.4
+
+  '@opentelemetry/propagator-b3@1.30.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/propagator-jaeger@1.30.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/resources@1.30.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.28.0
+
+  '@opentelemetry/sdk-logs@0.57.2(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.57.2
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/sdk-metrics@1.30.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/sdk-node@0.57.2(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.57.2
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-logs-otlp-grpc': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-logs-otlp-http': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-logs-otlp-proto': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-metrics-otlp-grpc': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-metrics-otlp-http': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-metrics-otlp-proto': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-prometheus': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-trace-otlp-grpc': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-trace-otlp-http': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-trace-otlp-proto': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-zipkin': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-logs': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-metrics': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-node': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.28.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.28.0
+
+  '@opentelemetry/sdk-trace-node@1.30.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/context-async-hooks': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/propagator-b3': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/propagator-jaeger': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.0)
+      semver: 7.7.4
+
+  '@opentelemetry/semantic-conventions@1.28.0': {}
+
+  '@opentelemetry/semantic-conventions@1.39.0': {}
 
   '@pinojs/redact@0.4.0': {}
 
@@ -3479,6 +4058,8 @@ snapshots:
       '@types/http-errors': 2.0.5
       '@types/node': 25.2.2
 
+  '@types/shimmer@1.2.0': {}
+
   '@types/uuid@10.0.0': {}
 
   '@types/ws@8.18.1':
@@ -3576,7 +4157,7 @@ snapshots:
       '@typescript-eslint/types': 8.55.0
       eslint-visitor-keys: 4.2.1
 
-  '@vitest/coverage-v8@4.0.18(vitest@4.0.18(@types/node@25.2.2)(yaml@2.8.2))':
+  '@vitest/coverage-v8@4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.2.2)(yaml@2.8.2))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.0.18
@@ -3588,7 +4169,7 @@ snapshots:
       obug: 2.1.1
       std-env: 3.10.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@types/node@25.2.2)(yaml@2.8.2)
+      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.2.2)(yaml@2.8.2)
 
   '@vitest/expect@4.0.18':
     dependencies:
@@ -3700,6 +4281,10 @@ snapshots:
       mime-types: 3.0.2
       negotiator: 1.0.0
 
+  acorn-import-attributes@1.9.5(acorn@8.15.0):
+    dependencies:
+      acorn: 8.15.0
+
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
       acorn: 8.15.0
@@ -3723,6 +4308,8 @@ snapshots:
       fast-uri: 3.1.0
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
+
+  ansi-regex@5.0.1: {}
 
   ansi-styles@4.3.0:
     dependencies:
@@ -3862,6 +4449,14 @@ snapshots:
     dependencies:
       readdirp: 5.0.0
 
+  cjs-module-lexer@1.4.3: {}
+
+  cliui@8.0.1:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
   codec-parser@2.5.0: {}
 
   color-convert@2.0.1:
@@ -3917,12 +4512,12 @@ snapshots:
 
   deep-is@0.1.4: {}
 
-  deepagents@1.7.2(zod-to-json-schema@3.25.1(zod@4.3.6)):
+  deepagents@1.7.2(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(zod-to-json-schema@3.25.1(zod@4.3.6)):
     dependencies:
-      '@langchain/core': 1.1.19
-      '@langchain/langgraph': 1.1.4(@langchain/core@1.1.19)(zod-to-json-schema@3.25.1(zod@4.3.6))(zod@4.3.6)
+      '@langchain/core': 1.1.19(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))
+      '@langchain/langgraph': 1.1.4(@langchain/core@1.1.19(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0)))(zod-to-json-schema@3.25.1(zod@4.3.6))(zod@4.3.6)
       fast-glob: 3.3.3
-      langchain: 1.2.18(@langchain/core@1.1.19)(zod-to-json-schema@3.25.1(zod@4.3.6))
+      langchain: 1.2.18(@langchain/core@1.1.19(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0)))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(zod-to-json-schema@3.25.1(zod@4.3.6))
       micromatch: 4.0.8
       yaml: 2.8.2
       zod: 4.3.6
@@ -3974,6 +4569,8 @@ snapshots:
 
   ee-first@1.1.1: {}
 
+  emoji-regex@8.0.0: {}
+
   encodeurl@2.0.0: {}
 
   es-define-property@1.0.1: {}
@@ -4021,6 +4618,8 @@ snapshots:
       '@esbuild/win32-arm64': 0.27.3
       '@esbuild/win32-ia32': 0.27.3
       '@esbuild/win32-x64': 0.27.3
+
+  escalade@3.2.0: {}
 
   escape-html@1.0.3: {}
 
@@ -4242,6 +4841,8 @@ snapshots:
 
   function-bind@1.1.2: {}
 
+  get-caller-file@2.0.5: {}
+
   get-intrinsic@1.3.0:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -4327,6 +4928,13 @@ snapshots:
       parent-module: 1.0.1
       resolve-from: 4.0.0
 
+  import-in-the-middle@1.15.0:
+    dependencies:
+      acorn: 8.15.0
+      acorn-import-attributes: 1.9.5(acorn@8.15.0)
+      cjs-module-lexer: 1.4.3
+      module-details-from-path: 1.0.4
+
   imurmurhash@0.1.4: {}
 
   inherits@2.0.4: {}
@@ -4335,9 +4943,15 @@ snapshots:
 
   ipaddr.js@1.9.1: {}
 
+  is-core-module@2.16.1:
+    dependencies:
+      hasown: 2.0.2
+
   is-electron@2.2.2: {}
 
   is-extglob@2.1.1: {}
+
+  is-fullwidth-code-point@3.0.0: {}
 
   is-glob@4.0.3:
     dependencies:
@@ -4422,12 +5036,12 @@ snapshots:
     dependencies:
       '@keyv/serialize': 1.1.1
 
-  langchain@1.2.18(@langchain/core@1.1.19)(zod-to-json-schema@3.25.1(zod@4.3.6)):
+  langchain@1.2.18(@langchain/core@1.1.19(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0)))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(zod-to-json-schema@3.25.1(zod@4.3.6)):
     dependencies:
-      '@langchain/core': 1.1.19
-      '@langchain/langgraph': 1.1.4(@langchain/core@1.1.19)(zod-to-json-schema@3.25.1(zod@4.3.6))(zod@3.25.76)
-      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@1.1.19)
-      langsmith: 0.4.12
+      '@langchain/core': 1.1.19(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))
+      '@langchain/langgraph': 1.1.4(@langchain/core@1.1.19(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0)))(zod-to-json-schema@3.25.1(zod@4.3.6))(zod@3.25.76)
+      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@1.1.19(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0)))
+      langsmith: 0.4.12(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))
       uuid: 10.0.0
       zod: 3.25.76
     transitivePeerDependencies:
@@ -4448,7 +5062,7 @@ snapshots:
       semver: 7.7.4
       uuid: 10.0.0
 
-  langsmith@0.4.12:
+  langsmith@0.4.12(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0)):
     dependencies:
       '@types/uuid': 10.0.0
       chalk: 4.1.2
@@ -4456,6 +5070,10 @@ snapshots:
       p-queue: 6.6.2
       semver: 7.7.4
       uuid: 10.0.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/exporter-trace-otlp-proto': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.0)
 
   levn@0.4.1:
     dependencies:
@@ -4473,6 +5091,8 @@ snapshots:
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
+
+  lodash.camelcase@4.3.0: {}
 
   lodash.clonedeep@4.5.0: {}
 
@@ -4557,6 +5177,8 @@ snapshots:
       pathe: 2.0.3
       pkg-types: 1.3.1
       ufo: 1.6.3
+
+  module-details-from-path@1.0.4: {}
 
   mpg123-decoder@1.0.3:
     dependencies:
@@ -4676,6 +5298,8 @@ snapshots:
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
+
+  path-parse@1.0.7: {}
 
   path-to-regexp@8.3.0: {}
 
@@ -4823,11 +5447,27 @@ snapshots:
 
   real-require@0.2.0: {}
 
+  require-directory@2.1.1: {}
+
   require-from-string@2.0.2: {}
+
+  require-in-the-middle@7.5.2:
+    dependencies:
+      debug: 4.4.3
+      module-details-from-path: 1.0.4
+      resolve: 1.22.11
+    transitivePeerDependencies:
+      - supports-color
 
   resolve-from@4.0.0: {}
 
   resolve-from@5.0.0: {}
+
+  resolve@1.22.11:
+    dependencies:
+      is-core-module: 2.16.1
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
 
   retry@0.13.1: {}
 
@@ -4923,6 +5563,8 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  shimmer@1.2.1: {}
+
   side-channel-list@1.0.0:
     dependencies:
       es-errors: 1.3.0
@@ -4973,9 +5615,19 @@ snapshots:
 
   std-env@3.10.0: {}
 
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
   string_decoder@1.3.0:
     dependencies:
       safe-buffer: 5.2.1
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
 
   strip-json-comments@3.1.1: {}
 
@@ -4997,6 +5649,8 @@ snapshots:
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
+
+  supports-preserve-symlinks-flag@1.0.0: {}
 
   thenify-all@1.6.0:
     dependencies:
@@ -5163,7 +5817,7 @@ snapshots:
       fsevents: 2.3.3
       yaml: 2.8.2
 
-  vitest@4.0.18(@types/node@22.19.11)(yaml@2.8.2):
+  vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(yaml@2.8.2):
     dependencies:
       '@vitest/expect': 4.0.18
       '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.2.2)(yaml@2.8.2))
@@ -5186,6 +5840,7 @@ snapshots:
       vite: 7.3.1(@types/node@22.19.11)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@opentelemetry/api': 1.9.0
       '@types/node': 22.19.11
     transitivePeerDependencies:
       - jiti
@@ -5200,7 +5855,7 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@4.0.18(@types/node@25.2.2)(yaml@2.8.2):
+  vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.2.2)(yaml@2.8.2):
     dependencies:
       '@vitest/expect': 4.0.18
       '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.2.2)(yaml@2.8.2))
@@ -5223,6 +5878,7 @@ snapshots:
       vite: 7.3.1(@types/node@25.2.2)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@opentelemetry/api': 1.9.0
       '@types/node': 25.2.2
     transitivePeerDependencies:
       - jiti
@@ -5255,11 +5911,31 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
   wrappy@1.0.2: {}
 
   ws@8.19.0: {}
 
+  y18n@5.0.8: {}
+
   yaml@2.8.2: {}
+
+  yargs-parser@21.1.1: {}
+
+  yargs@17.7.2:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
 
   yocto-queue@0.1.0: {}
 


### PR DESCRIPTION
## Summary

- Add new `@templar/telemetry` package with OpenTelemetry distributed tracing so a single trace spans the full request path (user → channel → gateway → node → agent → nexus → storage)
- Integrate OTel span context into `@templar/middleware` audit events (spanId + traceId), with UUID fallback when telemetry is disabled
- Add sync registration pattern in `@templar/core` (`registerMiddlewareWrapper`) to auto-wrap middleware with tracing without making `createTemplar()` async

### Key design decisions

| Decision | Choice |
|----------|--------|
| SDK auto-instrumentation | `@opentelemetry/instrumentation-undici` (Node fetch / @nexus/sdk) |
| Initialization | `OTEL_ENABLED` env var guard + lazy dynamic imports = zero overhead when disabled |
| Core ↔ Telemetry coupling | Registration pattern avoids circular deps, keeps `createTemplar()` synchronous |
| Sampling | `ParentBasedTraceIdRatio` matching Nexus Python |
| Metrics | Lazy-initialized counter + histogram (`getAgentOperations`, `getAgentLatency`) |

### New files (packages/telemetry/)

| File | Purpose |
|------|---------|
| `setup.ts` | `setupTelemetry()` / `shutdownTelemetry()` / `isTelemetryEnabled()` |
| `span-helpers.ts` | `withSpan()` — DRY span creation with auto error recording |
| `traced-middleware.ts` | `withTracing()` — wraps all 4 middleware lifecycle hooks |
| `metrics.ts` | `getAgentOperations()` / `getAgentLatency()` lazy OTel metrics |
| `types.ts` | `TelemetryConfig`, `SpanAttributes`, `SpanAttributeValue` |

### Modified files

| File | Change |
|------|--------|
| `packages/core/src/index.ts` | Add `registerMiddlewareWrapper` / `unregisterMiddlewareWrapper` + auto-wrap in `createTemplar()` |
| `packages/middleware/src/audit/middleware.ts` | Use OTel span context for spanId/traceId, UUID fallback |
| `packages/middleware/src/audit/types.ts` | Add optional `traceId` to `BaseAuditEvent` |

### Test coverage

- **35 new tests** in `@templar/telemetry` (setup, span-helpers, traced-middleware, integration)
- **5 new tests** in `@templar/middleware` (OTel active + UUID fallback audit suites)
- **0 regressions** — all 2,159+ existing tests pass

Closes #81

## Test plan

- [x] `pnpm build` — 21/21 packages pass
- [x] `pnpm typecheck` — 27/27 tasks pass
- [x] `pnpm lint` — 21/21 tasks pass
- [x] `pnpm test` — 42/42 tasks pass (2,159+ tests)
- [ ] Manual: Start Jaeger + Nexus with `OTEL_ENABLED=true`, verify end-to-end traces
- [ ] Manual: Verify zero overhead with `OTEL_ENABLED` unset (no OTel packages loaded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)