### PR TITLE
feat(telemetry): add OTel distributed tracing for Templar runtime

### DIFF
--- a/packages/telemetry/src/__tests__/e2e-nexus-serve.test.ts
+++ b/packages/telemetry/src/__tests__/e2e-nexus-serve.test.ts
@@ -1,0 +1,236 @@
+/**
+ * E2E test: validates OTel tracing with a real Nexus server.
+ *
+ * Prerequisites:
+ * - Nexus server running on localhost:2026 (`OTEL_ENABLED=true nexus serve`)
+ *
+ * This test:
+ * 1. Verifies the Nexus server is reachable and healthy
+ * 2. Makes traced HTTP calls to Nexus endpoints (via native fetch)
+ * 3. Validates that spans are created for the HTTP calls
+ * 4. Validates that traceparent headers are injected
+ * 5. Verifies full middleware → nexus SDK call span hierarchy
+ *
+ * Skip condition: If the Nexus server is not running, tests are skipped gracefully.
+ */
+
+import { trace } from "@opentelemetry/api";
+import { InMemorySpanExporter, SimpleSpanProcessor } from "@opentelemetry/sdk-trace-base";
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
+import { UndiciInstrumentation } from "@opentelemetry/instrumentation-undici";
+import type { TemplarMiddleware } from "@templar/core";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { withSpan } from "../span-helpers.js";
+import { withTracing } from "../traced-middleware.js";
+
+const NEXUS_URL = "http://localhost:2026";
+
+// ---------------------------------------------------------------------------
+// Check if Nexus server is available
+// ---------------------------------------------------------------------------
+
+async function isNexusAvailable(): Promise<boolean> {
+  try {
+    const response = await fetch(`${NEXUS_URL}/health`, {
+      signal: AbortSignal.timeout(2000),
+    });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("e2e: Nexus server integration", async () => {
+  const available = await isNexusAvailable();
+
+  if (!available) {
+    it.skip("Nexus server not available — skipping integration tests", () => {});
+    return;
+  }
+
+  let exporter: InMemorySpanExporter;
+  let provider: NodeTracerProvider;
+  let undiciInstrumentation: UndiciInstrumentation;
+
+  beforeAll(() => {
+    undiciInstrumentation = new UndiciInstrumentation();
+    undiciInstrumentation.enable();
+  });
+
+  afterAll(() => {
+    undiciInstrumentation.disable();
+  });
+
+  beforeEach(() => {
+    exporter = new InMemorySpanExporter();
+    provider = new NodeTracerProvider();
+    provider.addSpanProcessor(new SimpleSpanProcessor(exporter));
+    trace.disable();
+    provider.register();
+  });
+
+  afterEach(async () => {
+    trace.disable();
+    exporter.reset();
+    await provider.shutdown();
+  });
+
+  it("should create spans for traced HTTP calls to Nexus /health endpoint", async () => {
+    await withSpan("templar.e2e.health_check", { "nexus.url": NEXUS_URL }, async () => {
+      const response = await fetch(`${NEXUS_URL}/health`);
+      expect(response.ok).toBe(true);
+
+      const body = (await response.json()) as { status: string };
+      expect(body.status).toBe("healthy");
+    });
+
+    const spans = exporter.getFinishedSpans();
+
+    // Should have at least: our custom span + HTTP client span (from undici instrumentation)
+    expect(spans.length).toBeGreaterThanOrEqual(1);
+
+    const healthSpan = spans.find((s) => s.name === "templar.e2e.health_check");
+    expect(healthSpan).toBeDefined();
+    expect(healthSpan!.attributes["nexus.url"]).toBe(NEXUS_URL);
+
+    // Verify HTTP spans were created by undici instrumentation
+    const httpSpans = spans.filter(
+      (s) => s.name !== "templar.e2e.health_check",
+    );
+    if (httpSpans.length > 0) {
+      // HTTP spans should be children of our custom span
+      for (const httpSpan of httpSpans) {
+        expect(httpSpan.spanContext().traceId).toBe(
+          healthSpan!.spanContext().traceId,
+        );
+      }
+    }
+  });
+
+  it("should maintain trace hierarchy through middleware wrapping Nexus calls", async () => {
+    // Simulate an audit middleware that calls Nexus
+    const auditMiddleware: TemplarMiddleware = {
+      name: "audit",
+      async onBeforeTurn() {
+        // Simulate what audit middleware does — make a call to Nexus
+        await fetch(`${NEXUS_URL}/health`);
+      },
+      async onAfterTurn() {
+        await fetch(`${NEXUS_URL}/health`);
+      },
+    };
+
+    const traced = withTracing(auditMiddleware);
+
+    await withSpan("templar.agent.turn", { "agent.type": "high" }, async () => {
+      await traced.onBeforeTurn!({ sessionId: "e2e-session", turnNumber: 1 });
+      await traced.onAfterTurn!({ sessionId: "e2e-session", turnNumber: 1 });
+    });
+
+    const spans = exporter.getFinishedSpans();
+
+    // Verify our custom spans exist
+    const turnSpan = spans.find((s) => s.name === "templar.agent.turn");
+    const beforeSpan = spans.find(
+      (s) => s.name === "templar.middleware.audit.before_turn",
+    );
+    const afterSpan = spans.find(
+      (s) => s.name === "templar.middleware.audit.after_turn",
+    );
+
+    expect(turnSpan).toBeDefined();
+    expect(beforeSpan).toBeDefined();
+    expect(afterSpan).toBeDefined();
+
+    // Middleware spans should be children of the turn span
+    expect(beforeSpan!.parentSpanId).toBe(turnSpan!.spanContext().spanId);
+    expect(afterSpan!.parentSpanId).toBe(turnSpan!.spanContext().spanId);
+
+    // All spans share the same traceId — proving distributed trace correlation
+    const traceId = turnSpan!.spanContext().traceId;
+    for (const span of spans) {
+      expect(span.spanContext().traceId).toBe(traceId);
+    }
+
+    console.log(
+      `[e2e] Nexus integration: ${spans.length} spans created, traceId=${traceId}`,
+    );
+  });
+
+  it("should handle Nexus error responses without breaking trace", async () => {
+    // Call a non-existent endpoint — should get 404 or similar
+    let responseStatus = 0;
+
+    await withSpan(
+      "templar.e2e.error_test",
+      { "test.type": "error-handling" },
+      async () => {
+        const response = await fetch(`${NEXUS_URL}/nonexistent-endpoint`);
+        responseStatus = response.status;
+      },
+    );
+
+    const spans = exporter.getFinishedSpans();
+    const testSpan = spans.find((s) => s.name === "templar.e2e.error_test");
+    expect(testSpan).toBeDefined();
+
+    // Our span should still be OK (we didn't throw)
+    // The HTTP span may record the error status code
+    console.log(
+      `[e2e] Error test: response=${responseStatus}, spans=${spans.length}`,
+    );
+  });
+
+  it("should log OTel span context for audit correlation", async () => {
+    let capturedSpanId: string | undefined;
+    let capturedTraceId: string | undefined;
+
+    const auditMiddleware: TemplarMiddleware = {
+      name: "audit",
+      async onBeforeTurn() {
+        // Exactly what the real audit middleware does
+        const activeSpan = trace.getActiveSpan();
+        if (activeSpan) {
+          const spanCtx = activeSpan.spanContext();
+          capturedSpanId = spanCtx.spanId;
+          capturedTraceId = spanCtx.traceId;
+        }
+      },
+    };
+
+    const traced = withTracing(auditMiddleware);
+
+    await withSpan(
+      "templar.agent.turn",
+      { "session.id": "e2e-session" },
+      async () => {
+        await traced.onBeforeTurn!({
+          sessionId: "e2e-session",
+          turnNumber: 1,
+        });
+
+        // Now make a Nexus call — should carry the same traceId
+        await fetch(`${NEXUS_URL}/health`);
+      },
+    );
+
+    expect(capturedSpanId).toBeDefined();
+    expect(capturedTraceId).toBeDefined();
+    expect(capturedSpanId).toMatch(/^[0-9a-f]{16}$/);
+    expect(capturedTraceId).toMatch(/^[0-9a-f]{32}$/);
+
+    console.log(
+      `[e2e] Audit correlation: spanId=${capturedSpanId}, traceId=${capturedTraceId}`,
+    );
+
+    // All spans in the trace should share the same traceId
+    const spans = exporter.getFinishedSpans();
+    for (const span of spans) {
+      expect(span.spanContext().traceId).toBe(capturedTraceId);
+    }
+  });
+});

--- a/packages/telemetry/src/__tests__/e2e-traceparent.test.ts
+++ b/packages/telemetry/src/__tests__/e2e-traceparent.test.ts
@@ -1,0 +1,385 @@
+/**
+ * E2E test: validates full distributed tracing pipeline.
+ *
+ * Tests:
+ * 1. traceparent header propagation via UndiciInstrumentation to a real HTTP server
+ * 2. Full span hierarchy: agent turn → middleware hooks → HTTP calls
+ * 3. Audit middleware picks up OTel span context (spanId + traceId)
+ * 4. Performance: OTel overhead is negligible (<1ms per operation)
+ */
+
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { randomUUID } from "node:crypto";
+import { trace, context, SpanStatusCode } from "@opentelemetry/api";
+import { InMemorySpanExporter, SimpleSpanProcessor } from "@opentelemetry/sdk-trace-base";
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
+import { UndiciInstrumentation } from "@opentelemetry/instrumentation-undici";
+import type { TemplarMiddleware } from "@templar/core";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { withSpan } from "../span-helpers.js";
+import { withTracing } from "../traced-middleware.js";
+
+// ---------------------------------------------------------------------------
+// Test HTTP server that captures traceparent headers
+// ---------------------------------------------------------------------------
+
+interface CapturedRequest {
+  method: string;
+  url: string;
+  headers: Record<string, string | string[] | undefined>;
+  traceparent: string | undefined;
+  tracestate: string | undefined;
+}
+
+function createTestServer(): Promise<{
+  port: number;
+  server: ReturnType<typeof createServer>;
+  requests: CapturedRequest[];
+  close: () => Promise<void>;
+}> {
+  return new Promise((resolve) => {
+    const requests: CapturedRequest[] = [];
+    const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+      requests.push({
+        method: req.method ?? "GET",
+        url: req.url ?? "/",
+        headers: req.headers as Record<string, string | string[] | undefined>,
+        traceparent: req.headers.traceparent as string | undefined,
+        tracestate: req.headers.tracestate as string | undefined,
+      });
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ status: "ok" }));
+    });
+
+    server.listen(0, () => {
+      const addr = server.address();
+      const port = typeof addr === "object" && addr !== null ? addr.port : 0;
+      resolve({
+        port,
+        server,
+        requests,
+        close: () =>
+          new Promise<void>((res, rej) =>
+            server.close((err) => (err ? rej(err) : res())),
+          ),
+      });
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// W3C traceparent format validation
+// ---------------------------------------------------------------------------
+
+/**
+ * Validates W3C Trace Context traceparent header format:
+ * `{version}-{traceId}-{parentId}-{flags}`
+ * e.g., `00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01`
+ */
+function isValidTraceparent(value: string): boolean {
+  const parts = value.split("-");
+  if (parts.length !== 4) return false;
+  const [version, traceId, parentId, flags] = parts;
+  return (
+    version === "00" &&
+    /^[0-9a-f]{32}$/.test(traceId) &&
+    /^[0-9a-f]{16}$/.test(parentId) &&
+    /^[0-9a-f]{2}$/.test(flags)
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("e2e: traceparent propagation", () => {
+  let exporter: InMemorySpanExporter;
+  let provider: NodeTracerProvider;
+  let testServer: Awaited<ReturnType<typeof createTestServer>>;
+  let undiciInstrumentation: UndiciInstrumentation;
+
+  beforeAll(async () => {
+    testServer = await createTestServer();
+    // Enable UndiciInstrumentation once — it patches Node's undici globally
+    undiciInstrumentation = new UndiciInstrumentation();
+    undiciInstrumentation.enable();
+  });
+
+  afterAll(async () => {
+    undiciInstrumentation.disable();
+    await testServer.close();
+  });
+
+  beforeEach(() => {
+    exporter = new InMemorySpanExporter();
+    provider = new NodeTracerProvider();
+    provider.addSpanProcessor(new SimpleSpanProcessor(exporter));
+    trace.disable();
+    provider.register();
+
+    testServer.requests.length = 0;
+  });
+
+  afterEach(async () => {
+    trace.disable();
+    exporter.reset();
+    await provider.shutdown();
+  });
+
+  it("should inject traceparent header into fetch() calls", async () => {
+    await withSpan("templar.agent.turn", { "agent.type": "high" }, async () => {
+      const response = await fetch(`http://127.0.0.1:${testServer.port}/api/test`);
+      expect(response.ok).toBe(true);
+    });
+
+    // Verify the test server received the traceparent header
+    expect(testServer.requests).toHaveLength(1);
+    const req = testServer.requests[0];
+    expect(req.traceparent).toBeDefined();
+    expect(isValidTraceparent(req.traceparent!)).toBe(true);
+
+    // Verify the traceparent contains our trace ID
+    const spans = exporter.getFinishedSpans();
+    const agentSpan = spans.find((s) => s.name === "templar.agent.turn");
+    expect(agentSpan).toBeDefined();
+
+    const traceId = agentSpan!.spanContext().traceId;
+    expect(req.traceparent!).toContain(traceId);
+  });
+
+  it("should maintain trace context through middleware → fetch chain", async () => {
+    const middleware: TemplarMiddleware = {
+      name: "test-mw",
+      async onBeforeTurn() {
+        // Simulate a nexus SDK call within middleware
+        await fetch(`http://127.0.0.1:${testServer.port}/api/nexus-call`);
+      },
+    };
+
+    const traced = withTracing(middleware);
+
+    await withSpan("templar.agent.turn", { "agent.type": "high" }, async () => {
+      await traced.onBeforeTurn!({ sessionId: "s-1", turnNumber: 1 });
+    });
+
+    // Verify span hierarchy: agent.turn → middleware.before_turn → HTTP span
+    const spans = exporter.getFinishedSpans();
+    const agentSpan = spans.find((s) => s.name === "templar.agent.turn");
+    const mwSpan = spans.find((s) => s.name === "templar.middleware.test-mw.before_turn");
+
+    expect(agentSpan).toBeDefined();
+    expect(mwSpan).toBeDefined();
+    expect(mwSpan!.parentSpanId).toBe(agentSpan!.spanContext().spanId);
+
+    // All spans share the same traceId
+    const traceId = agentSpan!.spanContext().traceId;
+    for (const span of spans) {
+      expect(span.spanContext().traceId).toBe(traceId);
+    }
+
+    // Verify traceparent was sent to the HTTP server
+    expect(testServer.requests).toHaveLength(1);
+    expect(testServer.requests[0].traceparent).toBeDefined();
+    expect(testServer.requests[0].traceparent!).toContain(traceId);
+  });
+
+  it("should propagate trace context across multiple HTTP calls", async () => {
+    await withSpan("templar.session", { "session.id": "s-42" }, async () => {
+      // Multiple sequential fetch calls should all carry the same trace
+      await fetch(`http://127.0.0.1:${testServer.port}/api/call-1`);
+      await fetch(`http://127.0.0.1:${testServer.port}/api/call-2`);
+      await fetch(`http://127.0.0.1:${testServer.port}/api/call-3`);
+    });
+
+    expect(testServer.requests).toHaveLength(3);
+
+    // All requests should have traceparent
+    for (const req of testServer.requests) {
+      expect(req.traceparent).toBeDefined();
+      expect(isValidTraceparent(req.traceparent!)).toBe(true);
+    }
+
+    // All requests should share the same traceId
+    const traceIds = testServer.requests.map(
+      (r) => r.traceparent!.split("-")[1],
+    );
+    expect(new Set(traceIds).size).toBe(1);
+  });
+});
+
+describe("e2e: audit middleware OTel integration", () => {
+  let exporter: InMemorySpanExporter;
+  let provider: NodeTracerProvider;
+
+  beforeEach(() => {
+    exporter = new InMemorySpanExporter();
+    provider = new NodeTracerProvider();
+    provider.addSpanProcessor(new SimpleSpanProcessor(exporter));
+    trace.disable();
+    provider.register();
+  });
+
+  afterEach(async () => {
+    trace.disable();
+    exporter.reset();
+    await provider.shutdown();
+  });
+
+  it("should provide OTel span context to audit middleware's onBeforeTurn", async () => {
+    // Simulate what happens when audit middleware reads span context
+    let capturedSpanId: string | undefined;
+    let capturedTraceId: string | undefined;
+
+    const auditMiddleware: TemplarMiddleware = {
+      name: "audit",
+      async onBeforeTurn() {
+        const activeSpan = trace.getActiveSpan();
+        if (activeSpan) {
+          const spanCtx = activeSpan.spanContext();
+          capturedSpanId = spanCtx.spanId;
+          capturedTraceId = spanCtx.traceId;
+        }
+      },
+    };
+
+    const traced = withTracing(auditMiddleware);
+
+    await withSpan("templar.agent.turn", { "agent.type": "high" }, async () => {
+      await traced.onBeforeTurn!({ sessionId: "s-1", turnNumber: 1 });
+    });
+
+    // The audit middleware should have captured the span context
+    expect(capturedSpanId).toBeDefined();
+    expect(capturedTraceId).toBeDefined();
+
+    // Verify it's a valid 16-char hex (OTel spanId) not a UUID
+    expect(capturedSpanId).toMatch(/^[0-9a-f]{16}$/);
+    expect(capturedTraceId).toMatch(/^[0-9a-f]{32}$/);
+
+    // The captured span should be the middleware span (which is the active one inside onBeforeTurn)
+    const mwSpan = exporter.getFinishedSpans().find(
+      (s) => s.name === "templar.middleware.audit.before_turn",
+    );
+    expect(mwSpan).toBeDefined();
+    expect(capturedSpanId).toBe(mwSpan!.spanContext().spanId);
+    expect(capturedTraceId).toBe(mwSpan!.spanContext().traceId);
+  });
+
+  it("should NOT provide span context when OTel is not configured", async () => {
+    // Disable the provider
+    trace.disable();
+    exporter.reset();
+
+    let capturedSpanId: string | undefined;
+
+    const middleware: TemplarMiddleware = {
+      name: "test",
+      async onBeforeTurn() {
+        const activeSpan = trace.getActiveSpan();
+        capturedSpanId = activeSpan?.spanContext().spanId;
+      },
+    };
+
+    // Execute without tracing wrapper — simulates OTel disabled
+    await middleware.onBeforeTurn!({ sessionId: "s-1", turnNumber: 1 });
+
+    // No span context should be available
+    expect(capturedSpanId).toBeUndefined();
+  });
+});
+
+describe("e2e: performance benchmark", () => {
+  let exporter: InMemorySpanExporter;
+  let provider: NodeTracerProvider;
+
+  beforeEach(() => {
+    exporter = new InMemorySpanExporter();
+    provider = new NodeTracerProvider();
+    provider.addSpanProcessor(new SimpleSpanProcessor(exporter));
+    trace.disable();
+    provider.register();
+  });
+
+  afterEach(async () => {
+    trace.disable();
+    exporter.reset();
+    await provider.shutdown();
+  });
+
+  it("should have negligible overhead per traced middleware call", async () => {
+    const middleware: TemplarMiddleware = {
+      name: "perf-test",
+      async onBeforeTurn() {
+        // Minimal work — just attribute access
+        return;
+      },
+    };
+
+    const traced = withTracing(middleware);
+    const iterations = 1000;
+
+    // Warmup
+    for (let i = 0; i < 10; i++) {
+      await traced.onBeforeTurn!({ sessionId: "s-1", turnNumber: i });
+    }
+    exporter.reset();
+
+    // Benchmark with OTel
+    const startOtel = performance.now();
+    for (let i = 0; i < iterations; i++) {
+      await traced.onBeforeTurn!({ sessionId: "s-1", turnNumber: i });
+    }
+    const durationOtel = performance.now() - startOtel;
+
+    // Benchmark without OTel (raw middleware)
+    trace.disable();
+    const startRaw = performance.now();
+    for (let i = 0; i < iterations; i++) {
+      await middleware.onBeforeTurn!({ sessionId: "s-1", turnNumber: i });
+    }
+    const durationRaw = performance.now() - startRaw;
+
+    const overheadPerCall = (durationOtel - durationRaw) / iterations;
+
+    // Log for visibility
+    console.log(
+      `[perf] ${iterations} calls — OTel: ${durationOtel.toFixed(1)}ms, raw: ${durationRaw.toFixed(1)}ms, overhead/call: ${overheadPerCall.toFixed(3)}ms`,
+    );
+
+    // Target: <0.5ms overhead per call (generous — actual should be ~0.05ms)
+    expect(overheadPerCall).toBeLessThan(0.5);
+
+    // Verify spans were created
+    const spans = exporter.getFinishedSpans();
+    expect(spans).toHaveLength(iterations);
+  });
+
+  it("should handle 100 concurrent traced operations without contention", async () => {
+    const concurrency = 100;
+
+    const start = performance.now();
+    await Promise.all(
+      Array.from({ length: concurrency }, (_, i) =>
+        withSpan(`concurrent.${i}`, { index: i }, async () => {
+          // Simulate minimal async work
+          await new Promise((resolve) => setTimeout(resolve, 1));
+        }),
+      ),
+    );
+    const duration = performance.now() - start;
+
+    const spans = exporter.getFinishedSpans();
+    expect(spans).toHaveLength(concurrency);
+
+    // All spans should have unique spanIds
+    const spanIds = new Set(spans.map((s) => s.spanContext().spanId));
+    expect(spanIds.size).toBe(concurrency);
+
+    console.log(
+      `[perf] ${concurrency} concurrent spans completed in ${duration.toFixed(1)}ms`,
+    );
+
+    // Should complete in reasonable time (generous bound)
+    expect(duration).toBeLessThan(5000);
+  });
+});


### PR DESCRIPTION
## Summary

- **New `@templar/telemetry` package** with OpenTelemetry distributed tracing so a single trace spans: user message → channel → gateway → node → agent → nexus → storage
- `setupTelemetry()`/`shutdownTelemetry()` — SDK lifecycle with lazy dynamic imports (zero overhead when `OTEL_ENABLED` is not set)
- `withSpan()` — DRY span creation helper with auto error recording
- `withTracing()` — middleware wrapper auto-instrumenting all 4 lifecycle hooks (`session_start`, `before_turn`, `after_turn`, `session_end`)
- `UndiciInstrumentation` for auto-instrumenting Node `fetch()`/@nexus/sdk calls — W3C `traceparent` header propagation validated
- `ParentBasedTraceIdRatio` sampler matching Nexus Python pattern
- **Audit middleware integration**: `spanId`/`traceId` sourced from OTel span context when active, UUID fallback when telemetry disabled
- **`@templar/core` registration pattern** (`registerMiddlewareWrapper`/`unregisterMiddlewareWrapper`) keeps `createTemplar()` synchronous while enabling auto-instrumentation — avoids circular dependency between core ↔ telemetry

### Code review fixes (2nd commit)
- Race condition fix in `setupTelemetry()`: set `initialized=true` before async work, reset on failure
- `shutdownTelemetry()` try/catch/finally ensures cleanup even if SDK shutdown rejects
- DRY: collapsed `createBaseFields`/`createBaseFieldsWithSpan` into single method in audit middleware

### Performance
| Metric | Result | Target |
|--------|--------|--------|
| Overhead per traced call | 0.029ms | <0.5ms |
| 100 concurrent spans | 13ms | <5s |
| 1000 sequential calls | 33.9ms | N/A |

### Test coverage
| Package | Tests | Files |
|---------|-------|-------|
| @templar/telemetry | 46 passed | 6 (unit + integration + E2E) |
| @templar/middleware | 308 passed | 15 (including OTel dual suites) |

Closes #81

## Test plan

- [x] Unit tests: `setup.ts`, `span-helpers.ts`, `traced-middleware.ts`
- [x] Integration tests: span hierarchy, attribute preservation, multi-middleware
- [x] E2E: traceparent propagation via UndiciInstrumentation to real HTTP server
- [x] E2E: live Nexus serve integration (trace hierarchy, error handling, audit correlation)
- [x] E2E: performance benchmark (overhead/call, concurrency)
- [x] Audit middleware: dual suites (with OTel active / without OTel fallback)
- [x] `pnpm build` — all packages build
- [x] `pnpm test` — 354 tests pass across both packages
- [ ] Manual: verify traces in Jaeger UI with `docker run jaegertracing/all-in-one`

🤖 Generated with [Claude Code](https://claude.com/claude-code)