### PR TITLE
feat(gateway): implement 4-mode conversation scoping

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -50,6 +50,7 @@ export type {
   ChannelIdentityConfig,
   ChannelModule,
   ContentBlock,
+  ConversationContext,
   DeepAgentConfig,
   FileBlock,
   FileCapability,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -311,7 +311,12 @@ export interface ChannelModule {
 }
 
 /**
- * Session context — passed to middleware on session start/end
+ * Session context — passed to middleware on session start/end.
+ *
+ * NOTE: This type represents a conversation-level context (agent + user + scope),
+ * NOT the node connection lifecycle (see @templar/gateway-protocol SessionInfo).
+ * A type alias `ConversationContext` is provided for clarity in new code.
+ * Full rename planned for a follow-up PR.
  */
 export interface SessionContext {
   /** Unique session identifier */
@@ -325,6 +330,9 @@ export interface SessionContext {
   /** Arbitrary metadata */
   metadata?: Record<string, unknown>;
 }
+
+/** @see SessionContext — alias for clarity in conversation-scoping code */
+export type ConversationContext = SessionContext;
 
 /**
  * Turn context — passed to middleware before/after each turn

--- a/packages/gateway/src/__tests__/config-watcher.test.ts
+++ b/packages/gateway/src/__tests__/config-watcher.test.ts
@@ -15,6 +15,9 @@ const VALID_CONFIG: GatewayConfig = {
   laneCapacity: 256,
   maxConnections: 1024,
   maxFramesPerSecond: 100,
+  defaultConversationScope: "per-channel-peer",
+  maxConversations: 100_000,
+  conversationTtl: 86_400_000,
 };
 
 function createMockDeps(): ConfigWatcherDeps {

--- a/packages/gateway/src/__tests__/helpers.ts
+++ b/packages/gateway/src/__tests__/helpers.ts
@@ -25,6 +25,9 @@ export const DEFAULT_CONFIG: GatewayConfig = {
   laneCapacity: 256,
   maxConnections: 1024,
   maxFramesPerSecond: 100,
+  defaultConversationScope: "per-channel-peer",
+  maxConversations: 100_000,
+  conversationTtl: 86_400_000,
 };
 
 export const DEFAULT_CAPS: NodeCapabilities = {

--- a/packages/gateway/src/conversations/__tests__/conversation-store.bench.ts
+++ b/packages/gateway/src/conversations/__tests__/conversation-store.bench.ts
@@ -1,0 +1,49 @@
+import { bench, describe } from "vitest";
+import { type ConversationKey, resolveConversationKey } from "../../protocol/index.js";
+import { ConversationStore } from "../conversation-store.js";
+
+describe("ConversationStore performance", () => {
+  bench("resolveConversationKey (per-channel-peer)", () => {
+    resolveConversationKey({
+      scope: "per-channel-peer",
+      agentId: "agent-1",
+      channelId: "whatsapp",
+      peerId: "peer-42",
+      messageType: "dm",
+    });
+  });
+
+  bench("store.bind() single entry", () => {
+    const store = new ConversationStore({
+      maxConversations: 100_000,
+      conversationTtl: 86_400_000,
+    });
+    store.bind("agent:a1:whatsapp:dm:p1" as ConversationKey, "node-1");
+  });
+
+  const lookupStore = new ConversationStore({
+    maxConversations: 200_000,
+    conversationTtl: 86_400_000,
+  });
+  for (let i = 0; i < 100_000; i++) {
+    lookupStore.bind(`agent:a1:ch:dm:peer-${i}` as ConversationKey, "node-1");
+  }
+  bench("store.get() at 100K entries", () => {
+    lookupStore.get("agent:a1:ch:dm:peer-50000" as ConversationKey);
+  });
+
+  const sweepStore = new ConversationStore({
+    maxConversations: 200_000,
+    conversationTtl: 60_000,
+  });
+  const now = 100_000;
+  for (let i = 0; i < 90_000; i++) {
+    sweepStore.bind(`agent:a1:ch:dm:fresh-${i}` as ConversationKey, "node-1", now);
+  }
+  for (let i = 0; i < 10_000; i++) {
+    sweepStore.bind(`agent:a1:ch:dm:old-${i}` as ConversationKey, "node-1", 1000);
+  }
+  bench("store.sweep() at 100K entries (10% expired)", () => {
+    sweepStore.sweep(now + 60_001);
+  });
+});

--- a/packages/gateway/src/conversations/__tests__/conversation-store.test.ts
+++ b/packages/gateway/src/conversations/__tests__/conversation-store.test.ts
@@ -1,0 +1,251 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import type { ConversationKey } from "../../protocol/index.js";
+import { ConversationStore } from "../conversation-store.js";
+
+function key(s: string): ConversationKey {
+  return s as ConversationKey;
+}
+
+describe("ConversationStore", () => {
+  let store: ConversationStore;
+
+  beforeEach(() => {
+    store = new ConversationStore({
+      maxConversations: 100,
+      conversationTtl: 60_000,
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Binding CRUD
+  // -------------------------------------------------------------------------
+
+  describe("bind and get", () => {
+    it("binds a conversation to a node", () => {
+      const binding = store.bind(key("conv-1"), "node-a");
+      expect(binding.conversationKey).toBe("conv-1");
+      expect(binding.nodeId).toBe("node-a");
+      expect(binding.createdAt).toBeGreaterThan(0);
+      expect(binding.lastActiveAt).toBeGreaterThan(0);
+    });
+
+    it("retrieves a bound conversation", () => {
+      store.bind(key("conv-1"), "node-a");
+      const result = store.get(key("conv-1"));
+      expect(result).toBeDefined();
+      expect(result?.nodeId).toBe("node-a");
+    });
+
+    it("returns undefined for unbound key", () => {
+      expect(store.get(key("unknown"))).toBeUndefined();
+    });
+
+    it("updates lastActiveAt on re-bind to same node", () => {
+      const b1 = store.bind(key("conv-1"), "node-a", 1000);
+      const b2 = store.bind(key("conv-1"), "node-a", 2000);
+      expect(b2.lastActiveAt).toBe(2000);
+      expect(b2.createdAt).toBe(b1.createdAt);
+    });
+
+    it("updates nodeId on re-bind to different node", () => {
+      store.bind(key("conv-1"), "node-a");
+      store.bind(key("conv-1"), "node-b");
+      expect(store.get(key("conv-1"))?.nodeId).toBe("node-b");
+    });
+
+    it("preserves createdAt on re-bind", () => {
+      store.bind(key("conv-1"), "node-a", 1000);
+      store.bind(key("conv-1"), "node-b", 2000);
+      expect(store.get(key("conv-1"))?.createdAt).toBe(1000);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Size tracking
+  // -------------------------------------------------------------------------
+
+  describe("size", () => {
+    it("starts at 0", () => {
+      expect(store.size).toBe(0);
+    });
+
+    it("increments on new bindings", () => {
+      store.bind(key("conv-1"), "node-a");
+      store.bind(key("conv-2"), "node-a");
+      expect(store.size).toBe(2);
+    });
+
+    it("does not increment on re-bind", () => {
+      store.bind(key("conv-1"), "node-a");
+      store.bind(key("conv-1"), "node-a");
+      expect(store.size).toBe(1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Node removal (cascade via reverse index)
+  // -------------------------------------------------------------------------
+
+  describe("removeNode", () => {
+    it("removes all bindings for a node", () => {
+      store.bind(key("conv-1"), "node-a");
+      store.bind(key("conv-2"), "node-a");
+      store.bind(key("conv-3"), "node-b");
+
+      const removed = store.removeNode("node-a");
+      expect(removed).toBe(2);
+      expect(store.size).toBe(1);
+      expect(store.get(key("conv-1"))).toBeUndefined();
+      expect(store.get(key("conv-2"))).toBeUndefined();
+      expect(store.get(key("conv-3"))).toBeDefined();
+    });
+
+    it("returns 0 for unknown node", () => {
+      expect(store.removeNode("unknown")).toBe(0);
+    });
+
+    it("handles re-bind to different node before removal", () => {
+      store.bind(key("conv-1"), "node-a");
+      store.bind(key("conv-1"), "node-b");
+      const removed = store.removeNode("node-a");
+      expect(removed).toBe(0);
+      expect(store.get(key("conv-1"))?.nodeId).toBe("node-b");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // TTL sweep
+  // -------------------------------------------------------------------------
+
+  describe("sweep", () => {
+    it("removes expired bindings", () => {
+      store.bind(key("old"), "node-a", 1000);
+      store.bind(key("new"), "node-a", 100_000);
+
+      const swept = store.sweep(100_000);
+      expect(swept).toBe(1);
+      expect(store.get(key("old"))).toBeUndefined();
+      expect(store.get(key("new"))).toBeDefined();
+    });
+
+    it("returns 0 when nothing expired", () => {
+      store.bind(key("conv-1"), "node-a", 50_000);
+      expect(store.sweep(60_000)).toBe(0);
+    });
+
+    it("sweeps all expired bindings", () => {
+      store.bind(key("a"), "node-a", 100);
+      store.bind(key("b"), "node-a", 200);
+      store.bind(key("c"), "node-a", 300);
+
+      const swept = store.sweep(61_000);
+      expect(swept).toBe(3);
+      expect(store.size).toBe(0);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Capacity eviction
+  // -------------------------------------------------------------------------
+
+  describe("max capacity eviction", () => {
+    it("evicts oldest binding when at capacity", () => {
+      const smallStore = new ConversationStore({
+        maxConversations: 3,
+        conversationTtl: 60_000,
+      });
+
+      smallStore.bind(key("oldest"), "node-a", 1000);
+      smallStore.bind(key("middle"), "node-a", 2000);
+      smallStore.bind(key("newest"), "node-a", 3000);
+
+      // This should evict "oldest"
+      smallStore.bind(key("overflow"), "node-a", 4000);
+
+      expect(smallStore.size).toBe(3);
+      expect(smallStore.get(key("oldest"))).toBeUndefined();
+      expect(smallStore.get(key("middle"))).toBeDefined();
+      expect(smallStore.get(key("overflow"))).toBeDefined();
+    });
+
+    it("does not evict when re-binding existing key at capacity", () => {
+      const smallStore = new ConversationStore({
+        maxConversations: 2,
+        conversationTtl: 60_000,
+      });
+
+      smallStore.bind(key("a"), "node-a", 1000);
+      smallStore.bind(key("b"), "node-a", 2000);
+      smallStore.bind(key("a"), "node-a", 3000); // re-bind, not new
+
+      expect(smallStore.size).toBe(2);
+      expect(smallStore.get(key("a"))?.lastActiveAt).toBe(3000);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Clear
+  // -------------------------------------------------------------------------
+
+  describe("clear", () => {
+    it("removes all bindings", () => {
+      store.bind(key("conv-1"), "node-a");
+      store.bind(key("conv-2"), "node-b");
+      store.clear();
+      expect(store.size).toBe(0);
+      expect(store.get(key("conv-1"))).toBeUndefined();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Config update
+  // -------------------------------------------------------------------------
+
+  describe("updateConfig", () => {
+    it("applies new config values", () => {
+      const smallStore = new ConversationStore({
+        maxConversations: 2,
+        conversationTtl: 60_000,
+      });
+
+      smallStore.bind(key("a"), "node-a");
+      smallStore.bind(key("b"), "node-a");
+
+      // Expand capacity
+      smallStore.updateConfig({ maxConversations: 10, conversationTtl: 60_000 });
+      smallStore.bind(key("c"), "node-a");
+
+      expect(smallStore.size).toBe(3);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Idempotent bind
+  // -------------------------------------------------------------------------
+
+  describe("concurrent bind for same key", () => {
+    it("is idempotent — last bind wins", () => {
+      store.bind(key("conv-1"), "node-a", 1000);
+      store.bind(key("conv-1"), "node-b", 2000);
+      store.bind(key("conv-1"), "node-a", 3000);
+
+      expect(store.get(key("conv-1"))?.nodeId).toBe("node-a");
+      expect(store.get(key("conv-1"))?.lastActiveAt).toBe(3000);
+      expect(store.size).toBe(1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Immutable pattern verification
+  // -------------------------------------------------------------------------
+
+  describe("immutability", () => {
+    it("bind returns a new binding object", () => {
+      const b1 = store.bind(key("conv-1"), "node-a", 1000);
+      const b2 = store.bind(key("conv-1"), "node-a", 2000);
+      expect(b1).not.toBe(b2);
+      expect(b1.lastActiveAt).toBe(1000);
+      expect(b2.lastActiveAt).toBe(2000);
+    });
+  });
+});

--- a/packages/gateway/src/conversations/conversation-store.ts
+++ b/packages/gateway/src/conversations/conversation-store.ts
@@ -1,0 +1,203 @@
+import type { ConversationKey } from "../protocol/index.js";
+import { mapDelete, mapFilter, mapSet } from "../utils/immutable-map.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ConversationBinding {
+  readonly conversationKey: ConversationKey;
+  readonly nodeId: string;
+  readonly createdAt: number;
+  readonly lastActiveAt: number;
+}
+
+export interface ConversationStoreConfig {
+  readonly maxConversations: number;
+  readonly conversationTtl: number;
+}
+
+// ---------------------------------------------------------------------------
+// ConversationStore
+// ---------------------------------------------------------------------------
+
+/**
+ * Tracks conversation-to-node bindings with TTL expiry and reverse indexing.
+ *
+ * Immutable maps are used for the primary and reverse indexes — every mutation
+ * returns a new map, leaving the previous reference unchanged.
+ *
+ * Features:
+ * - Primary index:   conversationKey → ConversationBinding
+ * - Reverse index:   nodeId → Set<conversationKey>  (O(k) node cleanup)
+ * - TTL sweep:       removes bindings older than `conversationTtl`
+ * - Capacity eviction: evicts oldest binding when `maxConversations` is reached
+ */
+export class ConversationStore {
+  private bindings: ReadonlyMap<string, ConversationBinding> = new Map();
+  private nodeIndex: ReadonlyMap<string, ReadonlySet<string>> = new Map();
+  private config: ConversationStoreConfig;
+
+  constructor(config: ConversationStoreConfig) {
+    this.config = config;
+  }
+
+  /**
+   * Bind or update a conversation to a node.
+   * If the conversation already exists, updates `lastActiveAt` and `nodeId`.
+   * Evicts the oldest conversation if capacity is exceeded.
+   */
+  bind(key: ConversationKey, nodeId: string, now?: number): ConversationBinding {
+    const timestamp = now ?? Date.now();
+    const existing = this.bindings.get(key);
+
+    // If re-binding to a different node, remove from old node's reverse index
+    if (existing && existing.nodeId !== nodeId) {
+      this.removeFromNodeIndex(existing.nodeId, key);
+    }
+
+    // Evict oldest if at capacity and this is a new key
+    if (!existing && this.bindings.size >= this.config.maxConversations) {
+      this.evictOldest();
+    }
+
+    const binding: ConversationBinding = {
+      conversationKey: key,
+      nodeId,
+      createdAt: existing?.createdAt ?? timestamp,
+      lastActiveAt: timestamp,
+    };
+
+    this.bindings = mapSet(this.bindings, key, binding);
+    this.addToNodeIndex(nodeId, key);
+
+    return binding;
+  }
+
+  /**
+   * Get the binding for a conversation key.
+   */
+  get(key: ConversationKey): ConversationBinding | undefined {
+    return this.bindings.get(key);
+  }
+
+  /**
+   * Remove all bindings for a node. Returns the number of bindings removed.
+   * Uses the reverse index for O(k) performance where k = bindings for this node.
+   */
+  removeNode(nodeId: string): number {
+    const keys = this.nodeIndex.get(nodeId);
+    if (!keys || keys.size === 0) {
+      return 0;
+    }
+
+    let nextBindings = this.bindings;
+    for (const key of keys) {
+      nextBindings = mapDelete(nextBindings, key);
+    }
+    this.bindings = nextBindings;
+
+    const count = keys.size;
+    this.nodeIndex = mapDelete(this.nodeIndex, nodeId);
+    return count;
+  }
+
+  /**
+   * Remove expired bindings. Returns the number swept.
+   */
+  sweep(now?: number): number {
+    const cutoff = (now ?? Date.now()) - this.config.conversationTtl;
+    let swept = 0;
+
+    // Collect expired keys first to batch updates
+    const expiredKeys: string[] = [];
+    for (const [key, binding] of this.bindings) {
+      if (binding.lastActiveAt < cutoff) {
+        expiredKeys.push(key);
+      }
+    }
+
+    if (expiredKeys.length === 0) {
+      return 0;
+    }
+
+    // Remove from reverse index
+    for (const key of expiredKeys) {
+      const binding = this.bindings.get(key);
+      if (binding) {
+        this.removeFromNodeIndex(binding.nodeId, key);
+        swept++;
+      }
+    }
+
+    // Remove from primary index
+    this.bindings = mapFilter(this.bindings, (_key, binding) => binding.lastActiveAt >= cutoff);
+
+    return swept;
+  }
+
+  /**
+   * Clear all bindings (e.g., on scope config change).
+   */
+  clear(): void {
+    this.bindings = new Map();
+    this.nodeIndex = new Map();
+  }
+
+  /**
+   * Update the store configuration (e.g., on hot-reload).
+   */
+  updateConfig(config: ConversationStoreConfig): void {
+    this.config = config;
+  }
+
+  /**
+   * Number of tracked conversations.
+   */
+  get size(): number {
+    return this.bindings.size;
+  }
+
+  // -------------------------------------------------------------------------
+  // Internal helpers
+  // -------------------------------------------------------------------------
+
+  private addToNodeIndex(nodeId: string, key: string): void {
+    const existing = this.nodeIndex.get(nodeId) ?? new Set<string>();
+    const next = new Set(existing);
+    next.add(key);
+    this.nodeIndex = mapSet(this.nodeIndex, nodeId, next);
+  }
+
+  private removeFromNodeIndex(nodeId: string, key: string): void {
+    const existing = this.nodeIndex.get(nodeId);
+    if (!existing) return;
+    const next = new Set(existing);
+    next.delete(key);
+    if (next.size === 0) {
+      this.nodeIndex = mapDelete(this.nodeIndex, nodeId);
+    } else {
+      this.nodeIndex = mapSet(this.nodeIndex, nodeId, next);
+    }
+  }
+
+  private evictOldest(): void {
+    let oldestKey: string | undefined;
+    let oldestTime = Number.POSITIVE_INFINITY;
+
+    for (const [key, binding] of this.bindings) {
+      if (binding.lastActiveAt < oldestTime) {
+        oldestTime = binding.lastActiveAt;
+        oldestKey = key;
+      }
+    }
+
+    if (oldestKey) {
+      const binding = this.bindings.get(oldestKey);
+      if (binding) {
+        this.removeFromNodeIndex(binding.nodeId, oldestKey);
+      }
+      this.bindings = mapDelete(this.bindings, oldestKey);
+    }
+  }
+}

--- a/packages/gateway/src/conversations/index.ts
+++ b/packages/gateway/src/conversations/index.ts
@@ -1,0 +1,5 @@
+export {
+  type ConversationBinding,
+  ConversationStore,
+  type ConversationStoreConfig,
+} from "./conversation-store.js";

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -14,6 +14,12 @@ export {
   ConfigWatcher,
   type ConfigWatcherDeps,
 } from "./config-watcher.js";
+// Conversations
+export {
+  type ConversationBinding,
+  ConversationStore,
+  type ConversationStoreConfig,
+} from "./conversations/index.js";
 // Delivery tracking
 export { DeliveryTracker, type PendingMessage } from "./delivery-tracker.js";
 // Orchestrator
@@ -32,6 +38,7 @@ export {
   type HealthMonitorConfig,
   type NodeDeadHandler,
   type PingSender,
+  type SweepHandler,
 } from "./registry/health-monitor.js";
 // Registry
 export { NodeRegistry, type RegisteredNode } from "./registry/node-registry.js";

--- a/packages/gateway/src/protocol/__tests__/conversations.test.ts
+++ b/packages/gateway/src/protocol/__tests__/conversations.test.ts
@@ -1,0 +1,287 @@
+import { describe, expect, it } from "vitest";
+import {
+  CONVERSATION_SCOPES,
+  type ConversationKey,
+  type ConversationKeyInput,
+  ConversationScopeSchema,
+  MESSAGE_TYPES,
+  MessageRoutingContextSchema,
+  MessageTypeSchema,
+  parseConversationKey,
+  resolveConversationKey,
+} from "../conversations.js";
+
+// ---------------------------------------------------------------------------
+// Schema validation
+// ---------------------------------------------------------------------------
+
+describe("ConversationScopeSchema", () => {
+  it.each(CONVERSATION_SCOPES)("accepts '%s'", (scope) => {
+    expect(ConversationScopeSchema.parse(scope)).toBe(scope);
+  });
+
+  it("rejects invalid scope", () => {
+    expect(() => ConversationScopeSchema.parse("invalid")).toThrow();
+  });
+});
+
+describe("MessageTypeSchema", () => {
+  it.each(MESSAGE_TYPES)("accepts '%s'", (type) => {
+    expect(MessageTypeSchema.parse(type)).toBe(type);
+  });
+});
+
+describe("MessageRoutingContextSchema", () => {
+  it("accepts full context", () => {
+    const result = MessageRoutingContextSchema.parse({
+      peerId: "peer-1",
+      accountId: "acc-1",
+      groupId: "grp-1",
+      messageType: "dm",
+    });
+    expect(result.peerId).toBe("peer-1");
+  });
+
+  it("accepts empty context", () => {
+    const result = MessageRoutingContextSchema.parse({});
+    expect(result).toEqual({});
+  });
+
+  it("rejects empty string peerId", () => {
+    expect(() => MessageRoutingContextSchema.parse({ peerId: "" })).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveConversationKey
+// ---------------------------------------------------------------------------
+
+describe("resolveConversationKey()", () => {
+  const base: ConversationKeyInput = {
+    scope: "main",
+    agentId: "a1",
+    channelId: "whatsapp",
+  };
+
+  describe("DM scoping", () => {
+    it.each([
+      {
+        desc: "main scope",
+        input: { ...base, scope: "main" as const },
+        expected: "agent:a1:main",
+        degraded: false,
+      },
+      {
+        desc: "per-peer scope",
+        input: { ...base, scope: "per-peer" as const, peerId: "p1" },
+        expected: "agent:a1:dm:p1",
+        degraded: false,
+      },
+      {
+        desc: "per-channel-peer scope",
+        input: { ...base, scope: "per-channel-peer" as const, peerId: "p1" },
+        expected: "agent:a1:whatsapp:dm:p1",
+        degraded: false,
+      },
+      {
+        desc: "per-account-channel-peer scope",
+        input: {
+          ...base,
+          scope: "per-account-channel-peer" as const,
+          peerId: "p1",
+          accountId: "acc1",
+        },
+        expected: "agent:a1:whatsapp:acc1:dm:p1",
+        degraded: false,
+      },
+    ])("$desc → $expected", ({ input, expected, degraded }) => {
+      const result = resolveConversationKey(input);
+      expect(result.key).toBe(expected);
+      expect(result.degraded).toBe(degraded);
+      expect(result.warnings).toHaveLength(0);
+    });
+  });
+
+  describe("group messages", () => {
+    it("ignores DM scope and uses group key", () => {
+      const result = resolveConversationKey({
+        ...base,
+        scope: "per-channel-peer",
+        messageType: "group",
+        groupId: "grp-42",
+      });
+      expect(result.key).toBe("agent:a1:whatsapp:group:grp-42");
+      expect(result.degraded).toBe(false);
+    });
+
+    it("falls back to main when groupId missing", () => {
+      const result = resolveConversationKey({
+        ...base,
+        messageType: "group",
+      });
+      expect(result.key).toBe("agent:a1:main");
+      expect(result.degraded).toBe(true);
+      expect(result.warnings).toHaveLength(1);
+      expect(result.warnings[0]).toContain("groupId");
+    });
+  });
+
+  describe("fallback chain", () => {
+    it.each([
+      {
+        desc: "per-peer missing peerId → main",
+        input: { ...base, scope: "per-peer" as const },
+        expected: "agent:a1:main",
+        warningSubstring: "peerId",
+      },
+      {
+        desc: "per-channel-peer missing peerId → main",
+        input: { ...base, scope: "per-channel-peer" as const },
+        expected: "agent:a1:main",
+        warningSubstring: "peerId",
+      },
+      {
+        desc: "per-account-channel-peer missing peerId → main",
+        input: { ...base, scope: "per-account-channel-peer" as const, accountId: "acc1" },
+        expected: "agent:a1:main",
+        warningSubstring: "peerId",
+      },
+      {
+        desc: "per-account-channel-peer missing accountId → per-channel-peer",
+        input: { ...base, scope: "per-account-channel-peer" as const, peerId: "p1" },
+        expected: "agent:a1:whatsapp:dm:p1",
+        warningSubstring: "accountId",
+      },
+    ])("$desc", ({ input, expected, warningSubstring }) => {
+      const result = resolveConversationKey(input);
+      expect(result.key).toBe(expected);
+      expect(result.degraded).toBe(true);
+      expect(result.warnings.length).toBeGreaterThanOrEqual(1);
+      expect(result.warnings[0]).toContain(warningSubstring);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("treats empty string peerId as missing", () => {
+      const result = resolveConversationKey({
+        ...base,
+        scope: "per-peer",
+        peerId: "",
+      });
+      expect(result.key).toBe("agent:a1:main");
+      expect(result.degraded).toBe(true);
+    });
+
+    it("treats empty string accountId as missing", () => {
+      const result = resolveConversationKey({
+        ...base,
+        scope: "per-account-channel-peer",
+        peerId: "p1",
+        accountId: "",
+      });
+      expect(result.key).toBe("agent:a1:whatsapp:dm:p1");
+      expect(result.degraded).toBe(true);
+    });
+
+    it("handles special characters in peerId (phone numbers)", () => {
+      const result = resolveConversationKey({
+        ...base,
+        scope: "per-peer",
+        peerId: "+15551234567",
+      });
+      expect(result.key).toBe("agent:a1:dm:+15551234567");
+      expect(result.degraded).toBe(false);
+    });
+
+    it("rejects colon in agentId", () => {
+      expect(() => resolveConversationKey({ ...base, agentId: "a:b" })).toThrow(
+        "agentId must not contain ':'",
+      );
+    });
+
+    it("rejects colon in peerId", () => {
+      expect(() => resolveConversationKey({ ...base, scope: "per-peer", peerId: "p:1" })).toThrow(
+        "peerId must not contain ':'",
+      );
+    });
+
+    it("rejects colon in channelId", () => {
+      expect(() => resolveConversationKey({ ...base, channelId: "ch:1" })).toThrow(
+        "channelId must not contain ':'",
+      );
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseConversationKey
+// ---------------------------------------------------------------------------
+
+describe("parseConversationKey()", () => {
+  it.each([
+    {
+      desc: "main",
+      key: "agent:a1:main",
+      expected: { scope: "main", agentId: "a1", channelId: "" },
+    },
+    {
+      desc: "per-peer",
+      key: "agent:a1:dm:p1",
+      expected: { scope: "per-peer", agentId: "a1", channelId: "", peerId: "p1" },
+    },
+    {
+      desc: "per-channel-peer",
+      key: "agent:a1:whatsapp:dm:p1",
+      expected: { scope: "per-channel-peer", agentId: "a1", channelId: "whatsapp", peerId: "p1" },
+    },
+    {
+      desc: "per-account-channel-peer",
+      key: "agent:a1:telegram:acc1:dm:p1",
+      expected: {
+        scope: "per-account-channel-peer",
+        agentId: "a1",
+        channelId: "telegram",
+        accountId: "acc1",
+        peerId: "p1",
+      },
+    },
+    {
+      desc: "group",
+      key: "agent:a1:whatsapp:group:grp-42",
+      expected: {
+        scope: "main",
+        agentId: "a1",
+        channelId: "whatsapp",
+        groupId: "grp-42",
+        messageType: "group",
+      },
+    },
+  ])("parses $desc key", ({ key, expected }) => {
+    const result = parseConversationKey(key as ConversationKey);
+    expect(result).toEqual(expected);
+  });
+
+  it("round-trips resolveConversationKey → parseConversationKey", () => {
+    const input: ConversationKeyInput = {
+      scope: "per-channel-peer",
+      agentId: "bot-1",
+      channelId: "slack",
+      peerId: "user-42",
+    };
+    const { key } = resolveConversationKey(input);
+    const parsed = parseConversationKey(key);
+    expect(parsed).toBeDefined();
+    expect(parsed?.agentId).toBe("bot-1");
+    expect(parsed?.channelId).toBe("slack");
+    expect(parsed?.peerId).toBe("user-42");
+    expect(parsed?.scope).toBe("per-channel-peer");
+  });
+
+  it("returns undefined for unrecognized format", () => {
+    expect(parseConversationKey("garbage" as ConversationKey)).toBeUndefined();
+  });
+
+  it("returns undefined for too-short key", () => {
+    expect(parseConversationKey("agent:a1" as ConversationKey)).toBeUndefined();
+  });
+});

--- a/packages/gateway/src/protocol/__tests__/types.test.ts
+++ b/packages/gateway/src/protocol/__tests__/types.test.ts
@@ -26,6 +26,9 @@ describe("GatewayConfig", () => {
     laneCapacity: 256,
     maxConnections: 1024,
     maxFramesPerSecond: 100,
+    defaultConversationScope: "per-channel-peer" as const,
+    maxConversations: 100_000,
+    conversationTtl: 86_400_000,
   };
 
   it("accepts valid config", () => {
@@ -70,6 +73,9 @@ describe("DEFAULT_GATEWAY_CONFIG", () => {
     expect(DEFAULT_GATEWAY_CONFIG.suspendTimeout).toBe(300_000);
     expect(DEFAULT_GATEWAY_CONFIG.healthCheckInterval).toBe(30_000);
     expect(DEFAULT_GATEWAY_CONFIG.laneCapacity).toBe(256);
+    expect(DEFAULT_GATEWAY_CONFIG.defaultConversationScope).toBe("per-channel-peer");
+    expect(DEFAULT_GATEWAY_CONFIG.maxConversations).toBe(100_000);
+    expect(DEFAULT_GATEWAY_CONFIG.conversationTtl).toBe(86_400_000);
   });
 });
 
@@ -160,6 +166,23 @@ describe("LaneMessage", () => {
       timestamp: Date.now(),
     };
     expect(LaneMessageSchema.parse(msg)).toEqual(msg);
+  });
+
+  it("accepts message with routingContext", () => {
+    const msg = {
+      id: "msg-2",
+      lane: "steer" as const,
+      channelId: "ch-1",
+      payload: { text: "hello" },
+      timestamp: Date.now(),
+      routingContext: {
+        peerId: "peer-1",
+        accountId: "acc-1",
+        messageType: "dm" as const,
+      },
+    };
+    const result = LaneMessageSchema.parse(msg);
+    expect(result.routingContext?.peerId).toBe("peer-1");
   });
 
   it("rejects empty id", () => {

--- a/packages/gateway/src/protocol/conversations.ts
+++ b/packages/gateway/src/protocol/conversations.ts
@@ -1,0 +1,245 @@
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// Conversation Scope
+// ---------------------------------------------------------------------------
+
+/**
+ * The 4 DM scoping modes for conversation isolation.
+ *
+ * - main:                     Single conversation per agent (no isolation)
+ * - per-peer:                 One conversation per peer across all channels
+ * - per-channel-peer:         One conversation per (channel, peer) pair
+ * - per-account-channel-peer: One conversation per (account, channel, peer) triple
+ */
+export const CONVERSATION_SCOPES = [
+  "main",
+  "per-peer",
+  "per-channel-peer",
+  "per-account-channel-peer",
+] as const;
+export type ConversationScope = (typeof CONVERSATION_SCOPES)[number];
+export const ConversationScopeSchema = z.enum(CONVERSATION_SCOPES);
+
+// ---------------------------------------------------------------------------
+// Message Type
+// ---------------------------------------------------------------------------
+
+/** Whether a message is a DM or group message. */
+export const MESSAGE_TYPES = ["dm", "group"] as const;
+export type MessageType = (typeof MESSAGE_TYPES)[number];
+export const MessageTypeSchema = z.enum(MESSAGE_TYPES);
+
+// ---------------------------------------------------------------------------
+// Message Routing Context
+// ---------------------------------------------------------------------------
+
+/**
+ * Routing context attached to a LaneMessage for conversation scoping.
+ *
+ * Populated by the channel adapter that originates the message.
+ */
+export interface MessageRoutingContext {
+  /** Peer identifier (e.g., phone number, username) */
+  readonly peerId?: string;
+  /** Account identifier (multi-account channels like WhatsApp Business) */
+  readonly accountId?: string;
+  /** Group identifier (for group chats) */
+  readonly groupId?: string;
+  /** Whether this is a DM or group message */
+  readonly messageType?: MessageType;
+}
+
+export const MessageRoutingContextSchema = z.object({
+  peerId: z.string().min(1).optional(),
+  accountId: z.string().min(1).optional(),
+  groupId: z.string().min(1).optional(),
+  messageType: MessageTypeSchema.optional(),
+});
+
+// ---------------------------------------------------------------------------
+// Branded ConversationKey
+// ---------------------------------------------------------------------------
+
+/** Branded string type for conversation keys. */
+export type ConversationKey = string & { readonly __brand: "ConversationKey" };
+
+// ---------------------------------------------------------------------------
+// Key Resolution
+// ---------------------------------------------------------------------------
+
+/** Input for resolving a conversation key. */
+export interface ConversationKeyInput {
+  readonly scope: ConversationScope;
+  readonly agentId: string;
+  readonly channelId: string;
+  readonly peerId?: string;
+  readonly accountId?: string;
+  readonly groupId?: string;
+  readonly messageType?: MessageType;
+}
+
+/** Result of conversation key resolution. */
+export interface ConversationKeyResult {
+  readonly key: ConversationKey;
+  readonly degraded: boolean;
+  readonly warnings: readonly string[];
+}
+
+/**
+ * Compute a conversation key from scope + routing context.
+ *
+ * Key format by scope:
+ * - group messages:              `agent:<agentId>:<channelId>:group:<groupId>`
+ * - main:                        `agent:<agentId>:main`
+ * - per-peer:                    `agent:<agentId>:dm:<peerId>`
+ * - per-channel-peer:            `agent:<agentId>:<channelId>:dm:<peerId>`
+ * - per-account-channel-peer:    `agent:<agentId>:<channelId>:<accountId>:dm:<peerId>`
+ *
+ * Fallback chain (when required fields are missing):
+ * - group missing groupId        -> degrade to `main` + warning
+ * - per-account-channel-peer missing accountId -> degrade to `per-channel-peer` + warning
+ * - per-channel-peer or above missing peerId   -> degrade to `main` + warning
+ * - per-peer missing peerId      -> degrade to `main` + warning
+ */
+export function resolveConversationKey(input: ConversationKeyInput): ConversationKeyResult {
+  const { scope, agentId, channelId, messageType } = input;
+  const peerId = input.peerId || undefined; // treat empty string as missing
+  const accountId = input.accountId || undefined;
+  const groupId = input.groupId || undefined;
+  const warnings: string[] = [];
+
+  // Validate IDs do not contain the delimiter character to prevent key collisions
+  for (const [name, value] of [
+    ["agentId", agentId],
+    ["channelId", channelId],
+    ["peerId", peerId],
+    ["accountId", accountId],
+    ["groupId", groupId],
+  ] as const) {
+    if (value?.includes(":")) {
+      throw new Error(`${name} must not contain ':' — received "${value}"`);
+    }
+  }
+
+  // Group messages always use group scoping, ignoring DM scope
+  if (messageType === "group") {
+    if (!groupId) {
+      warnings.push("group message missing groupId, falling back to main scope");
+      return { key: `agent:${agentId}:main` as ConversationKey, degraded: true, warnings };
+    }
+    return {
+      key: `agent:${agentId}:${channelId}:group:${groupId}` as ConversationKey,
+      degraded: false,
+      warnings,
+    };
+  }
+
+  // DM scoping
+  switch (scope) {
+    case "main":
+      return { key: `agent:${agentId}:main` as ConversationKey, degraded: false, warnings };
+
+    case "per-peer":
+      if (!peerId) {
+        warnings.push("per-peer scope missing peerId, falling back to main scope");
+        return { key: `agent:${agentId}:main` as ConversationKey, degraded: true, warnings };
+      }
+      return { key: `agent:${agentId}:dm:${peerId}` as ConversationKey, degraded: false, warnings };
+
+    case "per-channel-peer":
+      if (!peerId) {
+        warnings.push("per-channel-peer scope missing peerId, falling back to main scope");
+        return { key: `agent:${agentId}:main` as ConversationKey, degraded: true, warnings };
+      }
+      return {
+        key: `agent:${agentId}:${channelId}:dm:${peerId}` as ConversationKey,
+        degraded: false,
+        warnings,
+      };
+
+    case "per-account-channel-peer": {
+      if (!peerId) {
+        warnings.push("per-account-channel-peer scope missing peerId, falling back to main scope");
+        return { key: `agent:${agentId}:main` as ConversationKey, degraded: true, warnings };
+      }
+      if (!accountId) {
+        warnings.push(
+          "per-account-channel-peer scope missing accountId, degrading to per-channel-peer",
+        );
+        return {
+          key: `agent:${agentId}:${channelId}:dm:${peerId}` as ConversationKey,
+          degraded: true,
+          warnings,
+        };
+      }
+      return {
+        key: `agent:${agentId}:${channelId}:${accountId}:dm:${peerId}` as ConversationKey,
+        degraded: false,
+        warnings,
+      };
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Key Parsing (for debugging/logging)
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a conversation key back into its component parts.
+ *
+ * Returns undefined if the key format is unrecognized.
+ */
+export function parseConversationKey(key: ConversationKey): ConversationKeyInput | undefined {
+  const parts = key.split(":");
+  // All keys start with "agent:<agentId>"
+  if (parts[0] !== "agent" || parts.length < 3) {
+    return undefined;
+  }
+
+  // Length checks above guarantee these indices exist
+  const agentId = parts[1] as string;
+
+  // agent:<agentId>:main
+  if (parts[2] === "main" && parts.length === 3) {
+    return { scope: "main", agentId, channelId: "" };
+  }
+
+  // agent:<agentId>:dm:<peerId>
+  if (parts[2] === "dm" && parts.length === 4) {
+    return { scope: "per-peer", agentId, channelId: "", peerId: parts[3] as string };
+  }
+
+  // Remaining formats have channelId at parts[2]
+  const channelId = parts[2] as string;
+
+  // agent:<agentId>:<channelId>:group:<groupId>
+  if (parts[3] === "group" && parts.length === 5) {
+    return {
+      scope: "main", // group ignores scope
+      agentId,
+      channelId,
+      groupId: parts[4] as string,
+      messageType: "group",
+    };
+  }
+
+  // agent:<agentId>:<channelId>:dm:<peerId>
+  if (parts[3] === "dm" && parts.length === 5) {
+    return { scope: "per-channel-peer", agentId, channelId, peerId: parts[4] as string };
+  }
+
+  // agent:<agentId>:<channelId>:<accountId>:dm:<peerId>
+  if (parts[4] === "dm" && parts.length === 6) {
+    return {
+      scope: "per-account-channel-peer",
+      agentId,
+      channelId,
+      accountId: parts[3] as string,
+      peerId: parts[5] as string,
+    };
+  }
+
+  return undefined;
+}

--- a/packages/gateway/src/protocol/index.ts
+++ b/packages/gateway/src/protocol/index.ts
@@ -5,6 +5,23 @@
  * Used by both @templar/gateway (server) and @templar/node (client).
  */
 
+// Conversations
+export {
+  CONVERSATION_SCOPES,
+  type ConversationKey,
+  type ConversationKeyInput,
+  type ConversationKeyResult,
+  type ConversationScope,
+  ConversationScopeSchema,
+  MESSAGE_TYPES,
+  type MessageRoutingContext,
+  MessageRoutingContextSchema,
+  type MessageType,
+  MessageTypeSchema,
+  parseConversationKey,
+  resolveConversationKey,
+} from "./conversations.js";
+
 // Frames
 export {
   type ConfigChangedFrame,

--- a/packages/gateway/src/protocol/lanes.ts
+++ b/packages/gateway/src/protocol/lanes.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { type MessageRoutingContext, MessageRoutingContextSchema } from "./conversations.js";
 
 // ---------------------------------------------------------------------------
 // Lane Priority
@@ -47,6 +48,8 @@ export interface LaneMessage {
   readonly channelId: string;
   readonly payload: unknown;
   readonly timestamp: number;
+  /** Routing context for conversation scoping (populated by channel adapter) */
+  readonly routingContext?: MessageRoutingContext;
 }
 
 export const LaneMessageSchema = z.object({
@@ -55,4 +58,5 @@ export const LaneMessageSchema = z.object({
   channelId: z.string().min(1),
   payload: z.unknown(),
   timestamp: z.number().int().positive(),
+  routingContext: MessageRoutingContextSchema.optional(),
 });

--- a/packages/gateway/src/protocol/types.ts
+++ b/packages/gateway/src/protocol/types.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { type ConversationScope, ConversationScopeSchema } from "./conversations.js";
 
 // ---------------------------------------------------------------------------
 // Node Capabilities
@@ -55,6 +56,9 @@ export const HOT_RELOADABLE_FIELDS = [
   "healthCheckInterval",
   "laneCapacity",
   "maxFramesPerSecond",
+  "defaultConversationScope",
+  "maxConversations",
+  "conversationTtl",
 ] as const;
 export type HotReloadableField = (typeof HOT_RELOADABLE_FIELDS)[number];
 
@@ -89,6 +93,12 @@ export interface GatewayConfig {
   readonly maxConnections: number;
   /** Max frames per second per connection before rate limiting (default: 100) */
   readonly maxFramesPerSecond: number;
+  /** Default conversation scoping mode for DM isolation (default: 'per-channel-peer') */
+  readonly defaultConversationScope: ConversationScope;
+  /** Maximum number of tracked conversations before eviction (default: 100_000) */
+  readonly maxConversations: number;
+  /** Conversation TTL in ms — inactive conversations are swept (default: 86_400_000 = 24h) */
+  readonly conversationTtl: number;
 }
 
 export const GatewayConfigSchema = z.object({
@@ -101,6 +111,9 @@ export const GatewayConfigSchema = z.object({
   laneCapacity: z.number().int().positive(),
   maxConnections: z.number().int().positive(),
   maxFramesPerSecond: z.number().int().positive(),
+  defaultConversationScope: ConversationScopeSchema,
+  maxConversations: z.number().int().positive(),
+  conversationTtl: z.number().int().positive(),
 });
 
 /**
@@ -114,4 +127,7 @@ export const DEFAULT_GATEWAY_CONFIG: Omit<GatewayConfig, "nexusUrl" | "nexusApiK
   laneCapacity: 256,
   maxConnections: 1024,
   maxFramesPerSecond: 100,
+  defaultConversationScope: "per-channel-peer",
+  maxConversations: 100_000,
+  conversationTtl: 86_400_000,
 } as const;

--- a/packages/gateway/src/router.ts
+++ b/packages/gateway/src/router.ts
@@ -1,8 +1,45 @@
 import { GatewayNodeNotFoundError } from "@templar/errors";
+import type { ConversationStore } from "./conversations/conversation-store.js";
 import type { LaneDispatcher } from "./lanes/lane-dispatcher.js";
-import type { LaneMessage } from "./protocol/index.js";
+import {
+  type ConversationKeyInput,
+  type ConversationKeyResult,
+  type ConversationScope,
+  type LaneMessage,
+  type MessageRoutingContext,
+  resolveConversationKey,
+} from "./protocol/index.js";
 import type { NodeRegistry } from "./registry/node-registry.js";
 import { mapDelete, mapFilter, mapSet } from "./utils/immutable-map.js";
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a ConversationKeyInput from routing context, omitting undefined
+ * properties to satisfy exactOptionalPropertyTypes.
+ */
+function buildKeyInput(
+  scope: ConversationScope,
+  agentId: string,
+  channelId: string,
+  ctx?: MessageRoutingContext,
+): ConversationKeyInput {
+  if (!ctx) {
+    return { scope, agentId, channelId };
+  }
+
+  return {
+    scope,
+    agentId,
+    channelId,
+    ...(ctx.peerId ? { peerId: ctx.peerId } : {}),
+    ...(ctx.accountId ? { accountId: ctx.accountId } : {}),
+    ...(ctx.groupId ? { groupId: ctx.groupId } : {}),
+    ...(ctx.messageType ? { messageType: ctx.messageType } : {}),
+  };
+}
 
 // ---------------------------------------------------------------------------
 // Types
@@ -19,11 +56,17 @@ export type MessageRouter = (message: LaneMessage) => void;
  *
  * Uses explicit channel → node bindings.
  * Falls back to capability-based selection via NodeRegistry.
+ *
+ * Supports conversation scoping via ConversationStore to isolate
+ * conversations by peer, channel, and account.
  */
 export class AgentRouter {
   private bindings: ReadonlyMap<string, string> = new Map();
   private dispatchers: ReadonlyMap<string, LaneDispatcher> = new Map();
   private readonly registry: NodeRegistry;
+  private conversationStore: ConversationStore | undefined;
+  private conversationScope: ConversationScope = "per-channel-peer";
+  private agentScopes: ReadonlyMap<string, ConversationScope> = new Map();
 
   constructor(registry: NodeRegistry) {
     this.registry = registry;
@@ -80,6 +123,41 @@ export class AgentRouter {
   }
 
   /**
+   * Route a message with conversation scoping.
+   *
+   * 1. Determine effective scope (agent override → gateway default)
+   * 2. Compute conversation key from scope + routing context
+   * 3. Dispatch via existing route() — throws on missing binding/dispatcher
+   * 4. Bind conversation to node only after successful dispatch
+   */
+  routeWithScope(message: LaneMessage, agentId: string): ConversationKeyResult {
+    const scope = this.agentScopes.get(agentId) ?? this.conversationScope;
+
+    const input = buildKeyInput(scope, agentId, message.channelId, message.routingContext);
+    const result = resolveConversationKey(input);
+
+    // Dispatch first — if route() throws, no stale conversation binding is created
+    this.route(message);
+
+    // Bind conversation to node only after successful dispatch
+    const nodeId = this.bindings.get(message.channelId);
+    if (nodeId && this.conversationStore) {
+      this.conversationStore.bind(result.key, nodeId);
+    }
+
+    return result;
+  }
+
+  /**
+   * Get the conversation key for a message without routing it.
+   */
+  resolveConversation(message: LaneMessage, agentId: string): ConversationKeyResult {
+    const scope = this.agentScopes.get(agentId) ?? this.conversationScope;
+    const input = buildKeyInput(scope, agentId, message.channelId, message.routingContext);
+    return resolveConversationKey(input);
+  }
+
+  /**
    * Drain all queued messages for a node in priority order.
    * Returns steer → collect → followup messages.
    */
@@ -103,5 +181,58 @@ export class AgentRouter {
    */
   getAllBindings(): ReadonlyMap<string, string> {
     return this.bindings;
+  }
+
+  // -------------------------------------------------------------------------
+  // Conversation scoping configuration
+  // -------------------------------------------------------------------------
+
+  /**
+   * Set the conversation store (called by gateway during setup).
+   */
+  setConversationStore(store: ConversationStore): void {
+    this.conversationStore = store;
+  }
+
+  /**
+   * Get the conversation store.
+   */
+  getConversationStore(): ConversationStore | undefined {
+    return this.conversationStore;
+  }
+
+  /**
+   * Update the default conversation scope (hot-reload).
+   */
+  setConversationScope(scope: ConversationScope): void {
+    this.conversationScope = scope;
+  }
+
+  /**
+   * Get the current default conversation scope.
+   */
+  getConversationScope(): ConversationScope {
+    return this.conversationScope;
+  }
+
+  /**
+   * Set a per-agent scope override.
+   */
+  setAgentScope(agentId: string, scope: ConversationScope): void {
+    this.agentScopes = mapSet(this.agentScopes, agentId, scope);
+  }
+
+  /**
+   * Remove a per-agent scope override.
+   */
+  removeAgentScope(agentId: string): void {
+    this.agentScopes = mapDelete(this.agentScopes, agentId);
+  }
+
+  /**
+   * Get the effective scope for an agent (override or gateway default).
+   */
+  getEffectiveScope(agentId: string): ConversationScope {
+    return this.agentScopes.get(agentId) ?? this.conversationScope;
   }
 }


### PR DESCRIPTION
Closes #82

## Summary

- Implements 4 DM conversation scoping modes (`main`, `per-peer`, `per-channel-peer`, `per-account-channel-peer`) to isolate conversations by peer, channel, and account — preventing cross-talk in multi-user environments
- Adds `ConversationStore` with TTL sweep, reverse index for O(k) node cleanup, and LRU capacity eviction
- Integrates conversation-aware routing into `AgentRouter.routeWithScope()` with graceful fallback chain when routing context fields are missing

## Changes

### `@templar/gateway` (protocol)
- **New** `conversations.ts` — `ConversationScope`, branded `ConversationKey` type, `resolveConversationKey()` pure function with fallback/degradation chain, `parseConversationKey()` inverse parser, colon-in-ID validation
- Added `routingContext?: MessageRoutingContext` to `LaneMessage` (peerId, accountId, groupId, messageType)
- Added `defaultConversationScope`, `maxConversations`, `conversationTtl` to `GatewayConfig` (hot-reloadable)

### `@templar/gateway` (store + routing)
- **New** `ConversationStore` — primary index + reverse index (nodeId → Set\<key\>), TTL sweep, capacity eviction, immutable map patterns
- `AgentRouter` — added `routeWithScope()` (dispatch-before-bind ordering), `resolveConversation()`, per-agent scope overrides
- `TemplarGateway` — wires ConversationStore lifecycle (constructor, cleanup cascade, hot-reload scope change → clear store, TTL sweep on health monitor)
- `HealthMonitor` — added `onSweep()` event for piggybacking TTL sweep

### `@templar/core`
- Added `ConversationContext` type alias for `SessionContext` with doc comment explaining the distinction

### Tests (55+ new tests)
- Table-driven resolver tests covering all 4 scopes, group messages, fallback chain, edge cases (34 tests)
- ConversationStore unit tests: bind/get, TTL sweep, node cascade, capacity eviction, immutability (21 tests)
- Gateway integration tests: binding creation, per-channel-peer isolation, per-peer shared, agent scope override, missing context fallback, cleanup cascade (7 tests)
- Performance benchmarks: resolveConversationKey, store operations at 100K entries

## Key design decisions

| Decision | Choice |
|----------|--------|
| Naming | `Conversation*` prefix (not Session) |
| Package split | Pure types + resolver in protocol, stateful store in gateway |
| Key format | `agent:<agentId>:<channelId>:<accountId>:dm:<peerId>` with branded string type |
| Missing context | Fallback to `main` scope + `degraded: true` + warnings array |
| Group chats | `messageType: 'group'` overrides DM scope → `agent:<id>:<ch>:group:<gid>` |
| Store impl | Map + TTL sweep (piggybacked on health check interval), reverse index for cascade |
| Dispatch ordering | Route message first, then bind conversation (prevents stale bindings on failure) |

## Test plan

- [x] `pnpm --filter @templar/gateway test` — 368 tests pass
- [x] `pnpm turbo build` — all packages build cleanly (ESM + DTS)
- [x] Biome lint passes
- [ ] Manual E2E: Start Nexus + gateway, send scoped messages from different peers, verify conversation isolation in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)