### PR TITLE
refactor(gateway): multi-agent routing review improvements

### DIFF
--- a/packages/gateway/src/__tests__/binding-resolver.bench.ts
+++ b/packages/gateway/src/__tests__/binding-resolver.bench.ts
@@ -1,0 +1,151 @@
+import { bench, describe } from "vitest";
+import { BindingResolver, compileBindings, compilePattern } from "../binding-resolver.js";
+import type { AgentBinding } from "../protocol/bindings.js";
+import { makeMessage } from "./helpers.js";
+
+// ---------------------------------------------------------------------------
+// Pattern compilation
+// ---------------------------------------------------------------------------
+
+describe("compilePattern", () => {
+  bench("exact pattern", () => {
+    compilePattern("slack");
+  });
+
+  bench("prefix pattern", () => {
+    compilePattern("slack-*");
+  });
+
+  bench("suffix pattern", () => {
+    compilePattern("*-personal");
+  });
+
+  bench("wildcard pattern", () => {
+    compilePattern("*");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Binding compilation at scale
+// ---------------------------------------------------------------------------
+
+function generateBindings(count: number): AgentBinding[] {
+  return Array.from({ length: count }, (_, i) => ({
+    agentId: `agent-${i}`,
+    match: { channel: `channel-${i}` },
+  }));
+}
+
+describe("compileBindings", () => {
+  const bindings5 = generateBindings(5);
+  const bindings50 = generateBindings(50);
+  const bindings500 = generateBindings(500);
+
+  bench("5 bindings", () => {
+    compileBindings(bindings5);
+  });
+
+  bench("50 bindings", () => {
+    compileBindings(bindings50);
+  });
+
+  bench("500 bindings", () => {
+    compileBindings(bindings500);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Resolution at scale
+// ---------------------------------------------------------------------------
+
+function setupResolver(count: number): BindingResolver {
+  const bindings = generateBindings(count);
+  const resolver = new BindingResolver();
+  resolver.updateBindings(bindings);
+  return resolver;
+}
+
+describe("BindingResolver.resolve()", () => {
+  // --- 5 bindings ---
+  const resolver5 = setupResolver(5);
+  const msg5Hit = makeMessage({ channelId: "channel-2" });
+  const msg5Miss = makeMessage({ channelId: "unknown" });
+
+  bench("5 bindings — hit (middle)", () => {
+    resolver5.resolve(msg5Hit);
+  });
+
+  bench("5 bindings — miss", () => {
+    resolver5.resolve(msg5Miss);
+  });
+
+  // --- 50 bindings ---
+  const resolver50 = setupResolver(50);
+  const msg50Hit = makeMessage({ channelId: "channel-25" });
+  const msg50Miss = makeMessage({ channelId: "unknown" });
+
+  bench("50 bindings — hit (middle)", () => {
+    resolver50.resolve(msg50Hit);
+  });
+
+  bench("50 bindings — miss", () => {
+    resolver50.resolve(msg50Miss);
+  });
+
+  // --- 500 bindings ---
+  const resolver500 = setupResolver(500);
+  const msg500Hit = makeMessage({ channelId: "channel-250" });
+  const msg500Miss = makeMessage({ channelId: "unknown" });
+
+  bench("500 bindings — hit (middle)", () => {
+    resolver500.resolve(msg500Hit);
+  });
+
+  bench("500 bindings — miss", () => {
+    resolver500.resolve(msg500Miss);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Mixed pattern types at scale
+// ---------------------------------------------------------------------------
+
+describe("BindingResolver.resolve() — mixed patterns", () => {
+  const resolver = new BindingResolver();
+  resolver.updateBindings([
+    ...Array.from({ length: 100 }, (_, i) => ({
+      agentId: `exact-${i}`,
+      match: { channel: `ch-${i}` },
+    })),
+    ...Array.from({ length: 100 }, (_, i) => ({
+      agentId: `prefix-${i}`,
+      match: { channel: `pfx-${i}-*` },
+    })),
+    ...Array.from({ length: 100 }, (_, i) => ({
+      agentId: `suffix-${i}`,
+      match: { channel: `*-sfx-${i}` },
+    })),
+    { agentId: "catch-all", match: {} },
+  ]);
+
+  const exactMsg = makeMessage({ channelId: "ch-50" });
+  const prefixMsg = makeMessage({ channelId: "pfx-50-workspace" });
+  const suffixMsg = makeMessage({ channelId: "workspace-sfx-50" });
+  const catchAllMsg = makeMessage({ channelId: "no-match" });
+
+  bench("301 bindings — exact hit", () => {
+    resolver.resolve(exactMsg);
+  });
+
+  bench("301 bindings — prefix hit", () => {
+    resolver.resolve(prefixMsg);
+  });
+
+  bench("301 bindings — suffix hit", () => {
+    resolver.resolve(suffixMsg);
+  });
+
+  bench("301 bindings — catch-all fallback", () => {
+    resolver.resolve(catchAllMsg);
+  });
+});

--- a/packages/gateway/src/__tests__/helpers.ts
+++ b/packages/gateway/src/__tests__/helpers.ts
@@ -8,7 +8,12 @@
 import { vi } from "vitest";
 import type { TemplarGatewayDeps } from "../gateway.js";
 import { TemplarGateway } from "../gateway.js";
-import type { GatewayConfig, GatewayFrame, NodeCapabilities } from "../protocol/index.js";
+import type {
+  GatewayConfig,
+  GatewayFrame,
+  LaneMessage,
+  NodeCapabilities,
+} from "../protocol/index.js";
 import type { WebSocketLike, WebSocketServerLike, WsServerFactory } from "../server.js";
 
 // ---------------------------------------------------------------------------
@@ -36,6 +41,25 @@ export const DEFAULT_CAPS: NodeCapabilities = {
   maxConcurrency: 4,
   channels: [],
 };
+
+// ---------------------------------------------------------------------------
+// Message factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a test LaneMessage with sensible defaults.
+ * Override any field via the `overrides` parameter.
+ */
+export function makeMessage(overrides: Partial<LaneMessage> = {}): LaneMessage {
+  return {
+    id: `msg-${Math.random().toString(36).slice(2)}`,
+    lane: "steer",
+    channelId: "ch-1",
+    payload: null,
+    timestamp: Date.now(),
+    ...overrides,
+  };
+}
 
 // ---------------------------------------------------------------------------
 // Mock WebSocket

--- a/packages/gateway/src/__tests__/multi-agent-routing.test.ts
+++ b/packages/gateway/src/__tests__/multi-agent-routing.test.ts
@@ -3,25 +3,10 @@ import { describe, expect, it } from "vitest";
 import { BindingResolver } from "../binding-resolver.js";
 import { LaneDispatcher } from "../lanes/lane-dispatcher.js";
 import type { AgentBinding } from "../protocol/bindings.js";
-import type { LaneMessage, NodeCapabilities } from "../protocol/index.js";
+import type { NodeCapabilities } from "../protocol/index.js";
 import { NodeRegistry } from "../registry/node-registry.js";
 import { AgentRouter } from "../router.js";
-import { createTestGateway, DEFAULT_CAPS, sendFrame } from "./helpers.js";
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function makeMessage(overrides: Partial<LaneMessage> = {}): LaneMessage {
-  return {
-    id: `msg-${Math.random().toString(36).slice(2)}`,
-    lane: "steer",
-    channelId: "ch-1",
-    payload: null,
-    timestamp: Date.now(),
-    ...overrides,
-  };
-}
+import { createTestGateway, DEFAULT_CAPS, makeMessage, sendFrame } from "./helpers.js";
 
 function setupRouterWithBindings(
   bindings: AgentBinding[],


### PR DESCRIPTION
## Summary

Post-implementation review of multi-agent routing (#83) covering architecture, code quality, tests, and performance. Key changes:

- **Move agentToNode index into NodeRegistry** — reverse index (agentId → nodeId) now lives in the registry with O(1) lookup via `resolveAgent()`, eliminating the separate `agentToNode` map in the gateway
- **`route()` returns nodeId** — callers (including `routeWithScope`) no longer need a separate resolution step; `resolveNodeForMessage()` removed
- **Extract `dispatchToNode()` helper** — reduces duplication across routing paths
- **Validate unsupported glob patterns** — rejects `*foo*`, `foo-*-bar`, `**` with clear error messages instead of silently misbehaving
- **Shared `makeMessage()` test helper** — DRY across 4 test files
- **Comprehensive test additions** — router return value tests, conversation scoping tests, gateway error paths, multi-agent integration tests, adversarial pattern tests
- **Binding resolver benchmark** — 17.8M ops/sec at 5 bindings, 5.5M at 50, 783K at 500
- **Rebase fix** — resolved merge conflicts with skills branch, added missing legacy error classes

## Metrics

| Metric | Value |
|--------|-------|
| Tests | 440/440 passing |
| Statement coverage | 94.9% |
| Branch coverage | 87.3% |
| Function coverage | 96.0% |
| Line coverage | 95.5% |
| Lint (Biome) | Clean |

## Files changed

| File | Change |
|------|--------|
| `packages/gateway/src/registry/node-registry.ts` | agentIndex reverse index, `resolveAgent()`, `getAgentIndex()` |
| `packages/gateway/src/router.ts` | `route()` → returns nodeId, `dispatchToNode()`, JSDoc precedence docs |
| `packages/gateway/src/gateway.ts` | delegate to registry, remove agentToNode map, hot-reload docs |
| `packages/gateway/src/binding-resolver.ts` | pattern validation (multi-wildcard, interior wildcard) |
| `packages/errors/src/legacy.ts` | add SkillNotFoundError, SkillParseError, SkillValidationError (rebase fix) |
| `packages/gateway/src/__tests__/helpers.ts` | shared `makeMessage()` factory |
| `packages/gateway/src/__tests__/router.test.ts` | route return value + conversation scoping tests |
| `packages/gateway/src/__tests__/gateway.test.ts` | error paths + multi-agent integration tests |
| `packages/gateway/src/__tests__/binding-resolver.test.ts` | adversarial pattern tests |
| `packages/gateway/src/__tests__/multi-agent-routing.test.ts` | use shared helpers |
| `packages/gateway/src/__tests__/binding-resolver.bench.ts` | benchmark at 5/50/500 bindings |

## Test plan

- [x] All 440 gateway tests pass
- [x] Coverage exceeds 80% threshold on all metrics
- [x] Biome lint passes clean
- [x] Build succeeds (`@templar/errors` + `@templar/gateway`)
- [x] Benchmark confirms sub-microsecond resolution at typical binding counts
- [ ] CI passes on remote

🤖 Generated with [Claude Code](https://claude.com/claude-code)