### PR TITLE
refactor(channel-voice): align with LiveKit v1.x Agent API

### DIFF
--- a/packages/channel-voice/package.json
+++ b/packages/channel-voice/package.json
@@ -17,19 +17,22 @@
   },
   "dependencies": {
     "@livekit/agents": "^1.0.32",
-    "@livekit/agents-plugin-silero": "^1.0.0",
     "livekit-server-sdk": "^2.15.0",
     "zod": "^3.24.0"
   },
   "peerDependencies": {
     "@livekit/agents-plugin-deepgram": "^1.0.44",
-    "@livekit/agents-plugin-openai": "^1.0.31"
+    "@livekit/agents-plugin-openai": "^1.0.31",
+    "@livekit/agents-plugin-silero": "^1.0.0"
   },
   "peerDependenciesMeta": {
     "@livekit/agents-plugin-deepgram": {
       "optional": true
     },
     "@livekit/agents-plugin-openai": {
+      "optional": true
+    },
+    "@livekit/agents-plugin-silero": {
       "optional": true
     }
   },


### PR DESCRIPTION
## Summary
- **v1.x API alignment**: Added `createTemplarAgentClass()` factory that creates a dynamic Agent subclass with `llmNode()` override bridging to Templar's handler. `AgentSession.start()` now receives `{ agent, room }` per the v1.x contract. Removed redundant `processTranscription()` from `wireTranscriptionEvents()` since the pipeline handles STT→LLM flow via `Agent.llmNode()`.
- **DRY refactor**: Extracted `log(level, context, error?)` private method, replacing 5 scattered `console.warn`/`console.error` calls with inconsistent formatting.
- **Bug fix**: Added `room.disconnect()` in `doConnect` catch block to prevent WebRTC connection leak when `AgentSession.start()` fails after `Room.connect()` succeeds.
- **Test coverage**: Added 4 `wireErrorEvents` tests covering recoverable errors, non-recoverable errors (bridge rejection), session close (sets `isConnected=false`), and close-after-disconnect (no-op).
- **Deps cleanup**: Moved unused `@livekit/agents-plugin-silero` from hard dependency to optional peer dependency.

## Test plan
- [x] All 75 tests pass (71 existing + 4 new wireErrorEvents tests)
- [x] Build succeeds (18.39 KB output)
- [x] Biome lint/format clean
- [ ] Verify LiveKit Agents v1.x API conformance with real SDK (requires LiveKit cloud account)
- [ ] Nexus e2e integration (requires Rust Metastore extension — not applicable at channel layer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)