### PR TITLE
feat(gateway): harden session scoping — perf, observability, manifest

### DIFF
--- a/packages/core/src/config-types.ts
+++ b/packages/core/src/config-types.ts
@@ -115,6 +115,8 @@ export interface AgentManifest {
   prompt?: string;
   skills?: string[];
   bootstrap?: BootstrapPathConfig;
+  /** Conversation isolation mode (maps to gateway ConversationScope) */
+  sessionScoping?: "main" | "per-peer" | "per-channel-peer" | "per-account-channel-peer";
 }
 
 /**

--- a/packages/gateway/src/conversations/index.ts
+++ b/packages/gateway/src/conversations/index.ts
@@ -1,4 +1,5 @@
 export {
+  type CapacityWarningHandler,
   type ConversationBinding,
   ConversationStore,
   type ConversationStoreConfig,

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -25,6 +25,7 @@ export {
 } from "./config-watcher.js";
 // Conversations
 export {
+  type CapacityWarningHandler,
   type ConversationBinding,
   ConversationStore,
   type ConversationStoreConfig,
@@ -52,7 +53,7 @@ export {
 // Registry
 export { NodeRegistry, type RegisteredNode } from "./registry/node-registry.js";
 // Router
-export { type AgentNodeResolver, AgentRouter, type MessageRouter } from "./router.js";
+export { type AgentNodeResolver, AgentRouter, type DegradationHandler } from "./router.js";
 // Server
 export {
   type ConnectionHandler,

--- a/packages/gateway/src/utils/immutable-map.ts
+++ b/packages/gateway/src/utils/immutable-map.ts
@@ -8,7 +8,9 @@
  * Return a new Map with the entry added or updated.
  */
 export function mapSet<K, V>(map: ReadonlyMap<K, V>, key: K, value: V): ReadonlyMap<K, V> {
-  return new Map([...map, [key, value]]);
+  const next = new Map(map);
+  next.set(key, value);
+  return next;
 }
 
 /**

--- a/packages/manifest/src/index.ts
+++ b/packages/manifest/src/index.ts
@@ -43,6 +43,8 @@ export {
   IdentityConfigSchema,
   PromptSchema,
   ScheduleSchema,
+  SESSION_SCOPING_VALUES,
+  SessionScopingSchema,
   SkillRefSchema,
 } from "./schema.js";
 

--- a/packages/manifest/src/schema.ts
+++ b/packages/manifest/src/schema.ts
@@ -109,6 +109,18 @@ export const BootstrapPathConfigSchema = z.object({
   budget: BootstrapBudgetSchema.optional(),
 });
 
+/**
+ * Conversation isolation modes — must stay in sync with
+ * CONVERSATION_SCOPES in @templar/gateway/protocol.
+ */
+export const SESSION_SCOPING_VALUES = [
+  "main",
+  "per-peer",
+  "per-channel-peer",
+  "per-account-channel-peer",
+] as const;
+export const SessionScopingSchema = z.enum(SESSION_SCOPING_VALUES);
+
 export const AgentManifestSchema = z.object({
   name: z.string().min(1),
   version: z.string().regex(/^\d+\.\d+\.\d+/, 'Must follow semver (e.g. "1.0.0")'),
@@ -123,6 +135,7 @@ export const AgentManifestSchema = z.object({
   prompt: PromptSchema.optional(),
   skills: z.array(SkillRefSchema).optional(),
   bootstrap: BootstrapPathConfigSchema.optional(),
+  sessionScoping: SessionScopingSchema.optional(),
 });
 
 /**


### PR DESCRIPTION
## Summary

Closes #82. Hardens the 4-mode conversation scoping implementation with performance optimizations, structured observability callbacks, and manifest integration across 3 packages (`@templar/gateway`, `@templar/core`, `@templar/manifest`).

- **Performance**: Eliminate O(n) array spread in `mapSet`, early-return in `addToNodeIndex`, refactor `removeNode` to single `mapFilter` pass
- **Observability**: Replace `console.warn` with `CapacityWarningHandler` callback (80% trigger, 70% hysteresis reset), add `DegradationHandler` for degraded key resolution, remove dead `MessageRouter` type
- **Manifest**: Add `sessionScoping` field to `AgentManifest` interface and `SessionScopingSchema` Zod enum with compile-time key assertion

### Files changed (11 files, 3 packages)

| Package | File | Change |
|---------|------|--------|
| `@templar/gateway` | `utils/immutable-map.ts` | `mapSet` perf fix (Map constructor + set) |
| `@templar/gateway` | `conversations/conversation-store.ts` | CapacityWarningHandler callback, early-return in nodeIndex, mapFilter in removeNode |
| `@templar/gateway` | `conversations/index.ts` | Export `CapacityWarningHandler` |
| `@templar/gateway` | `router.ts` | Add `DegradationHandler`, remove dead `MessageRouter` |
| `@templar/gateway` | `index.ts` | Export `DegradationHandler`, `CapacityWarningHandler` |
| `@templar/gateway` | `__tests__/gateway.test.ts` | 6 new integration tests |
| `@templar/gateway` | `conversations/__tests__/conversation-store.test.ts` | 5 new unit tests |
| `@templar/core` | `types.ts` | `sessionScoping` field on `AgentManifest` |
| `@templar/manifest` | `schema.ts` | `SessionScopingSchema` Zod enum |
| `@templar/manifest` | `index.ts` | Export `SessionScopingSchema`, `SESSION_SCOPING_VALUES` |
| `@templar/manifest` | `__tests__/unit/schema.test.ts` | 10 new schema validation tests |

## Test plan

- [x] Gateway: 451 tests pass (95% stmt coverage, 92% router branch coverage)
- [x] Manifest: 222 tests pass (10 new sessionScoping tests)
- [x] Core: 220 tests pass
- [x] TypeScript typechecks pass on all 3 packages
- [x] Biome lint passes on all changed files
- [x] Compile-time key assertion validates AgentManifest ↔ Zod schema sync
- [ ] Manual: verify `sessionScoping: per-channel-peer` in templar.yaml parses correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)