### PR TITLE
feat(auth): add Ed25519 device token authentication

### DIFF
--- a/packages/errors/src/catalog.ts
+++ b/packages/errors/src/catalog.ts
@@ -1017,6 +1017,43 @@ export const ERROR_CATALOG = {
     title: "Node stopped",
     description: "The operation was cancelled because the node is stopping",
   },
+  NODE_DEVICE_KEY_INVALID: {
+    domain: "node",
+    httpStatus: 401,
+    grpcCode: "UNAUTHENTICATED" as const,
+    baseType: "PermissionError" as const,
+    isExpected: true,
+    title: "Invalid device key",
+    description: "The Ed25519 device key JWT is invalid or malformed",
+  },
+  NODE_DEVICE_KEY_MISMATCH: {
+    domain: "node",
+    httpStatus: 403,
+    grpcCode: "PERMISSION_DENIED" as const,
+    baseType: "PermissionError" as const,
+    isExpected: true,
+    title: "Device key mismatch",
+    description:
+      "The Ed25519 public key does not match the previously registered key for this node",
+  },
+  NODE_DEVICE_KEY_EXPIRED: {
+    domain: "node",
+    httpStatus: 401,
+    grpcCode: "UNAUTHENTICATED" as const,
+    baseType: "PermissionError" as const,
+    isExpected: true,
+    title: "Device key expired",
+    description: "The Ed25519 device key JWT has expired",
+  },
+  GATEWAY_TOFU_REJECTED: {
+    domain: "gateway",
+    httpStatus: 403,
+    grpcCode: "PERMISSION_DENIED" as const,
+    baseType: "PermissionError" as const,
+    isExpected: true,
+    title: "TOFU registration rejected",
+    description: "Trust-On-First-Use device key registration is disabled; pre-register the key",
+  },
 
   // ============================================================================
   // SANITIZE ERRORS — Content sanitization

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@templar/core": "workspace:*",
     "@templar/errors": "workspace:*",
+    "jose": "^6.1.3",
     "zod": "^3.22.4"
   },
   "peerDependencies": {

--- a/packages/gateway/src/__tests__/auth-integration.test.ts
+++ b/packages/gateway/src/__tests__/auth-integration.test.ts
@@ -1,0 +1,483 @@
+import type { KeyObject } from "node:crypto";
+import { generateKeyPairSync } from "node:crypto";
+import { SignJWT } from "jose";
+import { describe, expect, it, vi } from "vitest";
+import { TemplarGateway, type TemplarGatewayDeps } from "../gateway.js";
+import type { GatewayConfig, GatewayFrame } from "../protocol/index.js";
+import type { WsServerFactory } from "../server.js";
+import { createMockWss, DEFAULT_CAPS, type MockWs, type MockWss, sendFrame } from "./helpers.js";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function makeKeyPair() {
+  const { privateKey, publicKey } = generateKeyPairSync("ed25519");
+  return { privateKey, publicKey };
+}
+
+function exportBase64url(key: KeyObject): string {
+  const der = key.export({ type: "spki", format: "der" }) as Buffer;
+  return der.subarray(12).toString("base64url");
+}
+
+async function signJwt(privateKey: KeyObject, nodeId: string, exp = "5m"): Promise<string> {
+  return new SignJWT({ sub: nodeId })
+    .setProtectedHeader({ alg: "EdDSA" })
+    .setIssuedAt()
+    .setExpirationTime(exp)
+    .sign(privateKey);
+}
+
+async function signExpiredJwt(privateKey: KeyObject, nodeId: string): Promise<string> {
+  const now = Math.floor(Date.now() / 1000);
+  return new SignJWT({ sub: nodeId })
+    .setProtectedHeader({ alg: "EdDSA" })
+    .setIssuedAt(now - 600)
+    .setExpirationTime(now - 300)
+    .sign(privateKey);
+}
+
+function createAuthGateway(overrides: Partial<GatewayConfig> = {}): {
+  gateway: TemplarGateway;
+  wss: MockWss;
+} {
+  const wss = createMockWss();
+  const factory: WsServerFactory = vi.fn().mockReturnValue(wss);
+  const config: GatewayConfig = {
+    port: 0,
+    nexusUrl: "https://api.nexus.test",
+    nexusApiKey: "test-key",
+    sessionTimeout: 60_000,
+    suspendTimeout: 300_000,
+    healthCheckInterval: 30_000,
+    laneCapacity: 256,
+    maxConnections: 1024,
+    maxFramesPerSecond: 100,
+    defaultConversationScope: "per-channel-peer",
+    maxConversations: 100_000,
+    conversationTtl: 86_400_000,
+    authMode: "dual",
+    deviceAuth: {
+      allowTofu: true,
+      maxDeviceKeys: 10_000,
+      jwtMaxAge: "5m",
+    },
+    ...overrides,
+  };
+  const deps: TemplarGatewayDeps = {
+    wsFactory: factory,
+    configWatcherDeps: {
+      watch: () => ({
+        on: vi.fn(),
+        close: vi.fn().mockResolvedValue(undefined),
+      }),
+    },
+  };
+  const gateway = new TemplarGateway(config, deps);
+  return { gateway, wss };
+}
+
+function getLastSentFrame(ws: MockWs): GatewayFrame | undefined {
+  const frames = ws.sentFrames();
+  return frames[frames.length - 1];
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("Auth integration", () => {
+  // -------------------------------------------------------------------------
+  // Legacy token auth
+  // -------------------------------------------------------------------------
+
+  describe("legacy token auth", () => {
+    it("legacy node connects with bearer token in dual mode", async () => {
+      const { gateway, wss } = createAuthGateway({ authMode: "dual" });
+      await gateway.start();
+
+      const ws = wss.connect();
+      sendFrame(ws, {
+        kind: "node.register",
+        nodeId: "legacy-node",
+        capabilities: DEFAULT_CAPS,
+        token: "test-key",
+      });
+
+      const ack = getLastSentFrame(ws);
+      expect(ack?.kind).toBe("node.register.ack");
+
+      await gateway.stop();
+    });
+
+    it("legacy node rejected in ed25519-only mode", async () => {
+      const { gateway, wss } = createAuthGateway({ authMode: "ed25519" });
+      await gateway.start();
+
+      const ws = wss.connect();
+      sendFrame(ws, {
+        kind: "node.register",
+        nodeId: "legacy-node",
+        capabilities: DEFAULT_CAPS,
+        token: "test-key",
+      });
+
+      const last = getLastSentFrame(ws);
+      expect(last?.kind).toBe("error");
+      if (last?.kind === "error") {
+        expect(last.error.status).toBe(403);
+        expect(last.error.detail).toContain("Legacy token auth is disabled");
+      }
+
+      await gateway.stop();
+    });
+
+    it("legacy node with wrong token rejected", async () => {
+      const { gateway, wss } = createAuthGateway({ authMode: "dual" });
+      await gateway.start();
+
+      const ws = wss.connect();
+      sendFrame(ws, {
+        kind: "node.register",
+        nodeId: "legacy-node",
+        capabilities: DEFAULT_CAPS,
+        token: "wrong-key",
+      });
+
+      const last = getLastSentFrame(ws);
+      expect(last?.kind).toBe("error");
+      if (last?.kind === "error") {
+        expect(last.error.status).toBe(401);
+      }
+
+      await gateway.stop();
+    });
+
+    it("logs deprecation warning for legacy tokens in dual mode", async () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const { gateway, wss } = createAuthGateway({ authMode: "dual" });
+      await gateway.start();
+
+      const ws = wss.connect();
+      sendFrame(ws, {
+        kind: "node.register",
+        nodeId: "legacy-node",
+        capabilities: DEFAULT_CAPS,
+        token: "test-key",
+      });
+
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("DEPRECATION"));
+      warnSpy.mockRestore();
+
+      await gateway.stop();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Ed25519 auth
+  // -------------------------------------------------------------------------
+
+  describe("Ed25519 auth", () => {
+    it("Ed25519 node connects with valid JWT", async () => {
+      const { privateKey, publicKey } = makeKeyPair();
+      const { gateway, wss } = createAuthGateway({
+        authMode: "dual",
+        deviceAuth: { allowTofu: true, maxDeviceKeys: 100, jwtMaxAge: "5m" },
+      });
+      await gateway.start();
+
+      const ws = wss.connect();
+      const jwt = await signJwt(privateKey, "ed25519-node");
+      sendFrame(ws, {
+        kind: "node.register",
+        nodeId: "ed25519-node",
+        capabilities: DEFAULT_CAPS,
+        signature: jwt,
+        publicKey: exportBase64url(publicKey),
+      });
+
+      // Need to wait for async verification
+      await new Promise((r) => setTimeout(r, 50));
+
+      const ack = getLastSentFrame(ws);
+      expect(ack?.kind).toBe("node.register.ack");
+
+      await gateway.stop();
+    });
+
+    it("Ed25519 node with expired JWT is rejected", async () => {
+      const { privateKey, publicKey } = makeKeyPair();
+      const { gateway, wss } = createAuthGateway({
+        authMode: "dual",
+        deviceAuth: { allowTofu: true, maxDeviceKeys: 100, jwtMaxAge: "5m" },
+      });
+      await gateway.start();
+
+      const ws = wss.connect();
+      const jwt = await signExpiredJwt(privateKey, "ed25519-node");
+      sendFrame(ws, {
+        kind: "node.register",
+        nodeId: "ed25519-node",
+        capabilities: DEFAULT_CAPS,
+        signature: jwt,
+        publicKey: exportBase64url(publicKey),
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      const last = getLastSentFrame(ws);
+      expect(last?.kind).toBe("error");
+      if (last?.kind === "error") {
+        expect(last.error.status).toBe(401);
+      }
+
+      await gateway.stop();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // TOFU
+  // -------------------------------------------------------------------------
+
+  describe("TOFU registration", () => {
+    it("unknown key + TOFU enabled: accepts and stores key", async () => {
+      const { privateKey, publicKey } = makeKeyPair();
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const { gateway, wss } = createAuthGateway({
+        authMode: "ed25519",
+        deviceAuth: { allowTofu: true, maxDeviceKeys: 100, jwtMaxAge: "5m" },
+      });
+      await gateway.start();
+
+      const ws = wss.connect();
+      const jwt = await signJwt(privateKey, "new-node");
+      sendFrame(ws, {
+        kind: "node.register",
+        nodeId: "new-node",
+        capabilities: DEFAULT_CAPS,
+        signature: jwt,
+        publicKey: exportBase64url(publicKey),
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      const ack = getLastSentFrame(ws);
+      expect(ack?.kind).toBe("node.register.ack");
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("TOFU"));
+      warnSpy.mockRestore();
+
+      await gateway.stop();
+    });
+
+    it("unknown key + TOFU disabled: rejected", async () => {
+      const { privateKey, publicKey } = makeKeyPair();
+      const { gateway, wss } = createAuthGateway({
+        authMode: "ed25519",
+        deviceAuth: { allowTofu: false, maxDeviceKeys: 100, jwtMaxAge: "5m" },
+      });
+      await gateway.start();
+
+      const ws = wss.connect();
+      const jwt = await signJwt(privateKey, "new-node");
+      sendFrame(ws, {
+        kind: "node.register",
+        nodeId: "new-node",
+        capabilities: DEFAULT_CAPS,
+        signature: jwt,
+        publicKey: exportBase64url(publicKey),
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      const last = getLastSentFrame(ws);
+      expect(last?.kind).toBe("error");
+      if (last?.kind === "error") {
+        expect(last.error.status).toBe(403);
+        expect(last.error.detail).toContain("TOFU");
+      }
+
+      await gateway.stop();
+    });
+
+    it("second connection with same key: accepted", async () => {
+      const { privateKey, publicKey } = makeKeyPair();
+      const { gateway, wss } = createAuthGateway({
+        authMode: "ed25519",
+        deviceAuth: { allowTofu: true, maxDeviceKeys: 100, jwtMaxAge: "5m" },
+      });
+      await gateway.start();
+
+      // First connection — TOFU accepts key
+      const ws1 = wss.connect();
+      const jwt1 = await signJwt(privateKey, "tofu-node");
+      sendFrame(ws1, {
+        kind: "node.register",
+        nodeId: "tofu-node",
+        capabilities: DEFAULT_CAPS,
+        signature: jwt1,
+        publicKey: exportBase64url(publicKey),
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+      expect(getLastSentFrame(ws1)?.kind).toBe("node.register.ack");
+
+      // Deregister first node cleanly before reconnecting
+      sendFrame(ws1, {
+        kind: "node.deregister",
+        nodeId: "tofu-node",
+        reason: "reconnecting",
+      });
+
+      // Simulate disconnect/cleanup after deregister
+      const closeHandlers = ws1.handlers.get("close") ?? [];
+      for (const h of closeHandlers) h(1000, "");
+
+      await new Promise((r) => setTimeout(r, 10));
+
+      // Second connection — same key should be accepted
+      const ws2 = wss.connect();
+      const jwt2 = await signJwt(privateKey, "tofu-node");
+      sendFrame(ws2, {
+        kind: "node.register",
+        nodeId: "tofu-node",
+        capabilities: DEFAULT_CAPS,
+        signature: jwt2,
+        publicKey: exportBase64url(publicKey),
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+      expect(getLastSentFrame(ws2)?.kind).toBe("node.register.ack");
+
+      await gateway.stop();
+    });
+
+    it("second connection with different key: rejected (key mismatch)", async () => {
+      const pair1 = makeKeyPair();
+      const pair2 = makeKeyPair();
+      const { gateway, wss } = createAuthGateway({
+        authMode: "ed25519",
+        deviceAuth: { allowTofu: true, maxDeviceKeys: 100, jwtMaxAge: "5m" },
+      });
+      await gateway.start();
+
+      // First connection — TOFU accepts key
+      const ws1 = wss.connect();
+      const jwt1 = await signJwt(pair1.privateKey, "tofu-node");
+      sendFrame(ws1, {
+        kind: "node.register",
+        nodeId: "tofu-node",
+        capabilities: DEFAULT_CAPS,
+        signature: jwt1,
+        publicKey: exportBase64url(pair1.publicKey),
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+      expect(getLastSentFrame(ws1)?.kind).toBe("node.register.ack");
+
+      // Simulate disconnect
+      const closeHandlers = ws1.handlers.get("close") ?? [];
+      for (const h of closeHandlers) h(1000, "");
+
+      // Second connection — different key should be rejected
+      const ws2 = wss.connect();
+      const jwt2 = await signJwt(pair2.privateKey, "tofu-node");
+      sendFrame(ws2, {
+        kind: "node.register",
+        nodeId: "tofu-node",
+        capabilities: DEFAULT_CAPS,
+        signature: jwt2,
+        publicKey: exportBase64url(pair2.publicKey),
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+      const last = getLastSentFrame(ws2);
+      expect(last?.kind).toBe("error");
+      if (last?.kind === "error") {
+        expect(last.error.status).toBe(403);
+        expect(last.error.detail).toContain("mismatch");
+      }
+
+      await gateway.stop();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Dual mode coexistence
+  // -------------------------------------------------------------------------
+
+  describe("dual mode", () => {
+    it("legacy and ed25519 nodes coexist in dual mode", async () => {
+      const { privateKey, publicKey } = makeKeyPair();
+      const { gateway, wss } = createAuthGateway({
+        authMode: "dual",
+        deviceAuth: { allowTofu: true, maxDeviceKeys: 100, jwtMaxAge: "5m" },
+      });
+      await gateway.start();
+
+      // Ed25519 node
+      const ws1 = wss.connect();
+      const jwt = await signJwt(privateKey, "ed25519-node");
+      sendFrame(ws1, {
+        kind: "node.register",
+        nodeId: "ed25519-node",
+        capabilities: DEFAULT_CAPS,
+        signature: jwt,
+        publicKey: exportBase64url(publicKey),
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+      expect(getLastSentFrame(ws1)?.kind).toBe("node.register.ack");
+
+      // Legacy node
+      const ws2 = wss.connect();
+      sendFrame(ws2, {
+        kind: "node.register",
+        nodeId: "legacy-node",
+        capabilities: DEFAULT_CAPS,
+        token: "test-key",
+      });
+
+      expect(getLastSentFrame(ws2)?.kind).toBe("node.register.ack");
+      expect(gateway.nodeCount).toBe(2);
+
+      await gateway.stop();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Pre-registered keys
+  // -------------------------------------------------------------------------
+
+  describe("pre-registered keys", () => {
+    it("accepts node with pre-registered key (TOFU disabled)", async () => {
+      const { privateKey, publicKey } = makeKeyPair();
+      const b64url = exportBase64url(publicKey);
+      const { gateway, wss } = createAuthGateway({
+        authMode: "ed25519",
+        deviceAuth: {
+          allowTofu: false,
+          maxDeviceKeys: 100,
+          jwtMaxAge: "5m",
+          knownKeys: [{ nodeId: "known-node", publicKey: b64url }],
+        },
+      });
+      await gateway.start();
+
+      const ws = wss.connect();
+      const jwt = await signJwt(privateKey, "known-node");
+      sendFrame(ws, {
+        kind: "node.register",
+        nodeId: "known-node",
+        capabilities: DEFAULT_CAPS,
+        signature: jwt,
+        publicKey: b64url,
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+      expect(getLastSentFrame(ws)?.kind).toBe("node.register.ack");
+
+      await gateway.stop();
+    });
+  });
+});

--- a/packages/gateway/src/__tests__/config-watcher.test.ts
+++ b/packages/gateway/src/__tests__/config-watcher.test.ts
@@ -18,6 +18,7 @@ const VALID_CONFIG: GatewayConfig = {
   defaultConversationScope: "per-channel-peer",
   maxConversations: 100_000,
   conversationTtl: 86_400_000,
+  authMode: "legacy",
 };
 
 function createMockDeps(): ConfigWatcherDeps {

--- a/packages/gateway/src/__tests__/device-auth.test.ts
+++ b/packages/gateway/src/__tests__/device-auth.test.ts
@@ -1,0 +1,114 @@
+import type { KeyObject } from "node:crypto";
+import { generateKeyPairSync } from "node:crypto";
+import { SignJWT } from "jose";
+import { describe, expect, it } from "vitest";
+import { timingSafeTokenCompare, verifyDeviceJwt } from "../device-auth.js";
+
+function makeKeyPair() {
+  const { privateKey, publicKey } = generateKeyPairSync("ed25519");
+  return { privateKey, publicKey };
+}
+
+async function signJwt(
+  privateKey: KeyObject,
+  nodeId: string,
+  options?: { exp?: string },
+): Promise<string> {
+  let builder = new SignJWT({ sub: nodeId }).setProtectedHeader({ alg: "EdDSA" }).setIssuedAt();
+  if (options?.exp) {
+    builder = builder.setExpirationTime(options.exp);
+  } else {
+    builder = builder.setExpirationTime("5m");
+  }
+  return builder.sign(privateKey);
+}
+
+describe("verifyDeviceJwt", () => {
+  it("verifies a valid JWT", async () => {
+    const { privateKey, publicKey } = makeKeyPair();
+    const jwt = await signJwt(privateKey, "node-1");
+
+    const result = await verifyDeviceJwt(jwt, publicKey);
+    expect(result.valid).toBe(true);
+    expect(result.nodeId).toBe("node-1");
+    expect(result.exp).toBeTypeOf("number");
+  });
+
+  it("rejects an expired JWT", async () => {
+    const { privateKey, publicKey } = makeKeyPair();
+    // Sign with 0 seconds expiration
+    const jwt = await new SignJWT({ sub: "node-1" })
+      .setProtectedHeader({ alg: "EdDSA" })
+      .setIssuedAt(Math.floor(Date.now() / 1000) - 600)
+      .setExpirationTime(Math.floor(Date.now() / 1000) - 300)
+      .sign(privateKey);
+
+    const result = await verifyDeviceJwt(jwt, publicKey);
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("expired");
+  });
+
+  it("rejects a JWT signed with a different key", async () => {
+    const attacker = makeKeyPair();
+    const victim = makeKeyPair();
+    const jwt = await signJwt(attacker.privateKey, "node-1");
+
+    const result = await verifyDeviceJwt(jwt, victim.publicKey);
+    expect(result.valid).toBe(false);
+  });
+
+  it("rejects a tampered JWT payload", async () => {
+    const { privateKey, publicKey } = makeKeyPair();
+    const jwt = await signJwt(privateKey, "node-1");
+
+    // Tamper with the payload
+    const [header, , sig] = jwt.split(".");
+    const fakePayload = Buffer.from(JSON.stringify({ sub: "attacker" })).toString("base64url");
+    const tampered = `${header}.${fakePayload}.${sig}`;
+
+    const result = await verifyDeviceJwt(tampered, publicKey);
+    expect(result.valid).toBe(false);
+  });
+
+  it("rejects a malformed JWT", async () => {
+    const { publicKey } = makeKeyPair();
+    const result = await verifyDeviceJwt("not-a-jwt", publicKey);
+    expect(result.valid).toBe(false);
+  });
+
+  it("rejects a JWT without sub claim", async () => {
+    const { privateKey, publicKey } = makeKeyPair();
+    const jwt = await new SignJWT({})
+      .setProtectedHeader({ alg: "EdDSA" })
+      .setIssuedAt()
+      .setExpirationTime("5m")
+      .sign(privateKey);
+
+    const result = await verifyDeviceJwt(jwt, publicKey);
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("sub");
+  });
+});
+
+describe("timingSafeTokenCompare", () => {
+  it("returns true for equal strings", () => {
+    expect(timingSafeTokenCompare("test-token-123", "test-token-123")).toBe(true);
+  });
+
+  it("returns false for different strings of same length", () => {
+    expect(timingSafeTokenCompare("test-token-aaa", "test-token-bbb")).toBe(false);
+  });
+
+  it("returns false for different-length strings", () => {
+    expect(timingSafeTokenCompare("short", "much-longer-string")).toBe(false);
+  });
+
+  it("returns true for empty strings", () => {
+    expect(timingSafeTokenCompare("", "")).toBe(true);
+  });
+
+  it("handles unicode strings", () => {
+    expect(timingSafeTokenCompare("héllo", "héllo")).toBe(true);
+    expect(timingSafeTokenCompare("héllo", "hello")).toBe(false);
+  });
+});

--- a/packages/gateway/src/__tests__/device-key-store.test.ts
+++ b/packages/gateway/src/__tests__/device-key-store.test.ts
@@ -1,0 +1,153 @@
+import type { KeyObject } from "node:crypto";
+import { generateKeyPairSync } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { InMemoryDeviceKeyStore, importBase64urlPublicKey } from "../device-key-store.js";
+
+function makeTestKeyPair() {
+  const { publicKey } = generateKeyPairSync("ed25519");
+  return publicKey;
+}
+
+function exportBase64url(key: KeyObject): string {
+  const der = key.export({ type: "spki", format: "der" }) as Buffer;
+  return der.subarray(12).toString("base64url");
+}
+
+describe("InMemoryDeviceKeyStore", () => {
+  // -------------------------------------------------------------------------
+  // Basic CRUD
+  // -------------------------------------------------------------------------
+
+  it("stores and retrieves a key", () => {
+    const store = new InMemoryDeviceKeyStore();
+    const key = makeTestKeyPair();
+    store.set("node-1", key);
+    expect(store.get("node-1")).toBe(key);
+  });
+
+  it("returns undefined for unknown nodeId", () => {
+    const store = new InMemoryDeviceKeyStore();
+    expect(store.get("unknown")).toBeUndefined();
+  });
+
+  it("has() returns true for stored keys", () => {
+    const store = new InMemoryDeviceKeyStore();
+    const key = makeTestKeyPair();
+    store.set("node-1", key);
+    expect(store.has("node-1")).toBe(true);
+    expect(store.has("node-2")).toBe(false);
+  });
+
+  it("delete() removes a key", () => {
+    const store = new InMemoryDeviceKeyStore();
+    const key = makeTestKeyPair();
+    store.set("node-1", key);
+    expect(store.delete("node-1")).toBe(true);
+    expect(store.has("node-1")).toBe(false);
+    expect(store.size).toBe(0);
+  });
+
+  it("delete() returns false for unknown key", () => {
+    const store = new InMemoryDeviceKeyStore();
+    expect(store.delete("unknown")).toBe(false);
+  });
+
+  it("tracks size correctly", () => {
+    const store = new InMemoryDeviceKeyStore();
+    expect(store.size).toBe(0);
+    store.set("node-1", makeTestKeyPair());
+    expect(store.size).toBe(1);
+    store.set("node-2", makeTestKeyPair());
+    expect(store.size).toBe(2);
+    store.delete("node-1");
+    expect(store.size).toBe(1);
+  });
+
+  it("overwrites existing key for same nodeId", () => {
+    const store = new InMemoryDeviceKeyStore();
+    const key1 = makeTestKeyPair();
+    const key2 = makeTestKeyPair();
+    store.set("node-1", key1);
+    store.set("node-1", key2);
+    expect(store.get("node-1")).toBe(key2);
+    expect(store.size).toBe(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // LRU Eviction
+  // -------------------------------------------------------------------------
+
+  it("evicts least-recently-used entry when maxKeys is exceeded", () => {
+    const store = new InMemoryDeviceKeyStore({ maxKeys: 2 });
+    store.set("node-1", makeTestKeyPair());
+    store.set("node-2", makeTestKeyPair());
+
+    // node-1 is LRU, should be evicted when node-3 is added
+    store.set("node-3", makeTestKeyPair());
+    expect(store.has("node-1")).toBe(false);
+    expect(store.has("node-2")).toBe(true);
+    expect(store.has("node-3")).toBe(true);
+    expect(store.size).toBe(2);
+  });
+
+  it("updates lastUsed on get()", async () => {
+    const store = new InMemoryDeviceKeyStore({ maxKeys: 2 });
+    store.set("node-1", makeTestKeyPair());
+    // Small delay so timestamps differ
+    await new Promise((r) => setTimeout(r, 5));
+    store.set("node-2", makeTestKeyPair());
+
+    // Small delay, then access node-1 to make it most recently used
+    await new Promise((r) => setTimeout(r, 5));
+    store.get("node-1");
+
+    // Now node-2 is LRU and should be evicted
+    store.set("node-3", makeTestKeyPair());
+    expect(store.has("node-1")).toBe(true);
+    expect(store.has("node-2")).toBe(false);
+    expect(store.has("node-3")).toBe(true);
+  });
+
+  it("does not evict when overwriting an existing key", () => {
+    const store = new InMemoryDeviceKeyStore({ maxKeys: 2 });
+    store.set("node-1", makeTestKeyPair());
+    store.set("node-2", makeTestKeyPair());
+
+    // Overwriting node-1 should not cause eviction
+    store.set("node-1", makeTestKeyPair());
+    expect(store.size).toBe(2);
+    expect(store.has("node-1")).toBe(true);
+    expect(store.has("node-2")).toBe(true);
+  });
+
+  // -------------------------------------------------------------------------
+  // loadFromConfig
+  // -------------------------------------------------------------------------
+
+  it("bulk loads keys from config", () => {
+    const store = new InMemoryDeviceKeyStore();
+    const key1 = makeTestKeyPair();
+    const key2 = makeTestKeyPair();
+    const knownKeys = [
+      { nodeId: "node-1", publicKey: exportBase64url(key1) },
+      { nodeId: "node-2", publicKey: exportBase64url(key2) },
+    ];
+    store.loadFromConfig(knownKeys);
+    expect(store.size).toBe(2);
+    expect(store.has("node-1")).toBe(true);
+    expect(store.has("node-2")).toBe(true);
+  });
+});
+
+describe("importBase64urlPublicKey", () => {
+  it("imports a base64url-encoded Ed25519 public key", () => {
+    const original = makeTestKeyPair();
+    const base64url = exportBase64url(original);
+    const imported = importBase64urlPublicKey(base64url);
+
+    // Compare DER exports
+    const originalDer = original.export({ type: "spki", format: "der" });
+    const importedDer = imported.export({ type: "spki", format: "der" });
+    expect(Buffer.compare(originalDer as Buffer, importedDer as Buffer)).toBe(0);
+  });
+});

--- a/packages/gateway/src/device-auth.ts
+++ b/packages/gateway/src/device-auth.ts
@@ -1,0 +1,71 @@
+import type { KeyObject } from "node:crypto";
+import { timingSafeEqual } from "node:crypto";
+import { jwtVerify } from "jose";
+
+// ---------------------------------------------------------------------------
+// JWT Verification
+// ---------------------------------------------------------------------------
+
+export interface DeviceJwtResult {
+  readonly valid: boolean;
+  readonly nodeId?: string | undefined;
+  readonly exp?: number | undefined;
+  readonly error?: string | undefined;
+}
+
+/**
+ * Verify an Ed25519-signed device JWT against a public key.
+ *
+ * Returns a result object indicating validity, the nodeId from the `sub` claim,
+ * and the expiration time.
+ */
+export async function verifyDeviceJwt(
+  signature: string,
+  publicKey: KeyObject,
+): Promise<DeviceJwtResult> {
+  try {
+    const { payload } = await jwtVerify(signature, publicKey, {
+      algorithms: ["EdDSA"],
+    });
+    const nodeId = payload.sub;
+    if (!nodeId) {
+      return { valid: false, error: "Missing 'sub' claim in JWT" };
+    }
+    return {
+      valid: true,
+      nodeId,
+      exp: payload.exp,
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    // Distinguish expired vs other errors
+    if (message.includes("exp") || message.includes("expired")) {
+      return { valid: false, error: "JWT expired" };
+    }
+    return { valid: false, error: message };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Timing-Safe Token Comparison
+// ---------------------------------------------------------------------------
+
+/**
+ * Compare two strings in constant time to prevent timing attacks.
+ *
+ * Handles different-length strings safely by comparing against
+ * a fixed-length hash-like buffer.
+ */
+export function timingSafeTokenCompare(a: string, b: string): boolean {
+  const bufA = Buffer.from(a, "utf-8");
+  const bufB = Buffer.from(b, "utf-8");
+
+  if (bufA.length !== bufB.length) {
+    // Compare bufA against itself to maintain constant time,
+    // then return false (different lengths are never equal)
+    timingSafeEqual(bufA, bufA);
+    return false;
+  }
+
+  return timingSafeEqual(bufA, bufB);
+}

--- a/packages/gateway/src/device-key-store.ts
+++ b/packages/gateway/src/device-key-store.ts
@@ -1,0 +1,122 @@
+import { createPublicKey, type KeyObject } from "node:crypto";
+
+// ---------------------------------------------------------------------------
+// DeviceKeyStore Interface
+// ---------------------------------------------------------------------------
+
+export interface DeviceKeyStore {
+  get(nodeId: string): KeyObject | undefined;
+  set(nodeId: string, key: KeyObject): void;
+  has(nodeId: string): boolean;
+  delete(nodeId: string): boolean;
+  readonly size: number;
+}
+
+// ---------------------------------------------------------------------------
+// InMemoryDeviceKeyStore
+// ---------------------------------------------------------------------------
+
+interface StoredKey {
+  readonly key: KeyObject;
+  lastUsed: number;
+}
+
+export interface InMemoryDeviceKeyStoreOptions {
+  readonly maxKeys?: number;
+}
+
+/**
+ * In-memory device key store with LRU eviction.
+ *
+ * Stores Ed25519 public keys keyed by nodeId.
+ * When the store reaches maxKeys, the least-recently-used entry is evicted.
+ */
+export class InMemoryDeviceKeyStore implements DeviceKeyStore {
+  private readonly keys = new Map<string, StoredKey>();
+  private readonly maxKeys: number;
+
+  constructor(options: InMemoryDeviceKeyStoreOptions = {}) {
+    this.maxKeys = options.maxKeys ?? 10_000;
+  }
+
+  get(nodeId: string): KeyObject | undefined {
+    const entry = this.keys.get(nodeId);
+    if (entry) {
+      entry.lastUsed = Date.now();
+      return entry.key;
+    }
+    return undefined;
+  }
+
+  set(nodeId: string, key: KeyObject): void {
+    // Update existing entry
+    const existing = this.keys.get(nodeId);
+    if (existing) {
+      // Replace with new key + updated timestamp (immutable key object)
+      this.keys.set(nodeId, { key, lastUsed: Date.now() });
+      return;
+    }
+
+    // Evict LRU if at capacity
+    if (this.keys.size >= this.maxKeys) {
+      this.evictLru();
+    }
+
+    this.keys.set(nodeId, { key, lastUsed: Date.now() });
+  }
+
+  has(nodeId: string): boolean {
+    return this.keys.has(nodeId);
+  }
+
+  delete(nodeId: string): boolean {
+    return this.keys.delete(nodeId);
+  }
+
+  get size(): number {
+    return this.keys.size;
+  }
+
+  /**
+   * Bulk-load known keys from config.
+   * Each entry is a { nodeId, publicKey } where publicKey is a base64url-encoded
+   * raw Ed25519 public key (32 bytes).
+   */
+  loadFromConfig(
+    knownKeys: readonly { readonly nodeId: string; readonly publicKey: string }[],
+  ): void {
+    for (const { nodeId, publicKey } of knownKeys) {
+      const keyObject = importBase64urlPublicKey(publicKey);
+      this.keys.set(nodeId, { key: keyObject, lastUsed: Date.now() });
+    }
+  }
+
+  private evictLru(): void {
+    let oldestId: string | undefined;
+    let oldestTime = Infinity;
+    for (const [id, entry] of this.keys) {
+      if (entry.lastUsed < oldestTime) {
+        oldestTime = entry.lastUsed;
+        oldestId = id;
+      }
+    }
+    if (oldestId !== undefined) {
+      this.keys.delete(oldestId);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Import a base64url-encoded raw Ed25519 public key (32 bytes) into a KeyObject.
+ */
+export function importBase64urlPublicKey(base64url: string): KeyObject {
+  const raw = Buffer.from(base64url, "base64url");
+  // Ed25519 public key in DER format: 12-byte OID prefix + 32-byte raw key
+  const ed25519OidPrefix = Buffer.from("302a300506032b6570032100", "hex");
+  const der = Buffer.concat([ed25519OidPrefix, raw]);
+  return createPublicKey({ key: der, format: "der", type: "spki" });
+}

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -32,6 +32,14 @@ export {
 } from "./conversations/index.js";
 // Delivery tracking
 export { DeliveryTracker, type PendingMessage } from "./delivery-tracker.js";
+// Device auth
+export { type DeviceJwtResult, timingSafeTokenCompare, verifyDeviceJwt } from "./device-auth.js";
+export {
+  type DeviceKeyStore,
+  InMemoryDeviceKeyStore,
+  type InMemoryDeviceKeyStoreOptions,
+  importBase64urlPublicKey,
+} from "./device-key-store.js";
 // Orchestrator
 export { type GatewayEventHandler, TemplarGateway, type TemplarGatewayDeps } from "./gateway.js";
 // Protocol (shared with @templar/node via @templar/gateway/protocol subpath)
@@ -56,6 +64,7 @@ export { NodeRegistry, type RegisteredNode } from "./registry/node-registry.js";
 export { type AgentNodeResolver, AgentRouter, type DegradationHandler } from "./router.js";
 // Server
 export {
+  type AuthResult,
   type ConnectionHandler,
   type DisconnectHandler,
   type FrameHandler,

--- a/packages/gateway/src/protocol/__tests__/frames.test.ts
+++ b/packages/gateway/src/protocol/__tests__/frames.test.ts
@@ -35,10 +35,23 @@ describe("GatewayFrame schemas", () => {
       expect(result.success).toBe(false);
     });
 
-    it("rejects node.register with missing token", () => {
+    it("accepts node.register without token when signature is absent (validation in handler)", () => {
       const { token: _, ...noToken } = validFrame;
+      // Schema allows optional token/signature; auth validation happens in frame handler
       const result = safeParseFrame(noToken);
-      expect(result.success).toBe(false);
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts node.register with signature instead of token", () => {
+      const frame = {
+        kind: "node.register" as const,
+        nodeId: "node-1",
+        capabilities: validFrame.capabilities,
+        signature: "eyJhbGciOiJFZERTQSJ9.test.signature",
+        publicKey: "dGVzdC1wdWJsaWMta2V5",
+      };
+      const result = safeParseFrame(frame);
+      expect(result.success).toBe(true);
     });
   });
 

--- a/packages/gateway/src/protocol/__tests__/types.test.ts
+++ b/packages/gateway/src/protocol/__tests__/types.test.ts
@@ -29,6 +29,7 @@ describe("GatewayConfig", () => {
     defaultConversationScope: "per-channel-peer" as const,
     maxConversations: 100_000,
     conversationTtl: 86_400_000,
+    authMode: "legacy" as const,
   };
 
   it("accepts valid config", () => {

--- a/packages/gateway/src/protocol/frames.ts
+++ b/packages/gateway/src/protocol/frames.ts
@@ -32,7 +32,12 @@ export interface NodeRegisterFrame {
   readonly kind: "node.register";
   readonly nodeId: string;
   readonly capabilities: NodeCapabilities;
-  readonly token: string;
+  /** Legacy bearer token (optional when using Ed25519 auth) */
+  readonly token?: string;
+  /** Base64url-encoded Ed25519 JWT for device auth */
+  readonly signature?: string;
+  /** Base64url-encoded Ed25519 public key (for TOFU registration) */
+  readonly publicKey?: string;
 }
 
 /** Sent by gateway to acknowledge registration */
@@ -125,7 +130,9 @@ export const NodeRegisterFrameSchema = z.object({
   kind: z.literal("node.register"),
   nodeId: z.string().min(1),
   capabilities: NodeCapabilitiesSchema,
-  token: z.string().min(1),
+  token: z.string().min(1).optional(),
+  signature: z.string().min(1).optional(),
+  publicKey: z.string().min(1).optional(),
 });
 
 export const NodeRegisterAckFrameSchema = z.object({

--- a/packages/gateway/src/protocol/index.ts
+++ b/packages/gateway/src/protocol/index.ts
@@ -86,7 +86,11 @@ export {
 } from "./sessions.js";
 // Types
 export {
+  type AuthMode,
+  AuthModeSchema,
   DEFAULT_GATEWAY_CONFIG,
+  type DeviceAuthConfig,
+  DeviceAuthConfigSchema,
   type GatewayConfig,
   GatewayConfigSchema,
   HOT_RELOADABLE_FIELDS,

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@templar/errors": "workspace:*",
     "@templar/gateway": "workspace:*",
+    "jose": "^6.1.3",
     "zod": "^3.22.4"
   },
   "peerDependencies": {

--- a/packages/node/src/__tests__/device-auth.test.ts
+++ b/packages/node/src/__tests__/device-auth.test.ts
@@ -1,0 +1,165 @@
+import { createPrivateKey, createPublicKey } from "node:crypto";
+import { mkdirSync, readFileSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { jwtVerify } from "jose";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  createDeviceJwt,
+  exportPublicKeyBase64url,
+  generateKeyPair,
+  loadOrCreateKeyPair,
+  resolveKeyPair,
+} from "../device-auth.js";
+
+describe("generateKeyPair", () => {
+  it("returns valid PEM-encoded Ed25519 keys", () => {
+    const pair = generateKeyPair();
+    expect(pair.privateKey).toContain("BEGIN PRIVATE KEY");
+    expect(pair.publicKey).toContain("BEGIN PUBLIC KEY");
+
+    // Verify they can be loaded
+    const privKey = createPrivateKey(pair.privateKey);
+    const pubKey = createPublicKey(pair.publicKey);
+    expect(privKey.asymmetricKeyType).toBe("ed25519");
+    expect(pubKey.asymmetricKeyType).toBe("ed25519");
+  });
+
+  it("generates unique key pairs", () => {
+    const pair1 = generateKeyPair();
+    const pair2 = generateKeyPair();
+    expect(pair1.publicKey).not.toBe(pair2.publicKey);
+  });
+});
+
+describe("loadOrCreateKeyPair", () => {
+  let testDir: string;
+
+  beforeEach(() => {
+    testDir = join(tmpdir(), `device-auth-test-${Date.now()}`);
+    mkdirSync(testDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it("generates and saves a key pair on first call", () => {
+    const keyPath = join(testDir, "device.key");
+    const pair = loadOrCreateKeyPair(keyPath);
+
+    expect(pair.privateKey).toContain("BEGIN PRIVATE KEY");
+    expect(pair.publicKey).toContain("BEGIN PUBLIC KEY");
+
+    // File should exist
+    const content = readFileSync(keyPath, "utf-8");
+    expect(content).toContain("BEGIN PRIVATE KEY");
+  });
+
+  it("sets file permissions to 0o600", () => {
+    const keyPath = join(testDir, "device.key");
+    loadOrCreateKeyPair(keyPath);
+
+    const stats = statSync(keyPath);
+    // On macOS/Linux, check owner-only permissions (0o600 = 384)
+    const mode = stats.mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+
+  it("loads existing key on second call", () => {
+    const keyPath = join(testDir, "device.key");
+    const pair1 = loadOrCreateKeyPair(keyPath);
+    const pair2 = loadOrCreateKeyPair(keyPath);
+
+    // Same key pair both times
+    expect(pair1.publicKey).toBe(pair2.publicKey);
+  });
+});
+
+describe("resolveKeyPair", () => {
+  it("resolves from static object", async () => {
+    const pair = generateKeyPair();
+    const resolved = await resolveKeyPair(pair);
+    expect(resolved.privateKey).toBe(pair.privateKey);
+    expect(resolved.publicKey).toBe(pair.publicKey);
+  });
+
+  it("resolves from sync factory function", async () => {
+    const pair = generateKeyPair();
+    const resolved = await resolveKeyPair(() => pair);
+    expect(resolved.privateKey).toBe(pair.privateKey);
+  });
+
+  it("resolves from async factory function", async () => {
+    const pair = generateKeyPair();
+    const resolved = await resolveKeyPair(async () => pair);
+    expect(resolved.privateKey).toBe(pair.privateKey);
+  });
+});
+
+describe("createDeviceJwt", () => {
+  it("produces a valid JWT with correct claims", async () => {
+    const pair = generateKeyPair();
+    const jwt = await createDeviceJwt(pair.privateKey, "node-42");
+
+    // Verify with jose
+    const pubKey = createPublicKey(pair.publicKey);
+    const { payload } = await jwtVerify(jwt, pubKey, { algorithms: ["EdDSA"] });
+
+    expect(payload.sub).toBe("node-42");
+    expect(payload.iat).toBeTypeOf("number");
+    expect(payload.exp).toBeTypeOf("number");
+  });
+
+  it("sets expiration to approximately 5 minutes from now", async () => {
+    const pair = generateKeyPair();
+    const jwt = await createDeviceJwt(pair.privateKey, "node-1");
+
+    const pubKey = createPublicKey(pair.publicKey);
+    const { payload } = await jwtVerify(jwt, pubKey, { algorithms: ["EdDSA"] });
+
+    const now = Math.floor(Date.now() / 1000);
+    const expectedExp = now + 300; // 5 minutes
+    // Allow 5 second tolerance
+    expect(Math.abs((payload.exp ?? 0) - expectedExp)).toBeLessThan(5);
+  });
+
+  it("uses EdDSA algorithm", async () => {
+    const pair = generateKeyPair();
+    const jwt = await createDeviceJwt(pair.privateKey, "node-1");
+
+    // Parse header
+    const headerB64 = jwt.split(".")[0] as string;
+    const header = JSON.parse(Buffer.from(headerB64, "base64url").toString());
+    expect(header.alg).toBe("EdDSA");
+  });
+});
+
+describe("exportPublicKeyBase64url", () => {
+  it("exports a 32-byte raw Ed25519 public key as base64url", () => {
+    const pair = generateKeyPair();
+    const b64url = exportPublicKeyBase64url(pair.publicKey);
+
+    // Ed25519 public key is 32 bytes = 43 base64url characters (no padding)
+    const raw = Buffer.from(b64url, "base64url");
+    expect(raw.length).toBe(32);
+  });
+
+  it("round-trips through import", () => {
+    const pair = generateKeyPair();
+    const b64url = exportPublicKeyBase64url(pair.publicKey);
+
+    // Use gateway's importBase64urlPublicKey equivalent
+    const raw = Buffer.from(b64url, "base64url");
+    const ed25519OidPrefix = Buffer.from("302a300506032b6570032100", "hex");
+    const der = Buffer.concat([ed25519OidPrefix, raw]);
+    const imported = createPublicKey({ key: der, format: "der", type: "spki" });
+
+    const originalDer = createPublicKey(pair.publicKey).export({
+      type: "spki",
+      format: "der",
+    });
+    const importedDer = imported.export({ type: "spki", format: "der" });
+    expect(Buffer.compare(originalDer as Buffer, importedDer as Buffer)).toBe(0);
+  });
+});

--- a/packages/node/src/__tests__/helpers.ts
+++ b/packages/node/src/__tests__/helpers.ts
@@ -1,4 +1,5 @@
 import type { GatewayFrame } from "@templar/gateway/protocol";
+import { generateKeyPair } from "../device-auth.js";
 import type { TemplarNode } from "../node.js";
 import type { NodeConfig } from "../types.js";
 import type { WebSocketClientLike } from "../ws-client.js";
@@ -129,4 +130,20 @@ export async function startAndConnect(
   }
 
   await startPromise;
+}
+
+// ---------------------------------------------------------------------------
+// Crypto helpers for Ed25519 device auth tests
+// ---------------------------------------------------------------------------
+
+export function generateTestKeyPair() {
+  return generateKeyPair();
+}
+
+export function makeDeviceKeyConfig() {
+  const pair = generateKeyPair();
+  return {
+    deviceKey: pair,
+    ...pair,
+  };
 }

--- a/packages/node/src/device-auth.ts
+++ b/packages/node/src/device-auth.ts
@@ -1,0 +1,97 @@
+import { createPrivateKey, createPublicKey, generateKeyPairSync } from "node:crypto";
+import { readFileSync, writeFileSync } from "node:fs";
+import { SignJWT } from "jose";
+import type { KeyProvider } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Key Generation
+// ---------------------------------------------------------------------------
+
+export interface KeyPair {
+  readonly privateKey: string;
+  readonly publicKey: string;
+}
+
+/**
+ * Generate a new Ed25519 key pair and return PEM-encoded strings.
+ */
+export function generateKeyPair(): KeyPair {
+  const { privateKey, publicKey } = generateKeyPairSync("ed25519");
+  return {
+    privateKey: privateKey.export({ type: "pkcs8", format: "pem" }) as string,
+    publicKey: publicKey.export({ type: "spki", format: "pem" }) as string,
+  };
+}
+
+/**
+ * Load an existing Ed25519 key pair from disk, or generate and persist one.
+ * Sets file permissions to 0o600 (owner read/write only).
+ */
+export function loadOrCreateKeyPair(keyPath: string): KeyPair {
+  try {
+    const pem = readFileSync(keyPath, "utf-8");
+    const privateKey = createPrivateKey(pem);
+    const publicKey = createPublicKey(privateKey);
+    return {
+      privateKey: privateKey.export({ type: "pkcs8", format: "pem" }) as string,
+      publicKey: publicKey.export({ type: "spki", format: "pem" }) as string,
+    };
+  } catch {
+    const pair = generateKeyPair();
+    writeFileSync(keyPath, pair.privateKey, { mode: 0o600 });
+    return pair;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Key Provider Resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve a KeyProvider into a concrete key pair.
+ */
+export async function resolveKeyPair(
+  provider: KeyProvider,
+): Promise<{ readonly privateKey: string; readonly publicKey: string }> {
+  if (typeof provider === "function") {
+    return provider();
+  }
+  return provider;
+}
+
+// ---------------------------------------------------------------------------
+// JWT Signing
+// ---------------------------------------------------------------------------
+
+/**
+ * Create an Ed25519-signed JWT for device authentication.
+ *
+ * Claims:
+ * - sub: nodeId
+ * - iat: current time
+ * - exp: current time + 5 minutes
+ */
+export async function createDeviceJwt(privateKeyPem: string, nodeId: string): Promise<string> {
+  const privateKey = createPrivateKey(privateKeyPem);
+  return new SignJWT({ sub: nodeId })
+    .setProtectedHeader({ alg: "EdDSA" })
+    .setIssuedAt()
+    .setExpirationTime("5m")
+    .sign(privateKey);
+}
+
+// ---------------------------------------------------------------------------
+// Public Key Export
+// ---------------------------------------------------------------------------
+
+/**
+ * Export a PEM-encoded Ed25519 public key as a base64url-encoded raw key (32 bytes).
+ * This is the compact form used in the register frame's `publicKey` field.
+ */
+export function exportPublicKeyBase64url(publicKeyPem: string): string {
+  const keyObject = createPublicKey(publicKeyPem);
+  // Export as DER/SPKI, then strip the 12-byte OID prefix to get raw 32 bytes
+  const der = keyObject.export({ type: "spki", format: "der" });
+  const raw = (der as Buffer).subarray(12); // Ed25519 SPKI DER has 12-byte prefix
+  return raw.toString("base64url");
+}

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -1,3 +1,11 @@
+export {
+  createDeviceJwt,
+  exportPublicKeyBase64url,
+  generateKeyPair,
+  type KeyPair,
+  loadOrCreateKeyPair,
+  resolveKeyPair,
+} from "./device-auth.js";
 export { HeartbeatResponder } from "./heartbeat-responder.js";
 export { TemplarNode, type TemplarNodeDeps } from "./node.js";
 export { ReconnectStrategy } from "./reconnect.js";
@@ -10,6 +18,7 @@ export {
   DEFAULT_REGISTRATION_TIMEOUT,
   type DisconnectedHandler,
   type ErrorHandler,
+  type KeyProvider,
   type MessageHandler,
   NODE_STATES,
   type NodeConfig,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -285,6 +285,9 @@ importers:
       '@templar/errors':
         specifier: workspace:*
         version: link:../errors
+      jose:
+        specifier: ^6.1.3
+        version: 6.1.3
       zod:
         specifier: ^3.22.4
         version: 3.25.76
@@ -465,6 +468,9 @@ importers:
       '@templar/gateway':
         specifier: workspace:*
         version: link:../gateway
+      jose:
+        specifier: ^6.1.3
+        version: 6.1.3
       zod:
         specifier: ^3.22.4
         version: 3.25.76


### PR DESCRIPTION
## Summary

- **Per-node Ed25519 key pair identity** with JWT (EdDSA) tokens via `jose`, replacing the shared static API key for cryptographic device authentication
- **Dual-mode auth migration** (`legacy | ed25519 | dual`) allowing gradual rollout — legacy bearer tokens and Ed25519 JWTs can coexist in `dual` mode
- **TOFU (Trust-On-First-Use) key registration** for development environments, with pre-registered known keys for production
- **DeviceKeyStore** with LRU eviction (configurable max entries) for managing per-node public keys on the gateway
- **Timing-safe token comparison** (`crypto.timingSafeEqual`) for legacy auth path to prevent timing attacks
- **48 new tests** across 4 test files: unit tests for key store, JWT signing/verification, and full auth integration flow

### Files changed (25 files, +1656/-27)

| Area | Changes |
|------|---------|
| Protocol | `frames.ts` — optional `signature`/`publicKey` on `NodeRegisterFrame`; `types.ts` — `AuthMode`, `DeviceAuthConfig` |
| Gateway | New `device-auth.ts` (JWT verify, timing-safe compare), `device-key-store.ts` (LRU store), updated `gateway.ts` (auth routing) |
| Node | New `device-auth.ts` (key generation, JWT signing, file persistence), updated `node.ts` (Ed25519 connect flow) |
| Errors | 4 new error codes: `NODE_DEVICE_KEY_INVALID`, `NODE_DEVICE_KEY_MISMATCH`, `NODE_DEVICE_KEY_EXPIRED`, `GATEWAY_TOFU_REJECTED` |
| Tests | `device-key-store.test.ts`, `device-auth.test.ts` (gateway + node), `auth-integration.test.ts` |

## Test plan

- [x] `pnpm build` — all 27 tasks pass
- [x] `pnpm test --filter @templar/errors` — 113 tests pass (including new error codes)
- [x] `pnpm test --filter @templar/gateway` — 495 tests pass (including 35 new auth tests)
- [x] `pnpm test --filter @templar/node` — 121 tests pass (including 13 new device-auth tests)
- [ ] E2E: gateway with `authMode: "dual"` + TOFU enabled, Ed25519 node connects successfully
- [ ] E2E: legacy node connects in dual mode with deprecation warning
- [ ] Verify no private keys or credentials in logs

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)