### PR TITLE
feat(self-test): add @templar/self-test pluggable verification package

### DIFF
--- a/packages/errors/src/__tests__/self-test.test.ts
+++ b/packages/errors/src/__tests__/self-test.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from "vitest";
+import { TemplarError } from "../base.js";
+import { ERROR_CATALOG } from "../catalog.js";
+import {
+  SelfTestConfigurationInvalidError,
+  SelfTestError,
+  SelfTestHealthCheckFailedError,
+  SelfTestTimeoutError,
+  SelfTestVerificationFailedError,
+} from "../self-test.js";
+
+describe("SelfTestError hierarchy", () => {
+  describe("SelfTestHealthCheckFailedError", () => {
+    it("should extend SelfTestError and TemplarError", () => {
+      const error = new SelfTestHealthCheckFailedError(
+        "health-check",
+        "http://localhost:3000/health",
+      );
+      expect(error).toBeInstanceOf(SelfTestError);
+      expect(error).toBeInstanceOf(TemplarError);
+      expect(error).toBeInstanceOf(Error);
+    });
+
+    it("should map to catalog entry", () => {
+      const error = new SelfTestHealthCheckFailedError(
+        "health-check",
+        "http://localhost:3000/health",
+      );
+      const entry = ERROR_CATALOG.SELF_TEST_HEALTH_CHECK_FAILED;
+      expect(error.code).toBe("SELF_TEST_HEALTH_CHECK_FAILED");
+      expect(error.httpStatus).toBe(entry.httpStatus);
+      expect(error.grpcCode).toBe(entry.grpcCode);
+      expect(error.domain).toBe(entry.domain);
+      expect(error.isExpected).toBe(entry.isExpected);
+    });
+
+    it("should have correct _tag discriminant", () => {
+      const error = new SelfTestHealthCheckFailedError(
+        "health-check",
+        "http://localhost:3000/health",
+      );
+      expect(error._tag).toBe("SelfTestError");
+    });
+
+    it("should store constructor args", () => {
+      const error = new SelfTestHealthCheckFailedError(
+        "api-check",
+        "http://localhost:8080/api",
+        503,
+      );
+      expect(error.verifierName).toBe("api-check");
+      expect(error.url).toBe("http://localhost:8080/api");
+      expect(error.lastStatus).toBe(503);
+    });
+
+    it("should handle undefined lastStatus", () => {
+      const error = new SelfTestHealthCheckFailedError("check", "http://localhost:3000");
+      expect(error.lastStatus).toBeUndefined();
+      expect(error.message).toBe("Health check failed: check at http://localhost:3000");
+    });
+
+    it("should include lastStatus in message when provided", () => {
+      const error = new SelfTestHealthCheckFailedError("check", "http://localhost:3000", 503);
+      expect(error.message).toBe(
+        "Health check failed: check at http://localhost:3000 (last status: 503)",
+      );
+    });
+
+    it("should serialize to JSON", () => {
+      const error = new SelfTestHealthCheckFailedError("check", "http://localhost:3000");
+      const json = error.toJSON();
+      expect(json.code).toBe("SELF_TEST_HEALTH_CHECK_FAILED");
+      expect(json._tag).toBe("SelfTestError");
+      expect(json.domain).toBe("selftest");
+    });
+  });
+
+  describe("SelfTestVerificationFailedError", () => {
+    const failedAssertions = [
+      { name: "status-check", passed: false, message: "Expected 200, got 500" },
+      { name: "body-check", passed: false, expected: "ok", actual: "error" },
+    ];
+    const report = {
+      results: { summary: { tests: 5, passed: 3, failed: 2 } },
+    };
+
+    it("should extend SelfTestError and TemplarError", () => {
+      const error = new SelfTestVerificationFailedError("api-test", failedAssertions, report);
+      expect(error).toBeInstanceOf(SelfTestError);
+      expect(error).toBeInstanceOf(TemplarError);
+    });
+
+    it("should map to catalog entry", () => {
+      const error = new SelfTestVerificationFailedError("api-test", failedAssertions, report);
+      const entry = ERROR_CATALOG.SELF_TEST_VERIFICATION_FAILED;
+      expect(error.code).toBe("SELF_TEST_VERIFICATION_FAILED");
+      expect(error.httpStatus).toBe(entry.httpStatus);
+      expect(error.grpcCode).toBe(entry.grpcCode);
+      expect(error.domain).toBe(entry.domain);
+      expect(error.isExpected).toBe(entry.isExpected);
+    });
+
+    it("should store constructor args", () => {
+      const error = new SelfTestVerificationFailedError("api-test", failedAssertions, report);
+      expect(error.verifierName).toBe("api-test");
+      expect(error.failedAssertions).toBe(failedAssertions);
+      expect(error.report).toBe(report);
+    });
+
+    it("should pluralize assertion count in message", () => {
+      const error = new SelfTestVerificationFailedError("test", failedAssertions, report);
+      expect(error.message).toContain("2 assertions failed");
+    });
+
+    it("should singularize for one assertion", () => {
+      const single = [failedAssertions[0]!];
+      const error = new SelfTestVerificationFailedError("test", single, report);
+      expect(error.message).toContain("1 assertion failed");
+    });
+  });
+
+  describe("SelfTestTimeoutError", () => {
+    it("should extend SelfTestError and TemplarError", () => {
+      const error = new SelfTestTimeoutError("browser-test", 30_000, 31_000);
+      expect(error).toBeInstanceOf(SelfTestError);
+      expect(error).toBeInstanceOf(TemplarError);
+    });
+
+    it("should map to catalog entry", () => {
+      const error = new SelfTestTimeoutError("browser-test", 30_000, 31_000);
+      const entry = ERROR_CATALOG.SELF_TEST_TIMEOUT;
+      expect(error.code).toBe("SELF_TEST_TIMEOUT");
+      expect(error.httpStatus).toBe(entry.httpStatus);
+      expect(error.grpcCode).toBe(entry.grpcCode);
+      expect(error.domain).toBe(entry.domain);
+      expect(error.isExpected).toBe(entry.isExpected);
+    });
+
+    it("should store constructor args", () => {
+      const error = new SelfTestTimeoutError("browser-test", 30_000, 31_000);
+      expect(error.verifierName).toBe("browser-test");
+      expect(error.timeoutMs).toBe(30_000);
+      expect(error.elapsedMs).toBe(31_000);
+    });
+
+    it("should include timing in message", () => {
+      const error = new SelfTestTimeoutError("test", 5000, 6000);
+      expect(error.message).toBe("Self-test timeout: test exceeded 5000ms (elapsed: 6000ms)");
+    });
+  });
+
+  describe("SelfTestConfigurationInvalidError", () => {
+    it("should extend SelfTestError and TemplarError", () => {
+      const error = new SelfTestConfigurationInvalidError(["workspace missing"]);
+      expect(error).toBeInstanceOf(SelfTestError);
+      expect(error).toBeInstanceOf(TemplarError);
+    });
+
+    it("should map to catalog entry", () => {
+      const error = new SelfTestConfigurationInvalidError(["workspace missing"]);
+      const entry = ERROR_CATALOG.SELF_TEST_CONFIGURATION_INVALID;
+      expect(error.code).toBe("SELF_TEST_CONFIGURATION_INVALID");
+      expect(error.httpStatus).toBe(entry.httpStatus);
+      expect(error.grpcCode).toBe(entry.grpcCode);
+      expect(error.domain).toBe(entry.domain);
+      expect(error.isExpected).toBe(entry.isExpected);
+    });
+
+    it("should store validation errors", () => {
+      const errors = ["workspace missing", "invalid url"];
+      const error = new SelfTestConfigurationInvalidError(errors);
+      expect(error.validationErrors).toBe(errors);
+    });
+
+    it("should join errors in message", () => {
+      const error = new SelfTestConfigurationInvalidError(["a", "b"]);
+      expect(error.message).toBe("Invalid self-test configuration: a; b");
+    });
+  });
+});

--- a/packages/errors/src/__tests__/unit/catalog.test.ts
+++ b/packages/errors/src/__tests__/unit/catalog.test.ts
@@ -80,6 +80,10 @@ describe("ERROR_CATALOG", () => {
     const exceptions = new Set([
       "RATE_LIMIT_EXCEEDED", // quota domain, but RATE prefix
       "PAYLOAD_TOO_LARGE", // quota domain, but PAYLOAD prefix
+      "SELF_TEST_HEALTH_CHECK_FAILED", // selftest domain, SELF prefix (compound)
+      "SELF_TEST_VERIFICATION_FAILED", // selftest domain, SELF prefix (compound)
+      "SELF_TEST_TIMEOUT", // selftest domain, SELF prefix (compound)
+      "SELF_TEST_CONFIGURATION_INVALID", // selftest domain, SELF prefix (compound)
     ]);
 
     for (const [code, entry] of Object.entries(ERROR_CATALOG)) {

--- a/packages/errors/src/catalog.ts
+++ b/packages/errors/src/catalog.ts
@@ -1504,6 +1504,46 @@ export const ERROR_CATALOG = {
     title: "Execution timeout",
     description: "Agent execution exceeded the configured wall-clock time limit",
   },
+
+  // ============================================================================
+  // SELF-TEST ERRORS — Pluggable self-verification (#44)
+  // ============================================================================
+  SELF_TEST_HEALTH_CHECK_FAILED: {
+    domain: "selftest",
+    httpStatus: 503,
+    grpcCode: "UNAVAILABLE" as const,
+    baseType: "ExternalError" as const,
+    isExpected: false,
+    title: "Health check failed",
+    description: "One or more health checks failed during preflight verification",
+  },
+  SELF_TEST_VERIFICATION_FAILED: {
+    domain: "selftest",
+    httpStatus: 422,
+    grpcCode: "FAILED_PRECONDITION" as const,
+    baseType: "ValidationError" as const,
+    isExpected: true,
+    title: "Verification failed",
+    description: "One or more verification assertions failed",
+  },
+  SELF_TEST_TIMEOUT: {
+    domain: "selftest",
+    httpStatus: 504,
+    grpcCode: "DEADLINE_EXCEEDED" as const,
+    baseType: "TimeoutError" as const,
+    isExpected: false,
+    title: "Self-test timeout",
+    description: "A self-test verifier exceeded the configured timeout",
+  },
+  SELF_TEST_CONFIGURATION_INVALID: {
+    domain: "selftest",
+    httpStatus: 400,
+    grpcCode: "INVALID_ARGUMENT" as const,
+    baseType: "ValidationError" as const,
+    isExpected: true,
+    title: "Invalid self-test configuration",
+    description: "The self-test configuration is invalid",
+  },
 } as const;
 
 // ============================================================================

--- a/packages/errors/src/index.ts
+++ b/packages/errors/src/index.ts
@@ -102,6 +102,18 @@ export {
 } from "./execution-guard.js";
 
 // ============================================================================
+// SELF-TEST ERRORS — Pluggable self-verification (#44)
+// ============================================================================
+
+export {
+  SelfTestConfigurationInvalidError,
+  SelfTestError,
+  SelfTestHealthCheckFailedError,
+  SelfTestTimeoutError,
+  SelfTestVerificationFailedError,
+} from "./self-test.js";
+
+// ============================================================================
 // LEGACY ERROR CLASSES (backward compatibility — all @deprecated)
 // ============================================================================
 

--- a/packages/errors/src/self-test.ts
+++ b/packages/errors/src/self-test.ts
@@ -1,0 +1,167 @@
+import { TemplarError } from "./base.js";
+import {
+  ERROR_CATALOG,
+  type ErrorDomain,
+  type GrpcStatusCode,
+  type HttpStatusCode,
+} from "./catalog.js";
+
+// ---------------------------------------------------------------------------
+// Base class for all self-test errors
+// ---------------------------------------------------------------------------
+
+/**
+ * Abstract base class for self-test verification errors.
+ *
+ * Enables generic catch: `if (e instanceof SelfTestError)`
+ * while specific subclasses allow precise handling.
+ */
+export abstract class SelfTestError extends TemplarError {}
+
+// ---------------------------------------------------------------------------
+// Health check failed
+// ---------------------------------------------------------------------------
+
+/**
+ * Thrown when one or more health checks fail during preflight.
+ */
+export class SelfTestHealthCheckFailedError extends SelfTestError {
+  readonly _tag = "SelfTestError" as const;
+  readonly code = "SELF_TEST_HEALTH_CHECK_FAILED" as const;
+  readonly httpStatus: HttpStatusCode;
+  readonly grpcCode: GrpcStatusCode;
+  readonly domain: ErrorDomain;
+  readonly isExpected: boolean;
+  readonly verifierName: string;
+  readonly url: string;
+  readonly lastStatus?: number | undefined;
+
+  constructor(verifierName: string, url: string, lastStatus?: number) {
+    const statusInfo = lastStatus !== undefined ? ` (last status: ${lastStatus})` : "";
+    super(`Health check failed: ${verifierName} at ${url}${statusInfo}`);
+    const entry = ERROR_CATALOG.SELF_TEST_HEALTH_CHECK_FAILED;
+    this.httpStatus = entry.httpStatus as HttpStatusCode;
+    this.grpcCode = entry.grpcCode as GrpcStatusCode;
+    this.domain = entry.domain as ErrorDomain;
+    this.isExpected = entry.isExpected;
+    this.verifierName = verifierName;
+    this.url = url;
+    this.lastStatus = lastStatus;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Verification failed
+// ---------------------------------------------------------------------------
+
+/** Shape of a failed assertion (structurally compatible with @templar/self-test AssertionResult) */
+interface FailedAssertionDetail {
+  readonly name: string;
+  readonly passed: boolean;
+  readonly message?: string;
+  readonly expected?: unknown;
+  readonly actual?: unknown;
+}
+
+/** Shape of a self-test report reference (structurally compatible) */
+interface SelfTestReportRef {
+  readonly results: {
+    readonly summary: {
+      readonly tests: number;
+      readonly passed: number;
+      readonly failed: number;
+    };
+  };
+}
+
+/**
+ * Thrown when one or more verification assertions fail.
+ */
+export class SelfTestVerificationFailedError extends SelfTestError {
+  readonly _tag = "SelfTestError" as const;
+  readonly code = "SELF_TEST_VERIFICATION_FAILED" as const;
+  readonly httpStatus: HttpStatusCode;
+  readonly grpcCode: GrpcStatusCode;
+  readonly domain: ErrorDomain;
+  readonly isExpected: boolean;
+  readonly verifierName: string;
+  readonly failedAssertions: readonly FailedAssertionDetail[];
+  readonly report: SelfTestReportRef;
+
+  constructor(
+    verifierName: string,
+    failedAssertions: readonly FailedAssertionDetail[],
+    report: SelfTestReportRef,
+  ) {
+    const count = failedAssertions.length;
+    super(
+      `Verification failed: ${verifierName} — ${count} assertion${count === 1 ? "" : "s"} failed`,
+    );
+    const entry = ERROR_CATALOG.SELF_TEST_VERIFICATION_FAILED;
+    this.httpStatus = entry.httpStatus as HttpStatusCode;
+    this.grpcCode = entry.grpcCode as GrpcStatusCode;
+    this.domain = entry.domain as ErrorDomain;
+    this.isExpected = entry.isExpected;
+    this.verifierName = verifierName;
+    this.failedAssertions = failedAssertions;
+    this.report = report;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Timeout
+// ---------------------------------------------------------------------------
+
+/**
+ * Thrown when a self-test verifier exceeds its timeout.
+ */
+export class SelfTestTimeoutError extends SelfTestError {
+  readonly _tag = "SelfTestError" as const;
+  readonly code = "SELF_TEST_TIMEOUT" as const;
+  readonly httpStatus: HttpStatusCode;
+  readonly grpcCode: GrpcStatusCode;
+  readonly domain: ErrorDomain;
+  readonly isExpected: boolean;
+  readonly verifierName: string;
+  readonly timeoutMs: number;
+  readonly elapsedMs: number;
+
+  constructor(verifierName: string, timeoutMs: number, elapsedMs: number) {
+    super(`Self-test timeout: ${verifierName} exceeded ${timeoutMs}ms (elapsed: ${elapsedMs}ms)`);
+    const entry = ERROR_CATALOG.SELF_TEST_TIMEOUT;
+    this.httpStatus = entry.httpStatus as HttpStatusCode;
+    this.grpcCode = entry.grpcCode as GrpcStatusCode;
+    this.domain = entry.domain as ErrorDomain;
+    this.isExpected = entry.isExpected;
+    this.verifierName = verifierName;
+    this.timeoutMs = timeoutMs;
+    this.elapsedMs = elapsedMs;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Configuration invalid
+// ---------------------------------------------------------------------------
+
+/**
+ * Thrown when the self-test configuration is invalid.
+ */
+export class SelfTestConfigurationInvalidError extends SelfTestError {
+  readonly _tag = "SelfTestError" as const;
+  readonly code = "SELF_TEST_CONFIGURATION_INVALID" as const;
+  readonly httpStatus: HttpStatusCode;
+  readonly grpcCode: GrpcStatusCode;
+  readonly domain: ErrorDomain;
+  readonly isExpected: boolean;
+  readonly validationErrors: readonly string[];
+
+  constructor(validationErrors: readonly string[]) {
+    super(`Invalid self-test configuration: ${validationErrors.join("; ")}`);
+    const entry = ERROR_CATALOG.SELF_TEST_CONFIGURATION_INVALID;
+    this.httpStatus = entry.httpStatus as HttpStatusCode;
+    this.grpcCode = entry.grpcCode as GrpcStatusCode;
+    this.domain = entry.domain as ErrorDomain;
+    this.isExpected = entry.isExpected;
+    this.validationErrors = validationErrors;
+  }
+}

--- a/packages/self-test/package.json
+++ b/packages/self-test/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@templar/self-test",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check .",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
+  },
+  "dependencies": {
+    "@templar/core": "workspace:*",
+    "@templar/errors": "workspace:*",
+    "zod": "^3.24.0"
+  },
+  "peerDependencies": {
+    "playwright": "^1.50.0"
+  },
+  "peerDependenciesMeta": {
+    "playwright": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@templar/long-running": "workspace:*",
+    "@templar/test-utils": "workspace:*",
+    "@types/node": "^25.0.0",
+    "playwright": "^1.50.0",
+    "vitest": "^4.0.0"
+  }
+}

--- a/packages/self-test/src/__tests__/helpers.ts
+++ b/packages/self-test/src/__tests__/helpers.ts
@@ -1,0 +1,155 @@
+import type {
+  ApiTestConfig,
+  AssertionResult,
+  BrowserStep,
+  HealthCheck,
+  Phase,
+  PhaseResult,
+  ScreenshotCapture,
+  SelfTestConfig,
+  SmokeStep,
+  Verifier,
+  VerifierContext,
+  VerifierResult,
+} from "../types.js";
+
+// ============================================================================
+// Context factories
+// ============================================================================
+
+export function makeVerifierContext(overrides?: Partial<VerifierContext>): VerifierContext {
+  return {
+    workspace: "/tmp/test-workspace",
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// Config factories
+// ============================================================================
+
+export function makeHealthCheck(overrides?: Partial<HealthCheck>): HealthCheck {
+  return {
+    name: "test-health",
+    url: "http://localhost:3000/health",
+    ...overrides,
+  };
+}
+
+export function makeSmokeStep(overrides?: Partial<SmokeStep>): SmokeStep {
+  return {
+    action: "navigate",
+    url: "http://localhost:3000",
+    ...overrides,
+  };
+}
+
+export function makeBrowserStep(overrides?: Partial<BrowserStep>): BrowserStep {
+  return {
+    action: "navigate",
+    url: "http://localhost:3000",
+    ...overrides,
+  };
+}
+
+export function makeApiTestConfig(overrides?: Partial<ApiTestConfig>): ApiTestConfig {
+  return {
+    baseUrl: "http://localhost:3000",
+    steps: [
+      {
+        method: "GET",
+        path: "/api/health",
+        expectedStatus: 200,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+export function makeSelfTestConfig(overrides?: Partial<SelfTestConfig>): SelfTestConfig {
+  return {
+    workspace: "/tmp/test-workspace",
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// Result factories
+// ============================================================================
+
+export function makeAssertionResult(overrides?: Partial<AssertionResult>): AssertionResult {
+  return {
+    name: "test-assertion",
+    passed: true,
+    ...overrides,
+  };
+}
+
+export function makeScreenshotCapture(overrides?: Partial<ScreenshotCapture>): ScreenshotCapture {
+  return {
+    name: "test-screenshot",
+    base64: "iVBORw0KGgo=",
+    timestamp: new Date().toISOString(),
+    viewport: { width: 1280, height: 720 },
+    ...overrides,
+  };
+}
+
+export function makeVerifierResult(overrides?: Partial<VerifierResult>): VerifierResult {
+  return {
+    verifierName: "test-verifier",
+    phase: "preflight",
+    status: "passed",
+    durationMs: 100,
+    assertions: [makeAssertionResult()],
+    screenshots: [],
+    ...overrides,
+  };
+}
+
+export function makePhaseResult(overrides?: Partial<PhaseResult>): PhaseResult {
+  return {
+    status: "passed",
+    durationMs: 100,
+    verifierResults: [makeVerifierResult()],
+    ...overrides,
+  };
+}
+
+/**
+ * Create a minimal mock Verifier for testing.
+ */
+export function makeMockVerifier(config: {
+  name?: string;
+  phase?: Phase;
+  result?: Partial<VerifierResult>;
+  setupFn?: () => Promise<void>;
+  teardownFn?: () => Promise<void>;
+  runFn?: () => Promise<VerifierResult>;
+}): Verifier {
+  const phase: Phase = config.phase ?? "preflight";
+  const name: string = config.name ?? `mock-${phase}-verifier`;
+  const result = makeVerifierResult({
+    verifierName: name,
+    phase,
+    ...config.result,
+  });
+
+  const verifier: Verifier = {
+    name,
+    phase,
+    run: config.runFn ?? (async () => result),
+  };
+
+  if (config.setupFn && config.teardownFn) {
+    return { ...verifier, setup: config.setupFn, teardown: config.teardownFn };
+  }
+  if (config.setupFn) {
+    return { ...verifier, setup: config.setupFn };
+  }
+  if (config.teardownFn) {
+    return { ...verifier, teardown: config.teardownFn };
+  }
+
+  return verifier;
+}

--- a/packages/self-test/src/__tests__/integration/long-running-bridge.test.ts
+++ b/packages/self-test/src/__tests__/integration/long-running-bridge.test.ts
@@ -1,0 +1,118 @@
+import * as http from "node:http";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { SelfTestMiddleware } from "../../middleware.js";
+
+let server: http.Server;
+let port: number;
+
+beforeAll(async () => {
+  await new Promise<void>((resolve) => {
+    server = http.createServer((req, res) => {
+      if (req.url === "/health") {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ status: "ok" }));
+        return;
+      }
+      if (req.url === "/api/features") {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ features: ["auth", "dashboard"] }));
+        return;
+      }
+      res.writeHead(404);
+      res.end("Not found");
+    });
+
+    server.listen(0, () => {
+      const addr = server.address();
+      port = typeof addr === "object" && addr !== null ? addr.port : 0;
+      resolve();
+    });
+  });
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => {
+    server.close(() => resolve());
+  });
+});
+
+describe("Self-test + Long-running bridge", () => {
+  it("should produce a report suitable as testEvidence for LongRunningMiddleware", async () => {
+    const baseUrl = `http://localhost:${port}`;
+
+    // 1. Set up self-test middleware
+    const selfTestMiddleware = new SelfTestMiddleware({
+      workspace: "/tmp/bridge-test",
+      health: {
+        checks: [{ name: "api", url: `${baseUrl}/health` }],
+      },
+      api: { baseUrl },
+    });
+
+    // 2. Start self-test session
+    await selfTestMiddleware.onSessionStart({ sessionId: "bridge-test" });
+
+    // 3. Run API test to verify a feature
+    const tools = selfTestMiddleware.getTools();
+    const apiResult = await tools.runApiTest({
+      baseUrl,
+      steps: [{ method: "GET", path: "/api/features", expectedStatus: 200 }],
+    });
+
+    expect(apiResult.status).toBe("passed");
+
+    // 4. Run full suite to get a complete report
+    const report = await tools.runFullSuite();
+
+    // 5. The report can be serialized as testEvidence for LongRunningMiddleware
+    const testEvidence = JSON.stringify(report);
+    const parsed = JSON.parse(testEvidence) as Record<string, unknown>;
+
+    expect(parsed).toHaveProperty("results");
+    expect(parsed).toHaveProperty("phases");
+
+    // Verify the evidence contains meaningful data
+    const results = parsed.results as Record<string, unknown>;
+    const summary = results.summary as Record<string, unknown>;
+    expect(typeof summary.tests).toBe("number");
+    expect(typeof summary.passed).toBe("number");
+
+    // This is what an agent would pass to:
+    // longRunningTools.updateFeatureStatus({
+    //   featureId: "some-feature",
+    //   testEvidence: JSON.stringify(report),
+    // })
+
+    // 6. Cleanup
+    await selfTestMiddleware.onSessionEnd({ sessionId: "bridge-test" });
+  });
+
+  it("should produce structured CTRF evidence even on partial failure", async () => {
+    const baseUrl = `http://localhost:${port}`;
+
+    const selfTestMiddleware = new SelfTestMiddleware({
+      workspace: "/tmp/bridge-test-2",
+      health: {
+        checks: [{ name: "api", url: `${baseUrl}/health` }],
+      },
+    });
+
+    await selfTestMiddleware.onSessionStart({ sessionId: "bridge-test-2" });
+
+    // Test a non-existent endpoint
+    const tools = selfTestMiddleware.getTools();
+    const apiResult = await tools.runApiTest({
+      baseUrl,
+      steps: [{ method: "GET", path: "/api/nonexistent", expectedStatus: 200 }],
+    });
+
+    expect(apiResult.status).toBe("failed");
+    expect(apiResult.assertions[0]?.passed).toBe(false);
+
+    // The failed result is still serializable as evidence
+    const evidence = JSON.stringify(apiResult);
+    expect(evidence).toContain("failed");
+
+    await selfTestMiddleware.onSessionEnd({ sessionId: "bridge-test-2" });
+  });
+});

--- a/packages/self-test/src/__tests__/integration/pipeline-lifecycle.test.ts
+++ b/packages/self-test/src/__tests__/integration/pipeline-lifecycle.test.ts
@@ -1,0 +1,139 @@
+import * as http from "node:http";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { SelfTestMiddleware } from "../../middleware.js";
+
+let server: http.Server;
+let port: number;
+
+beforeAll(async () => {
+  await new Promise<void>((resolve) => {
+    server = http.createServer((req, res) => {
+      if (req.url === "/health") {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ status: "ok" }));
+        return;
+      }
+      if (req.url === "/api/data") {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ items: [1, 2, 3] }));
+        return;
+      }
+      res.writeHead(404);
+      res.end("Not found");
+    });
+
+    server.listen(0, () => {
+      const addr = server.address();
+      port = typeof addr === "object" && addr !== null ? addr.port : 0;
+      resolve();
+    });
+  });
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => {
+    server.close(() => resolve());
+  });
+});
+
+describe("Pipeline lifecycle integration", () => {
+  it("should run full middleware lifecycle with real HTTP server", async () => {
+    const baseUrl = `http://localhost:${port}`;
+
+    const middleware = new SelfTestMiddleware({
+      workspace: "/tmp/test-workspace",
+      health: {
+        checks: [{ name: "api-health", url: `${baseUrl}/health` }],
+        timeoutMs: 5_000,
+      },
+      smoke: {
+        steps: [{ action: "assertStatus", url: `${baseUrl}/health`, expectedStatus: 200 }],
+        timeoutMs: 5_000,
+      },
+      api: { baseUrl },
+    });
+
+    // 1. onSessionStart should pass
+    await middleware.onSessionStart({ sessionId: "integration-test-1" });
+
+    // 2. Tools should be available
+    const tools = middleware.getTools();
+    expect(tools).toBeDefined();
+
+    // 3. Run API test on demand
+    const apiResult = await tools.runApiTest({
+      baseUrl,
+      steps: [
+        { method: "GET", path: "/api/data", expectedStatus: 200 },
+        { method: "GET", path: "/health", expectedStatus: 200 },
+      ],
+    });
+    expect(apiResult.status).toBe("passed");
+    expect(apiResult.assertions).toHaveLength(2);
+
+    // 4. Run preflight on demand
+    const preflightResult = await tools.runPreflight();
+    expect(preflightResult.status).toBe("passed");
+
+    // 5. Run smoke on demand
+    const smokeResult = await tools.runSmoke([{ action: "navigate", url: `${baseUrl}/health` }]);
+    expect(smokeResult.status).toBe("passed");
+
+    // 6. Get last report from session start
+    const report = middleware.getLastReport();
+    expect(report).toBeDefined();
+    expect(report?.phases.preflight.status).toBe("passed");
+    expect(report?.phases.smoke.status).toBe("passed");
+    expect(report?.results.tool.name).toBe("@templar/self-test");
+
+    // 7. Full suite run
+    const fullReport = await tools.runFullSuite();
+    expect(fullReport.phases.preflight.status).toBe("passed");
+
+    // 8. onSessionEnd should clean up
+    await middleware.onSessionEnd({ sessionId: "integration-test-1" });
+    expect(() => middleware.getTools()).toThrow();
+  });
+
+  it("should handle failed health check with real server returning 503", async () => {
+    // Use a non-existent port
+    const middleware = new SelfTestMiddleware({
+      workspace: "/tmp/test",
+      health: {
+        checks: [{ name: "bad-check", url: "http://localhost:1/health" }],
+        timeoutMs: 500,
+      },
+    });
+
+    await expect(middleware.onSessionStart({ sessionId: "fail-test" })).rejects.toThrow();
+  });
+
+  it("should produce CTRF-compatible report structure", async () => {
+    const baseUrl = `http://localhost:${port}`;
+
+    const middleware = new SelfTestMiddleware({
+      workspace: "/tmp/test",
+      health: {
+        checks: [{ name: "health", url: `${baseUrl}/health` }],
+      },
+    });
+
+    await middleware.onSessionStart({ sessionId: "ctrf-test" });
+    const report = middleware.getLastReport()!;
+
+    // Validate CTRF structure
+    expect(report.results).toHaveProperty("tool");
+    expect(report.results).toHaveProperty("summary");
+    expect(report.results).toHaveProperty("tests");
+    expect(report.results.summary).toHaveProperty("tests");
+    expect(report.results.summary).toHaveProperty("passed");
+    expect(report.results.summary).toHaveProperty("failed");
+    expect(report.results.summary).toHaveProperty("start");
+    expect(report.results.summary).toHaveProperty("stop");
+    expect(report.phases).toHaveProperty("preflight");
+    expect(report.phases).toHaveProperty("smoke");
+    expect(report.phases).toHaveProperty("verification");
+
+    await middleware.onSessionEnd({ sessionId: "ctrf-test" });
+  });
+});

--- a/packages/self-test/src/__tests__/middleware.test.ts
+++ b/packages/self-test/src/__tests__/middleware.test.ts
@@ -1,0 +1,146 @@
+import { SelfTestHealthCheckFailedError, SelfTestVerificationFailedError } from "@templar/errors";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SelfTestMiddleware } from "../middleware.js";
+
+const sessionContext = { sessionId: "test-session-1" };
+
+describe("SelfTestMiddleware", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should have correct name", () => {
+    const middleware = new SelfTestMiddleware({ workspace: "/tmp" });
+    expect(middleware.name).toBe("templar:self-test");
+  });
+
+  it("should resolve config with defaults", () => {
+    const middleware = new SelfTestMiddleware({ workspace: "/tmp" });
+    const config = middleware.getConfig();
+    expect(config.maxTotalDurationMs).toBe(300_000);
+    expect(config.browser.timeoutMs).toBe(120_000);
+  });
+
+  describe("onSessionStart", () => {
+    it("should pass when no health or smoke config", async () => {
+      const middleware = new SelfTestMiddleware({ workspace: "/tmp" });
+      await expect(middleware.onSessionStart(sessionContext)).resolves.toBeUndefined();
+    });
+
+    it("should pass when health checks succeed", async () => {
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("ok", { status: 200 }));
+
+      const middleware = new SelfTestMiddleware({
+        workspace: "/tmp",
+        health: {
+          checks: [{ name: "api", url: "http://localhost:3000/health" }],
+          timeoutMs: 5_000,
+        },
+      });
+
+      await expect(middleware.onSessionStart(sessionContext)).resolves.toBeUndefined();
+    });
+
+    it("should throw SelfTestHealthCheckFailedError when health fails", async () => {
+      vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("ECONNREFUSED"));
+
+      const middleware = new SelfTestMiddleware({
+        workspace: "/tmp",
+        health: {
+          checks: [{ name: "api", url: "http://localhost:3000/health" }],
+          timeoutMs: 200,
+        },
+      });
+
+      await expect(middleware.onSessionStart(sessionContext)).rejects.toThrow(
+        SelfTestHealthCheckFailedError,
+      );
+    });
+
+    it("should throw SelfTestVerificationFailedError when smoke fails", async () => {
+      // Health passes, smoke fails
+      let _fetchCount = 0;
+      vi.spyOn(globalThis, "fetch").mockImplementation(async (url) => {
+        _fetchCount++;
+        const urlStr = typeof url === "string" ? url : url.toString();
+        if (urlStr.includes("/health")) {
+          return new Response("ok", { status: 200 });
+        }
+        return new Response("error", { status: 500 });
+      });
+
+      const middleware = new SelfTestMiddleware({
+        workspace: "/tmp",
+        health: {
+          checks: [{ name: "api", url: "http://localhost:3000/health" }],
+          timeoutMs: 5_000,
+        },
+        smoke: {
+          steps: [{ action: "navigate", url: "http://localhost:3000/app" }],
+          timeoutMs: 5_000,
+        },
+      });
+
+      await expect(middleware.onSessionStart(sessionContext)).rejects.toThrow(
+        SelfTestVerificationFailedError,
+      );
+    });
+
+    it("should make tools available after successful start", async () => {
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("ok", { status: 200 }));
+
+      const middleware = new SelfTestMiddleware({
+        workspace: "/tmp",
+        health: {
+          checks: [{ name: "api", url: "http://localhost:3000/health" }],
+          timeoutMs: 5_000,
+        },
+      });
+
+      await middleware.onSessionStart(sessionContext);
+      const tools = middleware.getTools();
+      expect(tools).toBeDefined();
+      expect(typeof tools.runPreflight).toBe("function");
+      expect(typeof tools.runFullSuite).toBe("function");
+    });
+
+    it("should store last report", async () => {
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("ok", { status: 200 }));
+
+      const middleware = new SelfTestMiddleware({
+        workspace: "/tmp",
+        health: {
+          checks: [{ name: "api", url: "http://localhost:3000/health" }],
+        },
+      });
+
+      await middleware.onSessionStart(sessionContext);
+      const report = middleware.getLastReport();
+      expect(report).toBeDefined();
+      expect(report?.phases.preflight.status).toBe("passed");
+    });
+  });
+
+  describe("getTools", () => {
+    it("should throw before onSessionStart", () => {
+      const middleware = new SelfTestMiddleware({ workspace: "/tmp" });
+      expect(() => middleware.getTools()).toThrow("Call onSessionStart() first");
+    });
+  });
+
+  describe("getLastReport", () => {
+    it("should return null before onSessionStart", () => {
+      const middleware = new SelfTestMiddleware({ workspace: "/tmp" });
+      expect(middleware.getLastReport()).toBeNull();
+    });
+  });
+
+  describe("onSessionEnd", () => {
+    it("should clean up tools", async () => {
+      const middleware = new SelfTestMiddleware({ workspace: "/tmp" });
+      await middleware.onSessionStart(sessionContext);
+      await middleware.onSessionEnd(sessionContext);
+      expect(() => middleware.getTools()).toThrow();
+    });
+  });
+});

--- a/packages/self-test/src/__tests__/process-manager.test.ts
+++ b/packages/self-test/src/__tests__/process-manager.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ProcessManager } from "../process-manager.js";
+
+describe("ProcessManager", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should reuse existing server when reuseExisting is true", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("ok", { status: 200 }));
+
+    const manager = new ProcessManager();
+    await manager.start({
+      command: "echo hello",
+      url: "http://localhost:3000",
+      reuseExisting: true,
+    });
+
+    // Should have checked once and returned
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    await manager.stop();
+  });
+
+  it("should not reuse when reuseExisting is false", async () => {
+    // First call (status check for reuseExisting) should not happen
+    // Second+ calls are health polls
+    let callCount = 0;
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+      callCount++;
+      if (callCount <= 2) {
+        throw new Error("ECONNREFUSED");
+      }
+      return new Response("ok", { status: 200 });
+    });
+
+    const manager = new ProcessManager();
+
+    // This will attempt to spawn and poll
+    // Use a very short timeout to avoid waiting
+    await expect(
+      manager.start({
+        command: "echo hello",
+        url: "http://localhost:3000",
+        reuseExisting: false,
+        timeoutMs: 5_000,
+      }),
+    ).resolves.toBeUndefined();
+
+    await manager.stop();
+  });
+
+  it("should fail if server does not become healthy within timeout", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (_url, opts) => {
+      // For the reuse check
+      const signal = (opts as RequestInit | undefined)?.signal;
+      if (signal?.aborted) throw new DOMException("aborted", "AbortError");
+      throw new Error("ECONNREFUSED");
+    });
+
+    const manager = new ProcessManager();
+
+    await expect(
+      manager.start({
+        command: "sleep 60",
+        url: "http://localhost:3000",
+        reuseExisting: false,
+        timeoutMs: 500,
+      }),
+    ).rejects.toThrow("failed to become healthy");
+
+    await manager.stop();
+  });
+
+  it("should stop all tracked processes", async () => {
+    const manager = new ProcessManager();
+    // No processes to stop — should not throw
+    await expect(manager.stop()).resolves.toBeUndefined();
+  });
+});

--- a/packages/self-test/src/__tests__/report-builder.test.ts
+++ b/packages/self-test/src/__tests__/report-builder.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import { ReportBuilder } from "../report-builder.js";
+import { makePhaseResult, makeScreenshotCapture, makeVerifierResult } from "./helpers.js";
+
+describe("ReportBuilder", () => {
+  it("should build a valid CTRF report from all phases", () => {
+    const preflight = makePhaseResult({
+      verifierResults: [
+        makeVerifierResult({ verifierName: "health", phase: "preflight", status: "passed" }),
+      ],
+    });
+    const smoke = makePhaseResult({
+      verifierResults: [
+        makeVerifierResult({ verifierName: "smoke", phase: "smoke", status: "passed" }),
+      ],
+    });
+    const verification = makePhaseResult({
+      verifierResults: [
+        makeVerifierResult({ verifierName: "api", phase: "verification", status: "passed" }),
+        makeVerifierResult({ verifierName: "browser", phase: "verification", status: "failed" }),
+      ],
+    });
+
+    const report = ReportBuilder.build(preflight, smoke, verification, 1000);
+
+    expect(report.results.tool.name).toBe("@templar/self-test");
+    expect(report.results.summary.tests).toBe(4);
+    expect(report.results.summary.passed).toBe(3);
+    expect(report.results.summary.failed).toBe(1);
+    expect(report.results.summary.skipped).toBe(0);
+    expect(report.results.summary.pending).toBe(0);
+    expect(report.results.summary.other).toBe(0);
+    expect(report.results.summary.start).toBe(1000);
+    expect(report.results.summary.stop).toBeGreaterThanOrEqual(1000);
+    expect(report.results.tests).toHaveLength(4);
+    expect(report.phases.preflight).toBe(preflight);
+    expect(report.phases.smoke).toBe(smoke);
+    expect(report.phases.verification).toBe(verification);
+  });
+
+  it("should count skipped tests", () => {
+    const preflight = makePhaseResult({
+      verifierResults: [makeVerifierResult({ status: "skipped" })],
+    });
+
+    const report = ReportBuilder.build(
+      preflight,
+      makePhaseResult({ status: "skipped", verifierResults: [] }),
+      makePhaseResult({ status: "skipped", verifierResults: [] }),
+      0,
+    );
+
+    expect(report.results.summary.skipped).toBe(1);
+  });
+
+  it("should count error tests as 'other'", () => {
+    const preflight = makePhaseResult({
+      verifierResults: [makeVerifierResult({ status: "error", error: new Error("boom") })],
+    });
+
+    const report = ReportBuilder.build(
+      preflight,
+      makePhaseResult({ status: "skipped", verifierResults: [] }),
+      makePhaseResult({ status: "skipped", verifierResults: [] }),
+      0,
+    );
+
+    expect(report.results.summary.other).toBe(1);
+    expect(report.results.tests[0]?.status).toBe("other");
+    expect(report.results.tests[0]?.message).toBe("boom");
+  });
+
+  it("should include error trace in CTRF test", () => {
+    const err = new Error("test error");
+    const result = makeVerifierResult({ status: "error", error: err });
+
+    const report = ReportBuilder.build(
+      makePhaseResult({ verifierResults: [result] }),
+      makePhaseResult({ verifierResults: [] }),
+      makePhaseResult({ verifierResults: [] }),
+      0,
+    );
+
+    expect(report.results.tests[0]?.trace).toBe(err.stack);
+  });
+
+  it("should include screenshots in extra field", () => {
+    const screenshot = makeScreenshotCapture({ name: "failure-0" });
+    const result = makeVerifierResult({
+      screenshots: [screenshot],
+    });
+
+    const report = ReportBuilder.build(
+      makePhaseResult({ verifierResults: [result] }),
+      makePhaseResult({ verifierResults: [] }),
+      makePhaseResult({ verifierResults: [] }),
+      0,
+    );
+
+    const extra = report.results.tests[0]?.extra;
+    expect(extra).toBeDefined();
+    expect((extra as Record<string, unknown>).screenshots).toBeDefined();
+  });
+
+  it("should handle empty report", () => {
+    const report = ReportBuilder.build(
+      makePhaseResult({ status: "skipped", verifierResults: [] }),
+      makePhaseResult({ status: "skipped", verifierResults: [] }),
+      makePhaseResult({ status: "skipped", verifierResults: [] }),
+      0,
+    );
+
+    expect(report.results.summary.tests).toBe(0);
+    expect(report.results.tests).toHaveLength(0);
+  });
+});

--- a/packages/self-test/src/__tests__/runner.test.ts
+++ b/packages/self-test/src/__tests__/runner.test.ts
@@ -1,0 +1,266 @@
+import { describe, expect, it, vi } from "vitest";
+import { SelfTestRunner } from "../runner.js";
+import { makeMockVerifier, makeVerifierContext, makeVerifierResult } from "./helpers.js";
+
+describe("SelfTestRunner", () => {
+  describe("happy path", () => {
+    it("should run all phases and produce a report", async () => {
+      const runner = new SelfTestRunner()
+        .addVerifier(makeMockVerifier({ name: "health", phase: "preflight" }))
+        .addVerifier(makeMockVerifier({ name: "smoke", phase: "smoke" }))
+        .addVerifier(makeMockVerifier({ name: "api", phase: "verification" }));
+
+      const report = await runner.run(makeVerifierContext());
+
+      expect(report.phases.preflight.status).toBe("passed");
+      expect(report.phases.smoke.status).toBe("passed");
+      expect(report.phases.verification.status).toBe("passed");
+      expect(report.results.summary.tests).toBe(3);
+      expect(report.results.summary.passed).toBe(3);
+      expect(report.results.summary.failed).toBe(0);
+    });
+  });
+
+  describe("gating", () => {
+    it("should skip smoke + verification when preflight fails", async () => {
+      const runner = new SelfTestRunner()
+        .addVerifier(
+          makeMockVerifier({
+            name: "health",
+            phase: "preflight",
+            result: { status: "failed" },
+          }),
+        )
+        .addVerifier(makeMockVerifier({ name: "smoke", phase: "smoke" }))
+        .addVerifier(makeMockVerifier({ name: "api", phase: "verification" }));
+
+      const report = await runner.run(makeVerifierContext());
+
+      expect(report.phases.preflight.status).toBe("failed");
+      expect(report.phases.smoke.status).toBe("skipped");
+      expect(report.phases.verification.status).toBe("skipped");
+      expect(report.results.summary.tests).toBe(1);
+      expect(report.results.summary.failed).toBe(1);
+    });
+
+    it("should skip verification when smoke fails", async () => {
+      const runner = new SelfTestRunner()
+        .addVerifier(makeMockVerifier({ name: "health", phase: "preflight" }))
+        .addVerifier(
+          makeMockVerifier({
+            name: "smoke",
+            phase: "smoke",
+            result: { status: "failed" },
+          }),
+        )
+        .addVerifier(makeMockVerifier({ name: "api", phase: "verification" }));
+
+      const report = await runner.run(makeVerifierContext());
+
+      expect(report.phases.preflight.status).toBe("passed");
+      expect(report.phases.smoke.status).toBe("failed");
+      expect(report.phases.verification.status).toBe("skipped");
+    });
+  });
+
+  describe("partial verification failure", () => {
+    it("should collect all results when verification partially fails", async () => {
+      const runner = new SelfTestRunner()
+        .addVerifier(makeMockVerifier({ name: "health", phase: "preflight" }))
+        .addVerifier(makeMockVerifier({ name: "smoke", phase: "smoke" }))
+        .addVerifier(makeMockVerifier({ name: "api", phase: "verification" }))
+        .addVerifier(
+          makeMockVerifier({
+            name: "browser",
+            phase: "verification",
+            result: { status: "failed" },
+          }),
+        );
+
+      const report = await runner.run(makeVerifierContext());
+
+      expect(report.phases.preflight.status).toBe("passed");
+      expect(report.phases.smoke.status).toBe("passed");
+      expect(report.phases.verification.status).toBe("failed");
+      // Both verification verifiers should have results
+      expect(report.phases.verification.verifierResults).toHaveLength(2);
+      expect(report.results.summary.tests).toBe(4);
+    });
+  });
+
+  describe("empty phases", () => {
+    it("should skip phases with no verifiers", async () => {
+      const runner = new SelfTestRunner().addVerifier(
+        makeMockVerifier({ name: "api", phase: "verification" }),
+      );
+
+      const report = await runner.run(makeVerifierContext());
+
+      expect(report.phases.preflight.status).toBe("skipped");
+      expect(report.phases.smoke.status).toBe("skipped");
+      expect(report.phases.verification.status).toBe("passed");
+      expect(report.results.summary.tests).toBe(1);
+    });
+
+    it("should produce empty report with no verifiers", async () => {
+      const runner = new SelfTestRunner();
+      const report = await runner.run(makeVerifierContext());
+
+      expect(report.phases.preflight.status).toBe("skipped");
+      expect(report.phases.smoke.status).toBe("skipped");
+      expect(report.phases.verification.status).toBe("skipped");
+      expect(report.results.summary.tests).toBe(0);
+    });
+  });
+
+  describe("error handling", () => {
+    it("should handle verifier throwing an error", async () => {
+      const runner = new SelfTestRunner().addVerifier(
+        makeMockVerifier({
+          name: "broken",
+          phase: "preflight",
+          runFn: async () => {
+            throw new Error("verifier exploded");
+          },
+        }),
+      );
+
+      const report = await runner.run(makeVerifierContext());
+
+      expect(report.phases.preflight.status).toBe("failed");
+      expect(report.phases.preflight.verifierResults[0]?.status).toBe("error");
+      expect(report.phases.preflight.verifierResults[0]?.error?.message).toBe("verifier exploded");
+    });
+
+    it("should call teardown even on run error", async () => {
+      const teardownFn = vi.fn().mockResolvedValue(undefined);
+      const runner = new SelfTestRunner().addVerifier(
+        makeMockVerifier({
+          name: "broken",
+          phase: "preflight",
+          runFn: async () => {
+            throw new Error("boom");
+          },
+          teardownFn,
+        }),
+      );
+
+      await runner.run(makeVerifierContext());
+      expect(teardownFn).toHaveBeenCalled();
+    });
+
+    it("should call setup before run", async () => {
+      const callOrder: string[] = [];
+      const runner = new SelfTestRunner().addVerifier(
+        makeMockVerifier({
+          name: "setup-test",
+          phase: "preflight",
+          setupFn: async () => {
+            callOrder.push("setup");
+          },
+          runFn: async () => {
+            callOrder.push("run");
+            return makeVerifierResult({ verifierName: "setup-test", phase: "preflight" });
+          },
+          teardownFn: async () => {
+            callOrder.push("teardown");
+          },
+        }),
+      );
+
+      await runner.run(makeVerifierContext());
+      expect(callOrder).toEqual(["setup", "run", "teardown"]);
+    });
+  });
+
+  describe("immutability", () => {
+    it("should return new instance on addVerifier", () => {
+      const original = new SelfTestRunner();
+      const withVerifier = original.addVerifier(
+        makeMockVerifier({ name: "health", phase: "preflight" }),
+      );
+
+      expect(withVerifier).not.toBe(original);
+    });
+
+    it("should not modify original runner", async () => {
+      const original = new SelfTestRunner();
+      original.addVerifier(makeMockVerifier({ name: "health", phase: "preflight" }));
+
+      const report = await original.run(makeVerifierContext());
+      // Original has no verifiers
+      expect(report.results.summary.tests).toBe(0);
+    });
+  });
+
+  describe("last report", () => {
+    it("should return null before any run", () => {
+      const runner = new SelfTestRunner();
+      expect(runner.getLastReport()).toBeNull();
+    });
+
+    it("should store last report after run", async () => {
+      const runner = new SelfTestRunner().addVerifier(
+        makeMockVerifier({ name: "health", phase: "preflight" }),
+      );
+
+      const report = await runner.run(makeVerifierContext());
+      expect(runner.getLastReport()).toBe(report);
+    });
+  });
+
+  describe("abort signal", () => {
+    it("should handle abort signal during execution", async () => {
+      const controller = new AbortController();
+
+      const runner = new SelfTestRunner()
+        .addVerifier(
+          makeMockVerifier({
+            name: "slow",
+            phase: "preflight",
+            runFn: async () => {
+              controller.abort();
+              return makeVerifierResult({
+                verifierName: "slow",
+                phase: "preflight",
+                status: "passed",
+              });
+            },
+          }),
+        )
+        .addVerifier(makeMockVerifier({ name: "next", phase: "preflight" }));
+
+      const report = await runner.run(makeVerifierContext({ abortSignal: controller.signal }));
+
+      // First verifier passes, second should be skipped
+      expect(report.phases.preflight.verifierResults).toHaveLength(2);
+    });
+  });
+
+  describe("CTRF report format", () => {
+    it("should include tool metadata", async () => {
+      const runner = new SelfTestRunner().addVerifier(
+        makeMockVerifier({ name: "health", phase: "preflight" }),
+      );
+
+      const report = await runner.run(makeVerifierContext());
+
+      expect(report.results.tool.name).toBe("@templar/self-test");
+      expect(report.results.summary.start).toBeGreaterThan(0);
+      expect(report.results.summary.stop).toBeGreaterThanOrEqual(report.results.summary.start);
+    });
+
+    it("should include tests in CTRF format", async () => {
+      const runner = new SelfTestRunner().addVerifier(
+        makeMockVerifier({ name: "health", phase: "preflight" }),
+      );
+
+      const report = await runner.run(makeVerifierContext());
+
+      expect(report.results.tests).toHaveLength(1);
+      expect(report.results.tests[0]?.name).toBe("health");
+      expect(report.results.tests[0]?.status).toBe("passed");
+      expect(typeof report.results.tests[0]?.duration).toBe("number");
+    });
+  });
+});

--- a/packages/self-test/src/__tests__/tools.test.ts
+++ b/packages/self-test/src/__tests__/tools.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SelfTestRunner } from "../runner.js";
+import { createSelfTestTools } from "../tools.js";
+import type { ResolvedSelfTestConfig } from "../types.js";
+import { makeMockVerifier } from "./helpers.js";
+
+function makeConfig(overrides?: Partial<ResolvedSelfTestConfig>): ResolvedSelfTestConfig {
+  return {
+    workspace: "/tmp/test",
+    browser: {
+      timeoutMs: 120_000,
+      viewport: { width: 1280, height: 720 },
+      screenshotOnFailure: true,
+    },
+    screenshots: {
+      storage: "base64",
+      directory: ".self-test/screenshots",
+      onPass: "never",
+      onFail: "always",
+    },
+    report: {
+      outputPath: ".self-test/reports",
+      includeScreenshots: true,
+    },
+    maxTotalDurationMs: 300_000,
+    ...overrides,
+  };
+}
+
+describe("createSelfTestTools", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should create tools with all methods", () => {
+    const tools = createSelfTestTools(makeConfig(), new SelfTestRunner(), null);
+
+    expect(typeof tools.runPreflight).toBe("function");
+    expect(typeof tools.runSmoke).toBe("function");
+    expect(typeof tools.runApiTest).toBe("function");
+    expect(typeof tools.runBrowserTest).toBe("function");
+    expect(typeof tools.runFullSuite).toBe("function");
+    expect(typeof tools.getLastReport).toBe("function");
+  });
+
+  describe("runPreflight", () => {
+    it("should skip when no health config", async () => {
+      const tools = createSelfTestTools(makeConfig(), new SelfTestRunner(), null);
+      const result = await tools.runPreflight();
+      expect(result.status).toBe("skipped");
+    });
+
+    it("should run health checks when configured", async () => {
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("ok", { status: 200 }));
+
+      const config = makeConfig({
+        health: {
+          checks: [{ name: "api", url: "http://localhost:3000/health" }],
+          timeoutMs: 5_000,
+        },
+      });
+
+      const tools = createSelfTestTools(config, new SelfTestRunner(), null);
+      const result = await tools.runPreflight();
+
+      expect(result.status).toBe("passed");
+      expect(result.verifierResults).toHaveLength(1);
+    });
+
+    it("should return failed result on health check failure", async () => {
+      vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("ECONNREFUSED"));
+
+      const config = makeConfig({
+        health: {
+          checks: [{ name: "api", url: "http://localhost:3000/health" }],
+          timeoutMs: 200,
+        },
+      });
+
+      const tools = createSelfTestTools(config, new SelfTestRunner(), null);
+      const result = await tools.runPreflight();
+
+      expect(result.status).toBe("failed");
+    });
+  });
+
+  describe("runSmoke", () => {
+    it("should run smoke steps", async () => {
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("ok", { status: 200 }));
+
+      const tools = createSelfTestTools(makeConfig(), new SelfTestRunner(), null);
+      const result = await tools.runSmoke([{ action: "navigate", url: "http://localhost:3000" }]);
+
+      expect(result.status).toBe("passed");
+    });
+  });
+
+  describe("runApiTest", () => {
+    it("should run API test steps", async () => {
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify({ ok: true }), { status: 200 }),
+      );
+
+      const tools = createSelfTestTools(makeConfig(), new SelfTestRunner(), null);
+      const result = await tools.runApiTest({
+        baseUrl: "http://localhost:3000",
+        steps: [{ method: "GET", path: "/api/health", expectedStatus: 200 }],
+      });
+
+      expect(result.status).toBe("passed");
+    });
+  });
+
+  describe("runFullSuite", () => {
+    it("should run full pipeline and store report", async () => {
+      const runner = new SelfTestRunner().addVerifier(
+        makeMockVerifier({ name: "health", phase: "preflight" }),
+      );
+
+      const tools = createSelfTestTools(makeConfig(), runner, null);
+      const report = await tools.runFullSuite();
+
+      expect(report.phases.preflight.status).toBe("passed");
+      expect(tools.getLastReport()).toBe(report);
+    });
+  });
+
+  describe("getLastReport", () => {
+    it("should return initial report if no runs", () => {
+      const initialReport = {
+        results: {
+          tool: { name: "@templar/self-test" as const, version: "0.0.0" },
+          summary: {
+            tests: 1,
+            passed: 1,
+            failed: 0,
+            pending: 0,
+            skipped: 0,
+            other: 0,
+            start: 0,
+            stop: 0,
+          },
+          tests: [],
+        },
+        phases: {
+          preflight: { status: "passed" as const, durationMs: 0, verifierResults: [] },
+          smoke: { status: "skipped" as const, durationMs: 0, verifierResults: [] },
+          verification: { status: "skipped" as const, durationMs: 0, verifierResults: [] },
+        },
+      };
+
+      const tools = createSelfTestTools(makeConfig(), new SelfTestRunner(), initialReport);
+      expect(tools.getLastReport()).toBe(initialReport);
+    });
+
+    it("should return null when no initial report", () => {
+      const tools = createSelfTestTools(makeConfig(), new SelfTestRunner(), null);
+      expect(tools.getLastReport()).toBeNull();
+    });
+  });
+});

--- a/packages/self-test/src/__tests__/validation.test.ts
+++ b/packages/self-test/src/__tests__/validation.test.ts
@@ -1,0 +1,241 @@
+import { describe, expect, it } from "vitest";
+import { ZodError } from "zod";
+import { resolveSelfTestConfig, validateSelfTestConfig } from "../validation.js";
+
+describe("validateSelfTestConfig", () => {
+  const validConfig = {
+    workspace: "/tmp/workspace",
+  };
+
+  it("should accept minimal config with just workspace", () => {
+    const result = validateSelfTestConfig(validConfig);
+    expect(result.workspace).toBe("/tmp/workspace");
+  });
+
+  it("should accept full config", () => {
+    const result = validateSelfTestConfig({
+      workspace: "/tmp/workspace",
+      devServer: {
+        command: "npm start",
+        url: "http://localhost:3000",
+        timeoutMs: 10_000,
+        env: { NODE_ENV: "test" },
+        reuseExisting: false,
+      },
+      health: {
+        checks: [{ name: "api", url: "http://localhost:3000/health" }],
+        timeoutMs: 5_000,
+      },
+      smoke: {
+        steps: [{ action: "navigate", url: "http://localhost:3000" }],
+        timeoutMs: 15_000,
+      },
+      browser: {
+        timeoutMs: 60_000,
+        viewport: { width: 1920, height: 1080 },
+        screenshotOnFailure: true,
+      },
+      api: {
+        baseUrl: "http://localhost:3000",
+        timeoutMs: 10_000,
+      },
+      screenshots: {
+        storage: "disk",
+        directory: ".test-screenshots",
+        onPass: "always",
+        onFail: "always",
+      },
+      report: {
+        outputPath: ".test-reports",
+        includeScreenshots: false,
+      },
+      maxTotalDurationMs: 120_000,
+    });
+
+    expect(result.workspace).toBe("/tmp/workspace");
+    expect(result.devServer?.command).toBe("npm start");
+    expect(result.health?.checks).toHaveLength(1);
+    expect(result.smoke?.steps).toHaveLength(1);
+    expect(result.browser?.viewport?.width).toBe(1920);
+    expect(result.api?.baseUrl).toBe("http://localhost:3000");
+    expect(result.screenshots?.storage).toBe("disk");
+    expect(result.report?.includeScreenshots).toBe(false);
+    expect(result.maxTotalDurationMs).toBe(120_000);
+  });
+
+  it("should reject empty workspace", () => {
+    expect(() => validateSelfTestConfig({ workspace: "" })).toThrow(ZodError);
+  });
+
+  it("should reject missing workspace", () => {
+    expect(() => validateSelfTestConfig({})).toThrow(ZodError);
+  });
+
+  it("should reject invalid devServer url", () => {
+    expect(() =>
+      validateSelfTestConfig({
+        workspace: "/tmp",
+        devServer: { command: "npm start", url: "not-a-url" },
+      }),
+    ).toThrow(ZodError);
+  });
+
+  it("should reject empty devServer command", () => {
+    expect(() =>
+      validateSelfTestConfig({
+        workspace: "/tmp",
+        devServer: { command: "", url: "http://localhost:3000" },
+      }),
+    ).toThrow(ZodError);
+  });
+
+  it("should reject devServer timeoutMs exceeding max", () => {
+    expect(() =>
+      validateSelfTestConfig({
+        workspace: "/tmp",
+        devServer: { command: "npm start", url: "http://localhost:3000", timeoutMs: 200_000 },
+      }),
+    ).toThrow(ZodError);
+  });
+
+  it("should reject empty health checks array", () => {
+    expect(() =>
+      validateSelfTestConfig({
+        workspace: "/tmp",
+        health: { checks: [] },
+      }),
+    ).toThrow(ZodError);
+  });
+
+  it("should reject invalid health check url", () => {
+    expect(() =>
+      validateSelfTestConfig({
+        workspace: "/tmp",
+        health: { checks: [{ name: "api", url: "bad-url" }] },
+      }),
+    ).toThrow(ZodError);
+  });
+
+  it("should reject empty smoke steps array", () => {
+    expect(() =>
+      validateSelfTestConfig({
+        workspace: "/tmp",
+        smoke: { steps: [] },
+      }),
+    ).toThrow(ZodError);
+  });
+
+  it("should reject invalid smoke step action", () => {
+    expect(() =>
+      validateSelfTestConfig({
+        workspace: "/tmp",
+        smoke: { steps: [{ action: "invalid" }] },
+      }),
+    ).toThrow(ZodError);
+  });
+
+  it("should reject invalid api baseUrl", () => {
+    expect(() =>
+      validateSelfTestConfig({
+        workspace: "/tmp",
+        api: { baseUrl: "not-a-url" },
+      }),
+    ).toThrow(ZodError);
+  });
+
+  it("should reject maxTotalDurationMs exceeding 10 min", () => {
+    expect(() =>
+      validateSelfTestConfig({
+        workspace: "/tmp",
+        maxTotalDurationMs: 700_000,
+      }),
+    ).toThrow(ZodError);
+  });
+
+  it("should reject negative maxTotalDurationMs", () => {
+    expect(() =>
+      validateSelfTestConfig({
+        workspace: "/tmp",
+        maxTotalDurationMs: -1,
+      }),
+    ).toThrow(ZodError);
+  });
+});
+
+describe("resolveSelfTestConfig", () => {
+  it("should apply all defaults for minimal config", () => {
+    const validated = validateSelfTestConfig({ workspace: "/tmp/workspace" });
+    const resolved = resolveSelfTestConfig(validated);
+
+    expect(resolved.workspace).toBe("/tmp/workspace");
+    expect(resolved.maxTotalDurationMs).toBe(300_000);
+    expect(resolved.browser).toEqual({
+      timeoutMs: 120_000,
+      viewport: { width: 1280, height: 720 },
+      screenshotOnFailure: true,
+    });
+    expect(resolved.screenshots).toEqual({
+      storage: "base64",
+      directory: ".self-test/screenshots",
+      onPass: "never",
+      onFail: "always",
+    });
+    expect(resolved.report).toEqual({
+      outputPath: ".self-test/reports",
+      includeScreenshots: true,
+    });
+    expect(resolved.devServer).toBeUndefined();
+    expect(resolved.health).toBeUndefined();
+    expect(resolved.smoke).toBeUndefined();
+    expect(resolved.api).toBeUndefined();
+  });
+
+  it("should resolve devServer defaults", () => {
+    const validated = validateSelfTestConfig({
+      workspace: "/tmp",
+      devServer: { command: "npm start", url: "http://localhost:3000" },
+    });
+    const resolved = resolveSelfTestConfig(validated);
+
+    expect(resolved.devServer).toBeDefined();
+    expect(resolved.devServer?.timeoutMs).toBe(30_000);
+    expect(resolved.devServer?.reuseExisting).toBe(true);
+    expect(resolved.devServer?.env).toEqual({});
+  });
+
+  it("should preserve user-provided overrides", () => {
+    const validated = validateSelfTestConfig({
+      workspace: "/tmp",
+      browser: { timeoutMs: 60_000, viewport: { width: 1920, height: 1080 } },
+      screenshots: { storage: "disk", directory: "custom-dir" },
+      report: { outputPath: "custom-reports", includeScreenshots: false },
+      maxTotalDurationMs: 120_000,
+    });
+    const resolved = resolveSelfTestConfig(validated);
+
+    expect(resolved.browser.timeoutMs).toBe(60_000);
+    expect(resolved.browser.viewport).toEqual({ width: 1920, height: 1080 });
+    expect(resolved.browser.screenshotOnFailure).toBe(true); // default
+    expect(resolved.screenshots.storage).toBe("disk");
+    expect(resolved.screenshots.directory).toBe("custom-dir");
+    expect(resolved.screenshots.onPass).toBe("never"); // default
+    expect(resolved.screenshots.onFail).toBe("always"); // default
+    expect(resolved.report.outputPath).toBe("custom-reports");
+    expect(resolved.report.includeScreenshots).toBe(false);
+    expect(resolved.maxTotalDurationMs).toBe(120_000);
+  });
+
+  it("should pass through health config unchanged", () => {
+    const validated = validateSelfTestConfig({
+      workspace: "/tmp",
+      health: {
+        checks: [{ name: "api", url: "http://localhost:3000/health", expectedStatus: 200 }],
+        timeoutMs: 10_000,
+      },
+    });
+    const resolved = resolveSelfTestConfig(validated);
+
+    expect(resolved.health?.checks).toHaveLength(1);
+    expect(resolved.health?.timeoutMs).toBe(10_000);
+  });
+});

--- a/packages/self-test/src/__tests__/verifiers/api.test.ts
+++ b/packages/self-test/src/__tests__/verifiers/api.test.ts
@@ -1,0 +1,172 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ApiVerifier } from "../../verifiers/api.js";
+import { makeVerifierContext } from "../helpers.js";
+
+describe("ApiVerifier", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should pass when all steps match expected status", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), { status: 200 }),
+    );
+
+    const verifier = new ApiVerifier({
+      baseUrl: "http://localhost:3000",
+      steps: [
+        { method: "GET", path: "/api/health", expectedStatus: 200 },
+        { method: "GET", path: "/api/data", expectedStatus: 200 },
+      ],
+    });
+
+    const result = await verifier.run(makeVerifierContext());
+
+    expect(result.status).toBe("passed");
+    expect(result.phase).toBe("verification");
+    expect(result.verifierName).toBe("api");
+    expect(result.assertions).toHaveLength(2);
+    expect(result.assertions.every((a) => a.passed)).toBe(true);
+  });
+
+  it("should fail when status does not match", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("error", { status: 500 }));
+
+    const verifier = new ApiVerifier({
+      baseUrl: "http://localhost:3000",
+      steps: [{ method: "GET", path: "/api/health", expectedStatus: 200 }],
+    });
+
+    const result = await verifier.run(makeVerifierContext());
+
+    expect(result.status).toBe("failed");
+    expect(result.assertions[0]?.passed).toBe(false);
+    expect(result.assertions[0]?.expected).toBe(200);
+    expect(result.assertions[0]?.actual).toBe(500);
+  });
+
+  it("should fail when response body does not match", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ status: "error" }), { status: 200 }),
+    );
+
+    const verifier = new ApiVerifier({
+      baseUrl: "http://localhost:3000",
+      steps: [
+        {
+          method: "GET",
+          path: "/api/data",
+          expectedStatus: 200,
+          expectedBody: { status: "ok" },
+        },
+      ],
+    });
+
+    const result = await verifier.run(makeVerifierContext());
+
+    expect(result.status).toBe("failed");
+    expect(result.assertions[0]?.passed).toBe(false);
+    expect(result.assertions[0]?.message).toContain("body mismatch");
+  });
+
+  it("should pass when body matches", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ status: "ok" }), { status: 200 }),
+    );
+
+    const verifier = new ApiVerifier({
+      baseUrl: "http://localhost:3000",
+      steps: [
+        {
+          method: "GET",
+          path: "/api/data",
+          expectedStatus: 200,
+          expectedBody: { status: "ok" },
+        },
+      ],
+    });
+
+    const result = await verifier.run(makeVerifierContext());
+    expect(result.status).toBe("passed");
+  });
+
+  it("should send POST body and headers", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(JSON.stringify({ id: 1 }), { status: 201 }));
+
+    const verifier = new ApiVerifier({
+      baseUrl: "http://localhost:3000",
+      steps: [
+        {
+          method: "POST",
+          path: "/api/items",
+          body: { name: "test" },
+          headers: { Authorization: "Bearer token" },
+          expectedStatus: 201,
+        },
+      ],
+    });
+
+    await verifier.run(makeVerifierContext());
+
+    const callArgs = fetchSpy.mock.calls[0]!;
+    expect(callArgs[0]).toBe("http://localhost:3000/api/items");
+    const opts = callArgs[1] as RequestInit;
+    expect(opts.method).toBe("POST");
+    expect(opts.body).toBe(JSON.stringify({ name: "test" }));
+    expect((opts.headers as Record<string, string>).Authorization).toBe("Bearer token");
+  });
+
+  it("should handle network errors", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("ECONNREFUSED"));
+
+    const verifier = new ApiVerifier({
+      baseUrl: "http://localhost:3000",
+      steps: [{ method: "GET", path: "/api/health" }],
+    });
+
+    const result = await verifier.run(makeVerifierContext());
+
+    expect(result.status).toBe("failed");
+    expect(result.assertions[0]?.passed).toBe(false);
+    expect(result.assertions[0]?.message).toContain("ECONNREFUSED");
+  });
+
+  it("should support custom name", () => {
+    const verifier = new ApiVerifier({ baseUrl: "http://localhost:3000", steps: [] }, "custom-api");
+    expect(verifier.name).toBe("custom-api");
+  });
+
+  it("should pass without expectedStatus check", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("error", { status: 500 }));
+
+    const verifier = new ApiVerifier({
+      baseUrl: "http://localhost:3000",
+      steps: [{ method: "GET", path: "/api/health" }], // No expectedStatus
+    });
+
+    const result = await verifier.run(makeVerifierContext());
+    expect(result.status).toBe("passed"); // No assertion to fail
+  });
+
+  it("should handle abort signal", async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new DOMException("aborted", "AbortError"));
+
+    const verifier = new ApiVerifier({
+      baseUrl: "http://localhost:3000",
+      steps: [{ method: "GET", path: "/api/health", expectedStatus: 200 }],
+    });
+
+    const result = await verifier.run(makeVerifierContext({ abortSignal: controller.signal }));
+    // With aborted signal, steps should be marked as aborted
+    expect(result.assertions[0]?.passed).toBe(false);
+  });
+});

--- a/packages/self-test/src/__tests__/verifiers/browser.test.ts
+++ b/packages/self-test/src/__tests__/verifiers/browser.test.ts
@@ -1,0 +1,228 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { BrowserVerifier } from "../../verifiers/browser.js";
+import { makeVerifierContext } from "../helpers.js";
+
+// Mock playwright module
+const mockPage = {
+  goto: vi.fn().mockResolvedValue(undefined),
+  fill: vi.fn().mockResolvedValue(undefined),
+  click: vi.fn().mockResolvedValue(undefined),
+  waitForSelector: vi.fn().mockResolvedValue(undefined),
+  textContent: vi.fn().mockResolvedValue("Hello World"),
+  screenshot: vi.fn().mockResolvedValue(Buffer.from("fake-png")),
+  close: vi.fn().mockResolvedValue(undefined),
+};
+
+const mockContext = {
+  newPage: vi.fn().mockResolvedValue(mockPage),
+  close: vi.fn().mockResolvedValue(undefined),
+};
+
+const mockBrowser = {
+  newContext: vi.fn().mockResolvedValue(mockContext),
+  close: vi.fn().mockResolvedValue(undefined),
+};
+
+vi.mock("playwright", () => ({
+  chromium: {
+    launch: vi.fn().mockResolvedValue(mockBrowser),
+  },
+}));
+
+describe("BrowserVerifier", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should execute navigate step", async () => {
+    const verifier = new BrowserVerifier([{ action: "navigate", url: "http://localhost:3000" }]);
+
+    const result = await verifier.run(makeVerifierContext());
+
+    expect(result.status).toBe("passed");
+    expect(result.phase).toBe("verification");
+    expect(result.verifierName).toBe("browser");
+    expect(mockPage.goto).toHaveBeenCalledWith("http://localhost:3000");
+  });
+
+  it("should execute fill step", async () => {
+    const verifier = new BrowserVerifier([
+      { action: "navigate", url: "http://localhost:3000" },
+      { action: "fill", selector: "#username", value: "test" },
+    ]);
+
+    const result = await verifier.run(makeVerifierContext());
+
+    expect(result.status).toBe("passed");
+    expect(mockPage.fill).toHaveBeenCalledWith("#username", "test");
+  });
+
+  it("should execute click step", async () => {
+    const verifier = new BrowserVerifier([{ action: "click", selector: "#submit" }]);
+
+    const result = await verifier.run(makeVerifierContext());
+
+    expect(result.status).toBe("passed");
+    expect(mockPage.click).toHaveBeenCalledWith("#submit");
+  });
+
+  it("should execute waitFor step", async () => {
+    const verifier = new BrowserVerifier([{ action: "waitFor", selector: ".loaded" }]);
+
+    const result = await verifier.run(makeVerifierContext());
+
+    expect(result.status).toBe("passed");
+    expect(mockPage.waitForSelector).toHaveBeenCalledWith(".loaded", { timeout: 10_000 });
+  });
+
+  it("should pass assertText when text is found", async () => {
+    mockPage.textContent.mockResolvedValueOnce("Hello World from our app");
+
+    const verifier = new BrowserVerifier([
+      { action: "assertText", selector: "body", text: "Hello World" },
+    ]);
+
+    const result = await verifier.run(makeVerifierContext());
+
+    expect(result.status).toBe("passed");
+    expect(result.assertions[0]?.passed).toBe(true);
+  });
+
+  it("should fail assertText when text is not found", async () => {
+    mockPage.textContent.mockResolvedValueOnce("Goodbye");
+
+    const verifier = new BrowserVerifier([
+      { action: "assertText", selector: "body", text: "Hello" },
+    ]);
+
+    const result = await verifier.run(makeVerifierContext());
+
+    expect(result.status).toBe("failed");
+    expect(result.assertions[0]?.passed).toBe(false);
+    expect(result.assertions[0]?.message).toContain("not found");
+  });
+
+  it("should capture screenshot on failure when configured", async () => {
+    mockPage.textContent.mockResolvedValueOnce("Wrong text");
+
+    const verifier = new BrowserVerifier(
+      [{ action: "assertText", selector: "body", text: "Expected" }],
+      { screenshotOnFailure: true },
+    );
+
+    const result = await verifier.run(makeVerifierContext());
+
+    expect(result.status).toBe("failed");
+    expect(result.screenshots).toHaveLength(1);
+    expect(result.screenshots[0]?.name).toBe("failure-0");
+  });
+
+  it("should not capture screenshot on failure when disabled", async () => {
+    mockPage.textContent.mockResolvedValueOnce("Wrong text");
+
+    const verifier = new BrowserVerifier(
+      [{ action: "assertText", selector: "body", text: "Expected" }],
+      { screenshotOnFailure: false },
+    );
+
+    const result = await verifier.run(makeVerifierContext());
+
+    expect(result.status).toBe("failed");
+    expect(result.screenshots).toHaveLength(0);
+  });
+
+  it("should capture explicit screenshot step", async () => {
+    const verifier = new BrowserVerifier([
+      { action: "navigate", url: "http://localhost:3000" },
+      { action: "screenshot", screenshotName: "home-page" },
+    ]);
+
+    const result = await verifier.run(makeVerifierContext());
+
+    expect(result.status).toBe("passed");
+    expect(result.screenshots).toHaveLength(1);
+    expect(result.screenshots[0]?.name).toBe("home-page");
+  });
+
+  it("should fail navigate without url", async () => {
+    const verifier = new BrowserVerifier([{ action: "navigate" }]);
+
+    const result = await verifier.run(makeVerifierContext());
+
+    expect(result.status).toBe("failed");
+    expect(result.assertions[0]?.message).toContain("requires url");
+  });
+
+  it("should fail fill without selector", async () => {
+    const verifier = new BrowserVerifier([{ action: "fill", value: "test" }]);
+
+    const result = await verifier.run(makeVerifierContext());
+
+    expect(result.status).toBe("failed");
+    expect(result.assertions[0]?.message).toContain("requires selector and value");
+  });
+
+  it("should fail click without selector", async () => {
+    const verifier = new BrowserVerifier([{ action: "click" }]);
+
+    const result = await verifier.run(makeVerifierContext());
+
+    expect(result.status).toBe("failed");
+    expect(result.assertions[0]?.message).toContain("requires selector");
+  });
+
+  it("should use custom viewport", async () => {
+    const verifier = new BrowserVerifier([{ action: "navigate", url: "http://localhost:3000" }], {
+      viewport: { width: 1920, height: 1080 },
+    });
+
+    await verifier.run(makeVerifierContext());
+
+    expect(mockBrowser.newContext).toHaveBeenCalledWith({
+      viewport: { width: 1920, height: 1080 },
+    });
+  });
+
+  it("should support custom name", () => {
+    const verifier = new BrowserVerifier([], {}, "custom-browser");
+    expect(verifier.name).toBe("custom-browser");
+    expect(verifier.phase).toBe("verification");
+  });
+
+  it("should close browser even on error", async () => {
+    mockPage.goto.mockRejectedValueOnce(new Error("Navigation failed"));
+
+    const verifier = new BrowserVerifier([{ action: "navigate", url: "http://localhost:3000" }]);
+
+    const result = await verifier.run(makeVerifierContext());
+
+    expect(result.status).toBe("failed");
+    expect(mockPage.close).toHaveBeenCalled();
+    expect(mockContext.close).toHaveBeenCalled();
+    expect(mockBrowser.close).toHaveBeenCalled();
+  });
+});
+
+describe("BrowserVerifier — playwright not installed", () => {
+  it("should throw SelfTestConfigurationInvalidError when playwright is missing", async () => {
+    // Reset the mock to simulate playwright not being available
+    vi.doUnmock("playwright");
+    vi.resetModules();
+
+    // Re-import with a fresh mock that rejects
+    vi.doMock("playwright", () => {
+      throw new Error("Cannot find module 'playwright'");
+    });
+
+    const { BrowserVerifier: FreshBrowserVerifier } = await import("../../verifiers/browser.js");
+
+    const verifier = new FreshBrowserVerifier([
+      { action: "navigate", url: "http://localhost:3000" },
+    ]);
+
+    // Use name check since module re-import may create different class identity
+    await expect(verifier.run(makeVerifierContext())).rejects.toThrow(
+      "playwright is not installed",
+    );
+  });
+});

--- a/packages/self-test/src/__tests__/verifiers/health.test.ts
+++ b/packages/self-test/src/__tests__/verifiers/health.test.ts
@@ -1,0 +1,121 @@
+import { SelfTestTimeoutError } from "@templar/errors";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { HealthVerifier } from "../../verifiers/health.js";
+import { makeVerifierContext } from "../helpers.js";
+
+describe("HealthVerifier", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("should pass when all checks return expected status", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("ok", { status: 200 }));
+
+    const verifier = new HealthVerifier({
+      checks: [
+        { name: "api", url: "http://localhost:3000/health" },
+        { name: "db", url: "http://localhost:3000/db-health" },
+      ],
+      timeoutMs: 5_000,
+    });
+
+    const result = await verifier.run(makeVerifierContext());
+
+    expect(result.status).toBe("passed");
+    expect(result.phase).toBe("preflight");
+    expect(result.verifierName).toBe("health");
+    expect(result.assertions).toHaveLength(2);
+    expect(result.assertions[0]?.passed).toBe(true);
+    expect(result.assertions[1]?.passed).toBe(true);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("should pass with custom expected status", async () => {
+    // Use status 201 since 204 may not be valid in all Response implementations
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("", { status: 201 }));
+
+    const verifier = new HealthVerifier({
+      checks: [{ name: "api", url: "http://localhost:3000/health", expectedStatus: 201 }],
+      timeoutMs: 5_000,
+    });
+
+    const result = await verifier.run(makeVerifierContext());
+    expect(result.status).toBe("passed");
+    expect(result.assertions[0]?.passed).toBe(true);
+  });
+
+  it("should throw SelfTestTimeoutError on persistent status mismatch", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("error", { status: 503 }));
+
+    const verifier = new HealthVerifier({
+      checks: [{ name: "api", url: "http://localhost:3000/health" }],
+      timeoutMs: 500,
+    });
+
+    await expect(verifier.run(makeVerifierContext())).rejects.toThrow(SelfTestTimeoutError);
+  });
+
+  it("should throw on persistent network error", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("ECONNREFUSED"));
+
+    const verifier = new HealthVerifier({
+      checks: [{ name: "api", url: "http://localhost:3000/health" }],
+      timeoutMs: 500,
+    });
+
+    // With persistent errors and short timeout, throws either timeout or health check error
+    await expect(verifier.run(makeVerifierContext())).rejects.toThrow();
+  });
+
+  it("should retry with backoff on initial failure then succeed", async () => {
+    let callCount = 0;
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+      callCount++;
+      if (callCount < 3) {
+        throw new Error("ECONNREFUSED");
+      }
+      return new Response("ok", { status: 200 });
+    });
+
+    const verifier = new HealthVerifier({
+      checks: [{ name: "api", url: "http://localhost:3000/health" }],
+      timeoutMs: 10_000,
+    });
+
+    const result = await verifier.run(makeVerifierContext());
+    expect(result.status).toBe("passed");
+    expect(callCount).toBeGreaterThanOrEqual(3);
+  });
+
+  it("should use custom name", () => {
+    const verifier = new HealthVerifier(
+      { checks: [{ name: "api", url: "http://localhost:3000" }] },
+      "custom-health",
+    );
+    expect(verifier.name).toBe("custom-health");
+    expect(verifier.phase).toBe("preflight");
+  });
+
+  it("should handle pre-aborted signal", async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    const verifier = new HealthVerifier({
+      checks: [{ name: "api", url: "http://localhost:3000/health" }],
+      timeoutMs: 5_000,
+    });
+
+    // With pre-aborted signal, the check should fail immediately
+    const result = await verifier.run(makeVerifierContext({ abortSignal: controller.signal }));
+    expect(result.status).toBe("failed");
+    expect(result.assertions[0]?.passed).toBe(false);
+    expect(result.assertions[0]?.message).toBe("Aborted");
+  });
+});

--- a/packages/self-test/src/__tests__/verifiers/smoke.test.ts
+++ b/packages/self-test/src/__tests__/verifiers/smoke.test.ts
@@ -1,0 +1,178 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SmokeVerifier } from "../../verifiers/smoke.js";
+import { makeVerifierContext } from "../helpers.js";
+
+describe("SmokeVerifier", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should pass navigate step with 200 response", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("ok", { status: 200 }));
+
+    const verifier = new SmokeVerifier({
+      steps: [{ action: "navigate", url: "http://localhost:3000" }],
+    });
+
+    const result = await verifier.run(makeVerifierContext());
+
+    expect(result.status).toBe("passed");
+    expect(result.phase).toBe("smoke");
+    expect(result.verifierName).toBe("smoke");
+    expect(result.assertions[0]?.passed).toBe(true);
+  });
+
+  it("should pass navigate with 3xx redirect", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(null, { status: 301 }));
+
+    const verifier = new SmokeVerifier({
+      steps: [{ action: "navigate", url: "http://localhost:3000" }],
+    });
+
+    const result = await verifier.run(makeVerifierContext());
+    expect(result.status).toBe("passed");
+  });
+
+  it("should fail navigate with 500", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("error", { status: 500 }));
+
+    const verifier = new SmokeVerifier({
+      steps: [{ action: "navigate", url: "http://localhost:3000" }],
+    });
+
+    const result = await verifier.run(makeVerifierContext());
+    expect(result.status).toBe("failed");
+    expect(result.assertions[0]?.passed).toBe(false);
+  });
+
+  it("should pass assertStatus when status matches", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("ok", { status: 200 }));
+
+    const verifier = new SmokeVerifier({
+      steps: [{ action: "assertStatus", url: "http://localhost:3000/health", expectedStatus: 200 }],
+    });
+
+    const result = await verifier.run(makeVerifierContext());
+    expect(result.status).toBe("passed");
+    expect(result.assertions[0]?.expected).toBe(200);
+    expect(result.assertions[0]?.actual).toBe(200);
+  });
+
+  it("should fail assertStatus when status mismatches", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("error", { status: 503 }));
+
+    const verifier = new SmokeVerifier({
+      steps: [{ action: "assertStatus", url: "http://localhost:3000/health", expectedStatus: 200 }],
+    });
+
+    const result = await verifier.run(makeVerifierContext());
+    expect(result.status).toBe("failed");
+    expect(result.assertions[0]?.message).toContain("Expected 200, got 503");
+  });
+
+  it("should pass assertText when text is found in body", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response('{"status":"ok","message":"Server is running"}', { status: 200 }),
+    );
+
+    const verifier = new SmokeVerifier({
+      steps: [{ action: "assertText", url: "http://localhost:3000/health", text: "ok" }],
+    });
+
+    const result = await verifier.run(makeVerifierContext());
+    expect(result.status).toBe("passed");
+  });
+
+  it("should fail assertText when text is not found", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response('{"status":"error"}', { status: 200 }),
+    );
+
+    const verifier = new SmokeVerifier({
+      steps: [{ action: "assertText", url: "http://localhost:3000/health", text: "success" }],
+    });
+
+    const result = await verifier.run(makeVerifierContext());
+    expect(result.status).toBe("failed");
+    expect(result.assertions[0]?.message).toContain("not found");
+  });
+
+  it("should skip waitFor gracefully (no browser)", async () => {
+    const verifier = new SmokeVerifier({
+      steps: [{ action: "waitFor", selector: ".loaded" }],
+    });
+
+    const result = await verifier.run(makeVerifierContext());
+    expect(result.status).toBe("passed");
+    expect(result.assertions[0]?.message).toContain("skipped");
+  });
+
+  it("should fail navigate without url", async () => {
+    const verifier = new SmokeVerifier({
+      steps: [{ action: "navigate" }],
+    });
+
+    const result = await verifier.run(makeVerifierContext());
+    expect(result.status).toBe("failed");
+    expect(result.assertions[0]?.message).toContain("requires url");
+  });
+
+  it("should fail assertStatus without url", async () => {
+    const verifier = new SmokeVerifier({
+      steps: [{ action: "assertStatus", expectedStatus: 200 }],
+    });
+
+    const result = await verifier.run(makeVerifierContext());
+    expect(result.status).toBe("failed");
+    expect(result.assertions[0]?.message).toContain("requires url");
+  });
+
+  it("should fail assertText without url or text", async () => {
+    const verifier = new SmokeVerifier({
+      steps: [{ action: "assertText" }],
+    });
+
+    const result = await verifier.run(makeVerifierContext());
+    expect(result.status).toBe("failed");
+    expect(result.assertions[0]?.message).toContain("requires url and text");
+  });
+
+  it("should handle network errors", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("ECONNREFUSED"));
+
+    const verifier = new SmokeVerifier({
+      steps: [{ action: "navigate", url: "http://localhost:3000" }],
+    });
+
+    const result = await verifier.run(makeVerifierContext());
+    expect(result.status).toBe("failed");
+    expect(result.assertions[0]?.message).toContain("ECONNREFUSED");
+  });
+
+  it("should support custom name", () => {
+    const verifier = new SmokeVerifier(
+      { steps: [{ action: "navigate", url: "http://localhost:3000" }] },
+      "custom-smoke",
+    );
+    expect(verifier.name).toBe("custom-smoke");
+  });
+
+  it("should run multiple steps sequentially", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("ok", { status: 200 }));
+
+    const verifier = new SmokeVerifier({
+      steps: [
+        { action: "navigate", url: "http://localhost:3000" },
+        { action: "assertStatus", url: "http://localhost:3000/health", expectedStatus: 200 },
+        { action: "waitFor", selector: ".loaded" },
+      ],
+    });
+
+    const result = await verifier.run(makeVerifierContext());
+    expect(result.status).toBe("passed");
+    expect(result.assertions).toHaveLength(3);
+    expect(fetchSpy).toHaveBeenCalledTimes(2); // navigate + assertStatus, waitFor skips fetch
+  });
+});

--- a/packages/self-test/src/index.ts
+++ b/packages/self-test/src/index.ts
@@ -1,0 +1,74 @@
+/**
+ * @templar/self-test
+ *
+ * Pluggable self-verification for AI agents: health checks, smoke tests,
+ * API testing, and browser automation integrated into the session lifecycle.
+ */
+
+// ============================================================================
+// TYPES
+// ============================================================================
+
+export type {
+  ApiConfig,
+  ApiTestConfig,
+  ApiTestStep,
+  AssertionResult,
+  BrowserConfig,
+  BrowserStep,
+  CTRFTest,
+  DevServerConfig,
+  HealthCheck,
+  HealthConfig,
+  Phase,
+  PhaseResult,
+  ReportConfig,
+  ResolvedSelfTestConfig,
+  ScreenshotCapture,
+  ScreenshotConfig,
+  SelfTestConfig,
+  SelfTestReport,
+  SelfTestTools,
+  SmokeConfig,
+  SmokeStep,
+  Verifier,
+  VerifierContext,
+  VerifierResult,
+} from "./types.js";
+
+// ============================================================================
+// VALIDATION
+// ============================================================================
+
+export { resolveSelfTestConfig, validateSelfTestConfig } from "./validation.js";
+
+// ============================================================================
+// VERIFIERS
+// ============================================================================
+
+export { ApiVerifier } from "./verifiers/api.js";
+export { BrowserVerifier } from "./verifiers/browser.js";
+export { HealthVerifier } from "./verifiers/health.js";
+export { SmokeVerifier } from "./verifiers/smoke.js";
+
+// ============================================================================
+// RUNNER + INFRASTRUCTURE
+// ============================================================================
+
+export { ProcessManager } from "./process-manager.js";
+export { ReportBuilder } from "./report-builder.js";
+export { SelfTestRunner } from "./runner.js";
+
+// ============================================================================
+// MIDDLEWARE + TOOLS
+// ============================================================================
+
+export { SelfTestMiddleware } from "./middleware.js";
+export { createSelfTestTools } from "./tools.js";
+
+// ============================================================================
+// PACKAGE METADATA
+// ============================================================================
+
+export const PACKAGE_NAME = "@templar/self-test";
+export const PACKAGE_VERSION = "0.0.0";

--- a/packages/self-test/src/middleware.ts
+++ b/packages/self-test/src/middleware.ts
@@ -1,0 +1,146 @@
+import type { SessionContext, TemplarMiddleware } from "@templar/core";
+import { SelfTestHealthCheckFailedError, SelfTestVerificationFailedError } from "@templar/errors";
+import { ProcessManager } from "./process-manager.js";
+import { SelfTestRunner } from "./runner.js";
+import { createSelfTestTools } from "./tools.js";
+import type {
+  ResolvedSelfTestConfig,
+  SelfTestConfig,
+  SelfTestReport,
+  SelfTestTools,
+  VerifierContext,
+} from "./types.js";
+import { resolveSelfTestConfig, validateSelfTestConfig } from "./validation.js";
+import { HealthVerifier } from "./verifiers/health.js";
+import { SmokeVerifier } from "./verifiers/smoke.js";
+
+/**
+ * SelfTestMiddleware — gate middleware for session-level self-verification.
+ *
+ * Implements TemplarMiddleware to run health checks and smoke tests
+ * at session start, blocking the session if verification fails.
+ *
+ * Usage:
+ *   const middleware = new SelfTestMiddleware({ workspace: "/app", ... });
+ *   // Register with Templar engine
+ *
+ * On session start:
+ *   1. Start dev server if configured
+ *   2. Run preflight (health checks)
+ *   3. Run smoke tests
+ *   4. If either fails, throw — session is blocked
+ *   5. Expose tools for on-demand verification
+ *
+ * On session end:
+ *   1. Stop dev server
+ */
+export class SelfTestMiddleware implements TemplarMiddleware {
+  readonly name = "templar:self-test";
+
+  private readonly config: ResolvedSelfTestConfig;
+  private readonly runner: SelfTestRunner;
+  private readonly processManager: ProcessManager;
+  private tools: SelfTestTools | null = null;
+  private lastReport: SelfTestReport | null = null;
+
+  constructor(config: SelfTestConfig) {
+    this.config = resolveSelfTestConfig(validateSelfTestConfig(config));
+    this.processManager = new ProcessManager();
+
+    // Build runner from config
+    let runner = new SelfTestRunner();
+
+    // Register health verifier if configured
+    if (this.config.health) {
+      runner = runner.addVerifier(new HealthVerifier(this.config.health));
+    }
+
+    // Register smoke verifier if configured
+    if (this.config.smoke) {
+      runner = runner.addVerifier(new SmokeVerifier(this.config.smoke));
+    }
+
+    this.runner = runner;
+  }
+
+  async onSessionStart(_context: SessionContext): Promise<void> {
+    // 1. Start dev server if configured
+    if (this.config.devServer) {
+      await this.processManager.start(this.config.devServer);
+    }
+
+    // Build verifier context
+    const verifierContext: VerifierContext = {
+      workspace: this.config.workspace,
+      ...(this.config.api ? { baseUrl: this.config.api.baseUrl } : {}),
+      ...(_context.sessionId ? { sessionId: _context.sessionId } : {}),
+    };
+
+    // 2. Run preflight + smoke via runner
+    const report = await this.runner.run(verifierContext);
+    this.lastReport = report;
+
+    // 3. Gate: throw if preflight or smoke failed
+    if (report.phases.preflight.status === "failed") {
+      const failedResults = report.phases.preflight.verifierResults.filter(
+        (r) => r.status === "failed" || r.status === "error",
+      );
+      const firstFailed = failedResults[0];
+      if (firstFailed) {
+        throw new SelfTestHealthCheckFailedError(
+          firstFailed.verifierName,
+          this.config.health?.checks[0]?.url ?? "unknown",
+        );
+      }
+    }
+
+    if (report.phases.smoke.status === "failed") {
+      const failedResults = report.phases.smoke.verifierResults.filter(
+        (r) => r.status === "failed" || r.status === "error",
+      );
+      const firstFailed = failedResults[0];
+      if (firstFailed) {
+        const failedAssertions = firstFailed.assertions.filter((a) => !a.passed);
+        throw new SelfTestVerificationFailedError(
+          firstFailed.verifierName,
+          failedAssertions,
+          report,
+        );
+      }
+    }
+
+    // 4. Create tools for on-demand verification
+    this.tools = createSelfTestTools(this.config, this.runner, this.lastReport);
+  }
+
+  async onSessionEnd(_context: SessionContext): Promise<void> {
+    // Stop dev server
+    await this.processManager.stop();
+    this.tools = null;
+  }
+
+  /**
+   * Get the tools for on-demand verification.
+   * Must be called after onSessionStart.
+   */
+  getTools(): SelfTestTools {
+    if (!this.tools) {
+      throw new Error("Tools not available. Call onSessionStart() first.");
+    }
+    return this.tools;
+  }
+
+  /**
+   * Get the report from the last session start run.
+   */
+  getLastReport(): SelfTestReport | null {
+    return this.lastReport;
+  }
+
+  /**
+   * Get the resolved config.
+   */
+  getConfig(): ResolvedSelfTestConfig {
+    return this.config;
+  }
+}

--- a/packages/self-test/src/process-manager.ts
+++ b/packages/self-test/src/process-manager.ts
@@ -1,0 +1,151 @@
+import { type ChildProcess, spawn } from "node:child_process";
+
+import type { DevServerConfig } from "./types.js";
+
+const SIGKILL_DELAY_MS = 5_000;
+const BACKOFF_BASE_MS = 100;
+const BACKOFF_CAP_MS = 2_000;
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+function getBackoffDelay(attempt: number): number {
+  return Math.min(BACKOFF_BASE_MS * 2 ** attempt, BACKOFF_CAP_MS);
+}
+
+async function pollUrl(url: string, timeoutMs: number, signal?: AbortSignal): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  let attempt = 0;
+
+  while (Date.now() < deadline) {
+    if (signal?.aborted) return false;
+
+    try {
+      const response = await fetch(url, { method: "GET", ...(signal ? { signal } : {}) });
+      if (response.ok) return true;
+    } catch {
+      // Server not ready yet
+    }
+
+    const delay = getBackoffDelay(attempt);
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) break;
+
+    await new Promise<void>((resolve) => {
+      const timer = setTimeout(resolve, Math.min(delay, remaining));
+      signal?.addEventListener(
+        "abort",
+        () => {
+          clearTimeout(timer);
+          resolve();
+        },
+        { once: true },
+      );
+    });
+    attempt++;
+  }
+
+  return false;
+}
+
+function killProcess(proc: ChildProcess): Promise<void> {
+  return new Promise<void>((resolve) => {
+    if (proc.exitCode !== null || proc.killed) {
+      resolve();
+      return;
+    }
+
+    const forceKill = setTimeout(() => {
+      if (proc.exitCode === null && !proc.killed) {
+        proc.kill("SIGKILL");
+      }
+      resolve();
+    }, SIGKILL_DELAY_MS);
+
+    proc.once("exit", () => {
+      clearTimeout(forceKill);
+      resolve();
+    });
+
+    proc.kill("SIGTERM");
+  });
+}
+
+/**
+ * ProcessManager — manages dev server process lifecycle.
+ *
+ * Spawns dev server processes, polls until healthy, and ensures
+ * cleanup on shutdown. Supports reusing existing processes.
+ */
+export class ProcessManager {
+  private readonly processes: Set<ChildProcess> = new Set();
+  private cleanupRegistered = false;
+
+  /**
+   * Start a dev server. If reuseExisting is true and the URL is already
+   * responding, returns immediately without spawning.
+   */
+  async start(config: DevServerConfig, signal?: AbortSignal): Promise<void> {
+    const timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    const reuseExisting = config.reuseExisting ?? true;
+
+    // Check if server is already running
+    if (reuseExisting) {
+      try {
+        const response = await fetch(config.url, { method: "GET" });
+        if (response.ok) return;
+      } catch {
+        // Not running yet, spawn it
+      }
+    }
+
+    // Spawn the process
+    const proc = spawn(config.command, {
+      shell: true,
+      detached: false,
+      env: { ...process.env, ...config.env },
+      stdio: "pipe",
+    });
+
+    this.processes.add(proc);
+    this.registerCleanup();
+
+    // Remove from tracked set when process exits
+    proc.once("exit", () => {
+      this.processes.delete(proc);
+    });
+
+    // Poll until healthy
+    const healthy = await pollUrl(config.url, timeoutMs, signal);
+
+    if (!healthy) {
+      // Kill the process if it didn't become healthy
+      await killProcess(proc);
+      this.processes.delete(proc);
+      throw new Error(`Dev server failed to become healthy at ${config.url} within ${timeoutMs}ms`);
+    }
+  }
+
+  /**
+   * Stop all tracked processes (SIGTERM → wait 5s → SIGKILL).
+   */
+  async stop(): Promise<void> {
+    const kills = [...this.processes].map(killProcess);
+    await Promise.all(kills);
+    this.processes.clear();
+  }
+
+  private registerCleanup(): void {
+    if (this.cleanupRegistered) return;
+    this.cleanupRegistered = true;
+
+    const cleanup = (): void => {
+      for (const proc of this.processes) {
+        if (proc.exitCode === null && !proc.killed) {
+          proc.kill("SIGTERM");
+        }
+      }
+    };
+
+    process.on("exit", cleanup);
+    process.on("SIGTERM", cleanup);
+  }
+}

--- a/packages/self-test/src/report-builder.ts
+++ b/packages/self-test/src/report-builder.ts
@@ -1,0 +1,113 @@
+import type { CTRFTest, PhaseResult, SelfTestReport, VerifierResult } from "./types.js";
+
+const PACKAGE_VERSION = "0.0.0";
+
+function verifierResultToStatus(status: VerifierResult["status"]): CTRFTest["status"] {
+  switch (status) {
+    case "passed":
+      return "passed";
+    case "failed":
+      return "failed";
+    case "skipped":
+      return "skipped";
+    case "error":
+      return "other";
+  }
+}
+
+function verifierResultToCTRFTest(result: VerifierResult): CTRFTest {
+  const screenshotExtra =
+    result.screenshots.length > 0
+      ? {
+          screenshots: result.screenshots.map((s) => ({
+            name: s.name,
+            base64: s.base64,
+            timestamp: s.timestamp,
+          })),
+        }
+      : {};
+
+  return {
+    name: result.verifierName,
+    status: verifierResultToStatus(result.status),
+    duration: result.durationMs,
+    ...(result.error ? { message: result.error.message, trace: result.error.stack } : {}),
+    ...(Object.keys(screenshotExtra).length > 0 ? { extra: screenshotExtra } : {}),
+  };
+}
+
+/**
+ * ReportBuilder — constructs CTRF-compatible JSON reports from phase results.
+ */
+export class ReportBuilder {
+  /**
+   * Build a full SelfTestReport from phase results.
+   */
+  static build(
+    preflight: PhaseResult,
+    smoke: PhaseResult,
+    verification: PhaseResult,
+    startTime: number,
+  ): SelfTestReport {
+    const stopTime = Date.now();
+
+    // Collect all verifier results across phases
+    const allResults = [
+      ...preflight.verifierResults,
+      ...smoke.verifierResults,
+      ...verification.verifierResults,
+    ];
+
+    // Convert to CTRF tests
+    const tests = allResults.map(verifierResultToCTRFTest);
+
+    // Count statuses
+    let passed = 0;
+    let failed = 0;
+    let skipped = 0;
+    let pending = 0;
+    let other = 0;
+
+    for (const test of tests) {
+      switch (test.status) {
+        case "passed":
+          passed++;
+          break;
+        case "failed":
+          failed++;
+          break;
+        case "skipped":
+          skipped++;
+          break;
+        case "pending":
+          pending++;
+          break;
+        case "other":
+          other++;
+          break;
+      }
+    }
+
+    return {
+      results: {
+        tool: { name: "@templar/self-test", version: PACKAGE_VERSION },
+        summary: {
+          tests: tests.length,
+          passed,
+          failed,
+          pending,
+          skipped,
+          other,
+          start: startTime,
+          stop: stopTime,
+        },
+        tests,
+      },
+      phases: {
+        preflight,
+        smoke,
+        verification,
+      },
+    };
+  }
+}

--- a/packages/self-test/src/runner.ts
+++ b/packages/self-test/src/runner.ts
@@ -1,0 +1,207 @@
+import { ReportBuilder } from "./report-builder.js";
+import type {
+  Phase,
+  PhaseResult,
+  SelfTestReport,
+  Verifier,
+  VerifierContext,
+  VerifierResult,
+} from "./types.js";
+
+const PHASES: readonly Phase[] = ["preflight", "smoke", "verification"];
+
+function makeSkippedPhase(): PhaseResult {
+  return { status: "skipped", durationMs: 0, verifierResults: [] };
+}
+
+async function runVerifier(verifier: Verifier, context: VerifierContext): Promise<VerifierResult> {
+  try {
+    if (verifier.setup) {
+      await verifier.setup(context);
+    }
+    return await verifier.run(context);
+  } catch (err) {
+    return {
+      verifierName: verifier.name,
+      phase: verifier.phase,
+      status: "error",
+      durationMs: 0,
+      assertions: [],
+      screenshots: [],
+      error: err instanceof Error ? err : new Error(String(err)),
+    };
+  } finally {
+    if (verifier.teardown) {
+      try {
+        await verifier.teardown(context);
+      } catch {
+        // Teardown errors are swallowed to avoid masking the real error
+      }
+    }
+  }
+}
+
+async function runPhaseSequential(
+  verifiers: readonly Verifier[],
+  context: VerifierContext,
+): Promise<PhaseResult> {
+  if (verifiers.length === 0) {
+    return makeSkippedPhase();
+  }
+
+  const start = Date.now();
+  const results: VerifierResult[] = [];
+
+  for (const verifier of verifiers) {
+    if (context.abortSignal?.aborted) {
+      results.push({
+        verifierName: verifier.name,
+        phase: verifier.phase,
+        status: "skipped",
+        durationMs: 0,
+        assertions: [],
+        screenshots: [],
+      });
+      continue;
+    }
+
+    const result = await runVerifier(verifier, context);
+    results.push(result);
+
+    // Sequential phases: stop on first failure/error
+    if (result.status === "failed" || result.status === "error") {
+      return {
+        status: "failed",
+        durationMs: Date.now() - start,
+        verifierResults: results,
+      };
+    }
+  }
+
+  return {
+    status: "passed",
+    durationMs: Date.now() - start,
+    verifierResults: results,
+  };
+}
+
+async function runPhaseParallel(
+  verifiers: readonly Verifier[],
+  context: VerifierContext,
+): Promise<PhaseResult> {
+  if (verifiers.length === 0) {
+    return makeSkippedPhase();
+  }
+
+  const start = Date.now();
+  const settled = await Promise.allSettled(verifiers.map((v) => runVerifier(v, context)));
+
+  const results: VerifierResult[] = settled.map((s, i) => {
+    if (s.status === "fulfilled") {
+      return s.value;
+    }
+    const verifier = verifiers[i]!;
+    return {
+      verifierName: verifier.name,
+      phase: verifier.phase,
+      status: "error" as const,
+      durationMs: 0,
+      assertions: [],
+      screenshots: [],
+      error: s.reason instanceof Error ? s.reason : new Error(String(s.reason)),
+    };
+  });
+
+  const anyFailed = results.some((r) => r.status === "failed" || r.status === "error");
+
+  return {
+    status: anyFailed ? "failed" : "passed",
+    durationMs: Date.now() - start,
+    verifierResults: results,
+  };
+}
+
+/**
+ * SelfTestRunner — phased pipeline orchestrator.
+ *
+ * Executes verifiers in three phases:
+ * 1. preflight (health checks) — sequential, gate
+ * 2. smoke (critical path) — sequential, gate
+ * 3. verification (api + browser) — parallel, collect all
+ *
+ * If preflight fails, smoke + verification are skipped.
+ * If smoke fails, verification is skipped.
+ */
+export class SelfTestRunner {
+  private readonly verifiers: Map<Phase, Verifier[]>;
+  private lastReport: SelfTestReport | null = null;
+
+  constructor() {
+    this.verifiers = new Map<Phase, Verifier[]>();
+    for (const phase of PHASES) {
+      this.verifiers.set(phase, []);
+    }
+  }
+
+  /**
+   * Add a verifier to the pipeline.
+   * Returns a new SelfTestRunner instance (immutable/fluent).
+   */
+  addVerifier(verifier: Verifier): SelfTestRunner {
+    const next = new SelfTestRunner();
+    for (const [phase, list] of this.verifiers) {
+      next.verifiers.set(phase, [...list]);
+    }
+    const phaseList = next.verifiers.get(verifier.phase);
+    if (phaseList) {
+      phaseList.push(verifier);
+    }
+    return next;
+  }
+
+  /**
+   * Run the full phased pipeline.
+   */
+  async run(context: VerifierContext): Promise<SelfTestReport> {
+    const startTime = Date.now();
+
+    // Phase 1: preflight (sequential, gate)
+    const preflight = await runPhaseSequential(this.verifiers.get("preflight") ?? [], context);
+
+    // If preflight fails, skip remaining
+    if (preflight.status === "failed") {
+      const report = ReportBuilder.build(
+        preflight,
+        makeSkippedPhase(),
+        makeSkippedPhase(),
+        startTime,
+      );
+      this.lastReport = report;
+      return report;
+    }
+
+    // Phase 2: smoke (sequential, gate)
+    const smoke = await runPhaseSequential(this.verifiers.get("smoke") ?? [], context);
+
+    // If smoke fails, skip verification
+    if (smoke.status === "failed") {
+      const report = ReportBuilder.build(preflight, smoke, makeSkippedPhase(), startTime);
+      this.lastReport = report;
+      return report;
+    }
+
+    // Phase 3: verification (parallel, collect all)
+    const verification = await runPhaseParallel(this.verifiers.get("verification") ?? [], context);
+
+    const report = ReportBuilder.build(preflight, smoke, verification, startTime);
+    this.lastReport = report;
+    return report;
+  }
+
+  /**
+   * Get the report from the last run.
+   */
+  getLastReport(): SelfTestReport | null {
+    return this.lastReport;
+  }
+}

--- a/packages/self-test/src/tools.ts
+++ b/packages/self-test/src/tools.ts
@@ -1,0 +1,116 @@
+import type { SelfTestRunner } from "./runner.js";
+import type {
+  ApiTestConfig,
+  BrowserStep,
+  PhaseResult,
+  ResolvedSelfTestConfig,
+  SelfTestReport,
+  SelfTestTools,
+  SmokeStep,
+  VerifierContext,
+  VerifierResult,
+} from "./types.js";
+import { ApiVerifier } from "./verifiers/api.js";
+import { BrowserVerifier } from "./verifiers/browser.js";
+import { HealthVerifier } from "./verifiers/health.js";
+import { SmokeVerifier } from "./verifiers/smoke.js";
+
+/**
+ * Create SelfTestTools — factory function for agent-callable verification tools.
+ *
+ * These tools allow the agent to trigger verification on demand during
+ * a session, outside the automatic middleware gates.
+ */
+export function createSelfTestTools(
+  config: ResolvedSelfTestConfig,
+  runner: SelfTestRunner,
+  initialReport: SelfTestReport | null,
+): SelfTestTools {
+  let lastReport: SelfTestReport | null = initialReport;
+
+  function makeContext(): VerifierContext {
+    return {
+      workspace: config.workspace,
+      ...(config.api ? { baseUrl: config.api.baseUrl } : {}),
+    };
+  }
+
+  async function runPreflight(): Promise<PhaseResult> {
+    if (!config.health) {
+      return { status: "skipped", durationMs: 0, verifierResults: [] };
+    }
+    const verifier = new HealthVerifier(config.health);
+    const context = makeContext();
+    const start = Date.now();
+
+    try {
+      const result = await verifier.run(context);
+      return {
+        status: result.status === "passed" ? "passed" : "failed",
+        durationMs: Date.now() - start,
+        verifierResults: [result],
+      };
+    } catch (err) {
+      return {
+        status: "failed",
+        durationMs: Date.now() - start,
+        verifierResults: [
+          {
+            verifierName: verifier.name,
+            phase: "preflight",
+            status: "error",
+            durationMs: Date.now() - start,
+            assertions: [],
+            screenshots: [],
+            error: err instanceof Error ? err : new Error(String(err)),
+          },
+        ],
+      };
+    }
+  }
+
+  async function runSmoke(steps: readonly SmokeStep[]): Promise<PhaseResult> {
+    const verifier = new SmokeVerifier({ steps });
+    const context = makeContext();
+    const start = Date.now();
+
+    const result = await verifier.run(context);
+    return {
+      status: result.status === "passed" ? "passed" : "failed",
+      durationMs: Date.now() - start,
+      verifierResults: [result],
+    };
+  }
+
+  async function runApiTest(testConfig: ApiTestConfig): Promise<VerifierResult> {
+    const verifier = new ApiVerifier(testConfig);
+    const context = makeContext();
+    return verifier.run(context);
+  }
+
+  async function runBrowserTest(steps: readonly BrowserStep[]): Promise<VerifierResult> {
+    const verifier = new BrowserVerifier(steps, config.browser);
+    const context = makeContext();
+    return verifier.run(context);
+  }
+
+  async function runFullSuite(): Promise<SelfTestReport> {
+    const context = makeContext();
+    const report = await runner.run(context);
+    lastReport = report;
+    return report;
+  }
+
+  function getLastReport(): SelfTestReport | null {
+    return lastReport;
+  }
+
+  return {
+    runPreflight,
+    runSmoke,
+    runApiTest,
+    runBrowserTest,
+    runFullSuite,
+    getLastReport,
+  };
+}

--- a/packages/self-test/src/types.ts
+++ b/packages/self-test/src/types.ts
@@ -1,0 +1,250 @@
+/**
+ * @templar/self-test — Type definitions
+ *
+ * All interfaces for the pluggable self-verification system.
+ */
+
+// ============================================================================
+// PHASE TYPES
+// ============================================================================
+
+/** Verification pipeline phases, executed in order */
+export type Phase = "preflight" | "smoke" | "verification";
+
+// ============================================================================
+// VERIFIER STRATEGY
+// ============================================================================
+
+/** Context passed to each verifier */
+export interface VerifierContext {
+  readonly workspace: string;
+  readonly baseUrl?: string;
+  readonly sessionId?: string;
+  readonly abortSignal?: AbortSignal;
+}
+
+/** Result of a single assertion within a verifier */
+export interface AssertionResult {
+  readonly name: string;
+  readonly passed: boolean;
+  readonly message?: string;
+  readonly expected?: unknown;
+  readonly actual?: unknown;
+}
+
+/** Captured screenshot */
+export interface ScreenshotCapture {
+  readonly name: string;
+  readonly base64: string;
+  readonly timestamp: string;
+  readonly viewport: { readonly width: number; readonly height: number };
+}
+
+/** Result produced by a single verifier run */
+export interface VerifierResult {
+  readonly verifierName: string;
+  readonly phase: Phase;
+  readonly status: "passed" | "failed" | "skipped" | "error";
+  readonly durationMs: number;
+  readonly assertions: readonly AssertionResult[];
+  readonly screenshots: readonly ScreenshotCapture[];
+  readonly error?: Error;
+}
+
+/** Strategy pattern: a single verification step */
+export interface Verifier {
+  readonly name: string;
+  readonly phase: Phase;
+  run(context: VerifierContext): Promise<VerifierResult>;
+  setup?(context: VerifierContext): Promise<void>;
+  teardown?(context: VerifierContext): Promise<void>;
+}
+
+// ============================================================================
+// CONFIGURATION
+// ============================================================================
+
+/** Dev server management config */
+export interface DevServerConfig {
+  readonly command: string;
+  readonly url: string;
+  readonly timeoutMs?: number;
+  readonly env?: Record<string, string>;
+  readonly reuseExisting?: boolean;
+}
+
+/** Individual health check */
+export interface HealthCheck {
+  readonly name: string;
+  readonly url: string;
+  readonly expectedStatus?: number;
+  readonly timeoutMs?: number;
+}
+
+/** Health check config */
+export interface HealthConfig {
+  readonly checks: readonly HealthCheck[];
+  readonly timeoutMs?: number;
+}
+
+/** Smoke test step */
+export interface SmokeStep {
+  readonly action: "navigate" | "waitFor" | "assertText" | "assertStatus";
+  readonly url?: string;
+  readonly selector?: string;
+  readonly text?: string;
+  readonly expectedStatus?: number;
+}
+
+/** Smoke test config */
+export interface SmokeConfig {
+  readonly steps: readonly SmokeStep[];
+  readonly timeoutMs?: number;
+}
+
+/** Browser automation config */
+export interface BrowserConfig {
+  readonly timeoutMs?: number;
+  readonly viewport?: { readonly width: number; readonly height: number };
+  readonly screenshotOnFailure?: boolean;
+}
+
+/** API test config */
+export interface ApiConfig {
+  readonly baseUrl: string;
+  readonly timeoutMs?: number;
+}
+
+/** Screenshot storage config */
+export interface ScreenshotConfig {
+  readonly storage: "base64" | "disk";
+  readonly directory?: string;
+  readonly onPass?: "always" | "never";
+  readonly onFail?: "always" | "never";
+}
+
+/** Report output config */
+export interface ReportConfig {
+  readonly outputPath?: string;
+  readonly includeScreenshots?: boolean;
+}
+
+/** Top-level config for @templar/self-test */
+export interface SelfTestConfig {
+  readonly workspace: string;
+  readonly devServer?: DevServerConfig;
+  readonly health?: HealthConfig;
+  readonly smoke?: SmokeConfig;
+  readonly browser?: BrowserConfig;
+  readonly api?: ApiConfig;
+  readonly screenshots?: ScreenshotConfig;
+  readonly report?: ReportConfig;
+  readonly maxTotalDurationMs?: number;
+}
+
+/** Resolved config with all defaults applied */
+export interface ResolvedSelfTestConfig {
+  readonly workspace: string;
+  readonly devServer?: DevServerConfig;
+  readonly health?: HealthConfig;
+  readonly smoke?: SmokeConfig;
+  readonly browser: Required<BrowserConfig>;
+  readonly api?: ApiConfig;
+  readonly screenshots: Required<ScreenshotConfig>;
+  readonly report: Required<ReportConfig>;
+  readonly maxTotalDurationMs: number;
+}
+
+// ============================================================================
+// API TEST TYPES
+// ============================================================================
+
+/** A single API test step */
+export interface ApiTestStep {
+  readonly method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+  readonly path: string;
+  readonly body?: unknown;
+  readonly headers?: Record<string, string>;
+  readonly expectedStatus?: number;
+  readonly expectedBody?: unknown;
+}
+
+/** Config for an API test run */
+export interface ApiTestConfig {
+  readonly baseUrl: string;
+  readonly steps: readonly ApiTestStep[];
+  readonly timeoutMs?: number;
+}
+
+// ============================================================================
+// BROWSER TEST TYPES
+// ============================================================================
+
+/** A single browser automation step */
+export interface BrowserStep {
+  readonly action: "navigate" | "fill" | "click" | "waitFor" | "screenshot" | "assertText";
+  readonly url?: string;
+  readonly selector?: string;
+  readonly value?: string;
+  readonly text?: string;
+  readonly screenshotName?: string;
+}
+
+// ============================================================================
+// CTRF REPORT FORMAT
+// ============================================================================
+
+/** A single test in the CTRF report */
+export interface CTRFTest {
+  readonly name: string;
+  readonly status: "passed" | "failed" | "skipped" | "pending" | "other";
+  readonly duration: number;
+  readonly message?: string;
+  readonly trace?: string;
+  readonly extra?: Record<string, unknown>;
+}
+
+/** Result of a single pipeline phase */
+export interface PhaseResult {
+  readonly status: "passed" | "failed" | "skipped";
+  readonly durationMs: number;
+  readonly verifierResults: readonly VerifierResult[];
+}
+
+/** Full self-test CTRF-compatible report */
+export interface SelfTestReport {
+  readonly results: {
+    readonly tool: { readonly name: "@templar/self-test"; readonly version: string };
+    readonly summary: {
+      readonly tests: number;
+      readonly passed: number;
+      readonly failed: number;
+      readonly pending: number;
+      readonly skipped: number;
+      readonly other: number;
+      readonly start: number;
+      readonly stop: number;
+    };
+    readonly tests: readonly CTRFTest[];
+    readonly environment?: Record<string, unknown>;
+  };
+  readonly phases: {
+    readonly preflight: PhaseResult;
+    readonly smoke: PhaseResult;
+    readonly verification: PhaseResult;
+  };
+}
+
+// ============================================================================
+// TOOLS INTERFACE
+// ============================================================================
+
+/** Tools exposed to the agent for on-demand verification */
+export interface SelfTestTools {
+  runPreflight(): Promise<PhaseResult>;
+  runSmoke(steps: readonly SmokeStep[]): Promise<PhaseResult>;
+  runApiTest(config: ApiTestConfig): Promise<VerifierResult>;
+  runBrowserTest(steps: readonly BrowserStep[]): Promise<VerifierResult>;
+  runFullSuite(): Promise<SelfTestReport>;
+  getLastReport(): SelfTestReport | null;
+}

--- a/packages/self-test/src/validation.ts
+++ b/packages/self-test/src/validation.ts
@@ -1,0 +1,208 @@
+import { z } from "zod";
+import type { ResolvedSelfTestConfig, SelfTestConfig } from "./types.js";
+
+// ============================================================================
+// CONFIG DEFAULTS
+// ============================================================================
+
+const CONFIG_DEFAULTS = {
+  maxTotalDurationMs: 300_000,
+  devServer: {
+    timeoutMs: 30_000,
+    reuseExisting: true,
+  },
+  health: {
+    timeoutMs: 5_000,
+    expectedStatus: 200,
+  },
+  smoke: {
+    timeoutMs: 30_000,
+  },
+  browser: {
+    timeoutMs: 120_000,
+    viewport: { width: 1280, height: 720 },
+    screenshotOnFailure: true,
+  },
+  api: {
+    timeoutMs: 30_000,
+  },
+  screenshots: {
+    storage: "base64" as const,
+    directory: ".self-test/screenshots",
+    onPass: "never" as const,
+    onFail: "always" as const,
+  },
+  report: {
+    outputPath: ".self-test/reports",
+    includeScreenshots: true,
+  },
+} as const;
+
+// ============================================================================
+// SCHEMAS
+// ============================================================================
+
+const devServerConfigSchema = z.object({
+  command: z.string().min(1, { message: "devServer.command must not be empty" }),
+  url: z.string().url({ message: "devServer.url must be a valid URL" }),
+  timeoutMs: z
+    .number()
+    .int()
+    .positive({ message: "devServer.timeoutMs must be a positive integer" })
+    .max(120_000, { message: "devServer.timeoutMs must not exceed 120000ms" })
+    .optional(),
+  env: z.record(z.string()).optional(),
+  reuseExisting: z.boolean().optional(),
+});
+
+const healthCheckSchema = z.object({
+  name: z.string().min(1, { message: "health check name must not be empty" }),
+  url: z.string().url({ message: "health check url must be a valid URL" }),
+  expectedStatus: z.number().int().min(100).max(599).optional(),
+  timeoutMs: z
+    .number()
+    .int()
+    .positive()
+    .max(60_000, { message: "health check timeoutMs must not exceed 60000ms" })
+    .optional(),
+});
+
+const healthConfigSchema = z.object({
+  checks: z.array(healthCheckSchema).min(1, {
+    message: "health config must have at least one check",
+  }),
+  timeoutMs: z
+    .number()
+    .int()
+    .positive()
+    .max(60_000, { message: "health.timeoutMs must not exceed 60000ms" })
+    .optional(),
+});
+
+const smokeStepSchema = z.object({
+  action: z.enum(["navigate", "waitFor", "assertText", "assertStatus"]),
+  url: z.string().optional(),
+  selector: z.string().optional(),
+  text: z.string().optional(),
+  expectedStatus: z.number().int().min(100).max(599).optional(),
+});
+
+const smokeConfigSchema = z.object({
+  steps: z.array(smokeStepSchema).min(1, {
+    message: "smoke config must have at least one step",
+  }),
+  timeoutMs: z
+    .number()
+    .int()
+    .positive()
+    .max(120_000, { message: "smoke.timeoutMs must not exceed 120000ms" })
+    .optional(),
+});
+
+const browserConfigSchema = z.object({
+  timeoutMs: z
+    .number()
+    .int()
+    .positive()
+    .max(300_000, { message: "browser.timeoutMs must not exceed 300000ms" })
+    .optional(),
+  viewport: z
+    .object({
+      width: z.number().int().positive(),
+      height: z.number().int().positive(),
+    })
+    .optional(),
+  screenshotOnFailure: z.boolean().optional(),
+});
+
+const apiConfigSchema = z.object({
+  baseUrl: z.string().url({ message: "api.baseUrl must be a valid URL" }),
+  timeoutMs: z
+    .number()
+    .int()
+    .positive()
+    .max(120_000, { message: "api.timeoutMs must not exceed 120000ms" })
+    .optional(),
+});
+
+const screenshotConfigSchema = z.object({
+  storage: z.enum(["base64", "disk"]).optional(),
+  directory: z.string().min(1).optional(),
+  onPass: z.enum(["always", "never"]).optional(),
+  onFail: z.enum(["always", "never"]).optional(),
+});
+
+const reportConfigSchema = z.object({
+  outputPath: z.string().min(1).optional(),
+  includeScreenshots: z.boolean().optional(),
+});
+
+const selfTestConfigSchema = z.object({
+  workspace: z.string().min(1, { message: "workspace must not be empty" }),
+  devServer: devServerConfigSchema.optional(),
+  health: healthConfigSchema.optional(),
+  smoke: smokeConfigSchema.optional(),
+  browser: browserConfigSchema.optional(),
+  api: apiConfigSchema.optional(),
+  screenshots: screenshotConfigSchema.optional(),
+  report: reportConfigSchema.optional(),
+  maxTotalDurationMs: z
+    .number()
+    .int()
+    .positive({ message: "maxTotalDurationMs must be a positive integer" })
+    .max(600_000, { message: "maxTotalDurationMs must not exceed 600000ms (10 min)" })
+    .optional(),
+});
+
+// ============================================================================
+// EXPORTS
+// ============================================================================
+
+/**
+ * Validate a SelfTestConfig, returning the parsed result or throwing ZodError.
+ */
+export function validateSelfTestConfig(config: unknown): SelfTestConfig {
+  return selfTestConfigSchema.parse(config) as SelfTestConfig;
+}
+
+/**
+ * Resolve config by applying defaults to validated config.
+ */
+export function resolveSelfTestConfig(config: SelfTestConfig): ResolvedSelfTestConfig {
+  return {
+    workspace: config.workspace,
+    ...(config.devServer
+      ? {
+          devServer: {
+            command: config.devServer.command,
+            url: config.devServer.url,
+            timeoutMs: config.devServer.timeoutMs ?? CONFIG_DEFAULTS.devServer.timeoutMs,
+            env: config.devServer.env ?? {},
+            reuseExisting:
+              config.devServer.reuseExisting ?? CONFIG_DEFAULTS.devServer.reuseExisting,
+          },
+        }
+      : {}),
+    ...(config.health ? { health: config.health } : {}),
+    ...(config.smoke ? { smoke: config.smoke } : {}),
+    browser: {
+      timeoutMs: config.browser?.timeoutMs ?? CONFIG_DEFAULTS.browser.timeoutMs,
+      viewport: config.browser?.viewport ?? CONFIG_DEFAULTS.browser.viewport,
+      screenshotOnFailure:
+        config.browser?.screenshotOnFailure ?? CONFIG_DEFAULTS.browser.screenshotOnFailure,
+    },
+    ...(config.api ? { api: config.api } : {}),
+    screenshots: {
+      storage: config.screenshots?.storage ?? CONFIG_DEFAULTS.screenshots.storage,
+      directory: config.screenshots?.directory ?? CONFIG_DEFAULTS.screenshots.directory,
+      onPass: config.screenshots?.onPass ?? CONFIG_DEFAULTS.screenshots.onPass,
+      onFail: config.screenshots?.onFail ?? CONFIG_DEFAULTS.screenshots.onFail,
+    },
+    report: {
+      outputPath: config.report?.outputPath ?? CONFIG_DEFAULTS.report.outputPath,
+      includeScreenshots:
+        config.report?.includeScreenshots ?? CONFIG_DEFAULTS.report.includeScreenshots,
+    },
+    maxTotalDurationMs: config.maxTotalDurationMs ?? CONFIG_DEFAULTS.maxTotalDurationMs,
+  };
+}

--- a/packages/self-test/src/verifiers/api.ts
+++ b/packages/self-test/src/verifiers/api.ts
@@ -1,0 +1,135 @@
+import type {
+  ApiTestConfig,
+  ApiTestStep,
+  AssertionResult,
+  Verifier,
+  VerifierContext,
+  VerifierResult,
+} from "../types.js";
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+async function executeStep(
+  step: ApiTestStep,
+  baseUrl: string,
+  signal?: AbortSignal,
+): Promise<AssertionResult> {
+  const url = `${baseUrl}${step.path}`;
+  const stepName = `${step.method} ${step.path}`;
+
+  try {
+    const response = await fetch(url, {
+      method: step.method,
+      headers: {
+        "Content-Type": "application/json",
+        ...step.headers,
+      },
+      ...(step.body !== undefined ? { body: JSON.stringify(step.body) } : {}),
+      ...(signal ? { signal } : {}),
+    });
+
+    // Check status code
+    if (step.expectedStatus !== undefined && response.status !== step.expectedStatus) {
+      return {
+        name: stepName,
+        passed: false,
+        message: `Expected status ${step.expectedStatus}, got ${response.status}`,
+        expected: step.expectedStatus,
+        actual: response.status,
+      };
+    }
+
+    // Check response body
+    if (step.expectedBody !== undefined) {
+      const body: unknown = await response.json();
+      const expected = JSON.stringify(step.expectedBody);
+      const actual = JSON.stringify(body);
+      if (expected !== actual) {
+        return {
+          name: stepName,
+          passed: false,
+          message: `Response body mismatch`,
+          expected: step.expectedBody,
+          actual: body,
+        };
+      }
+    }
+
+    return {
+      name: stepName,
+      passed: true,
+      ...(step.expectedStatus !== undefined
+        ? { expected: step.expectedStatus, actual: response.status }
+        : {}),
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      name: stepName,
+      passed: false,
+      message: `Request failed: ${message}`,
+    };
+  }
+}
+
+/**
+ * ApiVerifier — fetch-based API endpoint testing.
+ *
+ * Runs as part of the verification phase. Tests API endpoints
+ * sequentially with status and body assertions.
+ */
+export class ApiVerifier implements Verifier {
+  readonly name: string;
+  readonly phase = "verification" as const;
+  private readonly config: ApiTestConfig;
+
+  constructor(config: ApiTestConfig, name?: string) {
+    this.config = config;
+    this.name = name ?? "api";
+  }
+
+  async run(context: VerifierContext): Promise<VerifierResult> {
+    const start = Date.now();
+    const timeoutMs = this.config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    const assertions: AssertionResult[] = [];
+    const baseUrl = this.config.baseUrl;
+
+    // Create a timeout controller that composes with the context signal
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+    // If context has an abort signal, chain it
+    const contextAbortHandler = (): void => controller.abort();
+    context.abortSignal?.addEventListener("abort", contextAbortHandler, { once: true });
+
+    try {
+      for (const step of this.config.steps) {
+        if (controller.signal.aborted) {
+          assertions.push({
+            name: `${step.method} ${step.path}`,
+            passed: false,
+            message: "Aborted or timed out",
+          });
+          continue;
+        }
+
+        const result = await executeStep(step, baseUrl, controller.signal);
+        assertions.push(result);
+      }
+    } finally {
+      clearTimeout(timer);
+      context.abortSignal?.removeEventListener("abort", contextAbortHandler);
+    }
+
+    const allPassed = assertions.every((a) => a.passed);
+
+    return {
+      verifierName: this.name,
+      phase: this.phase,
+      status: allPassed ? "passed" : "failed",
+      durationMs: Date.now() - start,
+      assertions,
+      screenshots: [],
+    };
+  }
+}

--- a/packages/self-test/src/verifiers/browser.ts
+++ b/packages/self-test/src/verifiers/browser.ts
@@ -1,0 +1,220 @@
+import { SelfTestConfigurationInvalidError } from "@templar/errors";
+import type {
+  AssertionResult,
+  BrowserConfig,
+  BrowserStep,
+  ScreenshotCapture,
+  Verifier,
+  VerifierContext,
+  VerifierResult,
+} from "../types.js";
+
+const _DEFAULT_TIMEOUT_MS = 120_000;
+const DEFAULT_VIEWPORT = { width: 1280, height: 720 };
+
+/** Playwright types — minimal structural interface to avoid hard dep */
+interface PlaywrightBrowser {
+  newContext(opts?: { viewport?: { width: number; height: number } }): Promise<PlaywrightContext>;
+  close(): Promise<void>;
+}
+
+interface PlaywrightContext {
+  newPage(): Promise<PlaywrightPage>;
+  close(): Promise<void>;
+}
+
+interface PlaywrightPage {
+  goto(url: string): Promise<unknown>;
+  fill(selector: string, value: string): Promise<void>;
+  click(selector: string): Promise<void>;
+  waitForSelector(selector: string, opts?: { timeout?: number }): Promise<unknown>;
+  textContent(selector: string): Promise<string | null>;
+  screenshot(opts?: { type?: "png"; fullPage?: boolean }): Promise<Buffer>;
+  close(): Promise<void>;
+}
+
+interface PlaywrightModule {
+  chromium: {
+    launch(opts?: { headless?: boolean }): Promise<PlaywrightBrowser>;
+  };
+}
+
+async function loadPlaywright(): Promise<PlaywrightModule> {
+  try {
+    return (await import("playwright")) as unknown as PlaywrightModule;
+  } catch {
+    throw new SelfTestConfigurationInvalidError([
+      "playwright is not installed. Install it with: pnpm add -D playwright",
+    ]);
+  }
+}
+
+async function captureScreenshot(
+  page: PlaywrightPage,
+  name: string,
+  viewport: { width: number; height: number },
+): Promise<ScreenshotCapture> {
+  const buffer = await page.screenshot({ type: "png", fullPage: false });
+  return {
+    name,
+    base64: buffer.toString("base64"),
+    timestamp: new Date().toISOString(),
+    viewport,
+  };
+}
+
+async function executeStep(step: BrowserStep, page: PlaywrightPage): Promise<AssertionResult> {
+  const stepName = `${step.action}${step.selector ? ` ${step.selector}` : ""}${step.url ? ` ${step.url}` : ""}`;
+
+  try {
+    switch (step.action) {
+      case "navigate": {
+        if (!step.url) {
+          return { name: stepName, passed: false, message: "navigate requires url" };
+        }
+        await page.goto(step.url);
+        return { name: stepName, passed: true };
+      }
+      case "fill": {
+        if (!step.selector || step.value === undefined) {
+          return { name: stepName, passed: false, message: "fill requires selector and value" };
+        }
+        await page.fill(step.selector, step.value);
+        return { name: stepName, passed: true };
+      }
+      case "click": {
+        if (!step.selector) {
+          return { name: stepName, passed: false, message: "click requires selector" };
+        }
+        await page.click(step.selector);
+        return { name: stepName, passed: true };
+      }
+      case "waitFor": {
+        if (!step.selector) {
+          return { name: stepName, passed: false, message: "waitFor requires selector" };
+        }
+        await page.waitForSelector(step.selector, { timeout: 10_000 });
+        return { name: stepName, passed: true };
+      }
+      case "screenshot": {
+        // Screenshot is always "passed" — it's a capture, not an assertion
+        return { name: stepName, passed: true };
+      }
+      case "assertText": {
+        if (!step.selector || !step.text) {
+          return {
+            name: stepName,
+            passed: false,
+            message: "assertText requires selector and text",
+          };
+        }
+        const content = await page.textContent(step.selector);
+        const found = content?.includes(step.text) ?? false;
+        return {
+          name: stepName,
+          passed: found,
+          ...(found
+            ? {}
+            : { message: `Text "${step.text}" not found`, expected: step.text, actual: content }),
+        };
+      }
+      default: {
+        return {
+          name: stepName,
+          passed: false,
+          message: `Unknown action: ${step.action as string}`,
+        };
+      }
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { name: stepName, passed: false, message };
+  }
+}
+
+/**
+ * BrowserVerifier — Playwright-based browser automation testing.
+ *
+ * Runs as part of the verification phase. Requires playwright as
+ * an optional peer dependency. Creates a fresh browser context per run.
+ */
+export class BrowserVerifier implements Verifier {
+  readonly name: string;
+  readonly phase = "verification" as const;
+  private readonly steps: readonly BrowserStep[];
+  private readonly browserConfig: BrowserConfig;
+
+  constructor(steps: readonly BrowserStep[], config?: BrowserConfig, name?: string) {
+    this.steps = steps;
+    this.browserConfig = config ?? {};
+    this.name = name ?? "browser";
+  }
+
+  async run(context: VerifierContext): Promise<VerifierResult> {
+    const start = Date.now();
+    const viewport = this.browserConfig.viewport ?? DEFAULT_VIEWPORT;
+    const screenshotOnFailure = this.browserConfig.screenshotOnFailure ?? true;
+    const assertions: AssertionResult[] = [];
+    const screenshots: ScreenshotCapture[] = [];
+
+    const pw = await loadPlaywright();
+    const browser = await pw.chromium.launch({ headless: true });
+
+    try {
+      const browserContext = await browser.newContext({ viewport });
+      const page = await browserContext.newPage();
+
+      try {
+        for (const step of this.steps) {
+          if (context.abortSignal?.aborted) {
+            assertions.push({
+              name: `${step.action}`,
+              passed: false,
+              message: "Aborted",
+            });
+            continue;
+          }
+
+          const result = await executeStep(step, page);
+          assertions.push(result);
+
+          // Handle screenshot step
+          if (step.action === "screenshot") {
+            const capture = await captureScreenshot(
+              page,
+              step.screenshotName ?? `screenshot-${screenshots.length}`,
+              viewport,
+            );
+            screenshots.push(capture);
+          }
+
+          // Capture screenshot on failure if configured
+          if (!result.passed && screenshotOnFailure) {
+            const capture = await captureScreenshot(
+              page,
+              `failure-${assertions.length - 1}`,
+              viewport,
+            );
+            screenshots.push(capture);
+          }
+        }
+      } finally {
+        await page.close();
+        await browserContext.close();
+      }
+    } finally {
+      await browser.close();
+    }
+
+    const allPassed = assertions.every((a) => a.passed);
+
+    return {
+      verifierName: this.name,
+      phase: this.phase,
+      status: allPassed ? "passed" : "failed",
+      durationMs: Date.now() - start,
+      assertions,
+      screenshots,
+    };
+  }
+}

--- a/packages/self-test/src/verifiers/health.ts
+++ b/packages/self-test/src/verifiers/health.ts
@@ -1,0 +1,169 @@
+import { SelfTestHealthCheckFailedError, SelfTestTimeoutError } from "@templar/errors";
+import type {
+  AssertionResult,
+  HealthCheck,
+  HealthConfig,
+  Verifier,
+  VerifierContext,
+  VerifierResult,
+} from "../types.js";
+
+const BACKOFF_BASE_MS = 100;
+const BACKOFF_CAP_MS = 2_000;
+const JITTER_MS = 50;
+const DEFAULT_TIMEOUT_MS = 5_000;
+const DEFAULT_EXPECTED_STATUS = 200;
+
+function getBackoffDelay(attempt: number): number {
+  const exponential = Math.min(BACKOFF_BASE_MS * 2 ** attempt, BACKOFF_CAP_MS);
+  const jitter = (Math.random() - 0.5) * 2 * JITTER_MS;
+  return Math.max(0, exponential + jitter);
+}
+
+async function pollCheck(
+  check: HealthCheck,
+  timeoutMs: number,
+  signal?: AbortSignal,
+): Promise<AssertionResult> {
+  const expectedStatus = check.expectedStatus ?? DEFAULT_EXPECTED_STATUS;
+  const deadline = Date.now() + timeoutMs;
+  let attempt = 0;
+  let lastStatus: number | undefined;
+  let lastError: string | undefined;
+
+  while (Date.now() < deadline) {
+    if (signal?.aborted) {
+      return {
+        name: check.name,
+        passed: false,
+        message: "Aborted",
+      };
+    }
+
+    try {
+      const response = await fetch(check.url, {
+        method: "GET",
+        ...(signal ? { signal } : {}),
+      });
+      lastStatus = response.status;
+
+      if (response.status === expectedStatus) {
+        return {
+          name: check.name,
+          passed: true,
+          expected: expectedStatus,
+          actual: response.status,
+        };
+      }
+      lastError = `Expected status ${expectedStatus}, got ${response.status}`;
+    } catch (err) {
+      lastError = err instanceof Error ? err.message : String(err);
+      if (signal?.aborted) {
+        return {
+          name: check.name,
+          passed: false,
+          message: "Aborted",
+        };
+      }
+    }
+
+    const delay = getBackoffDelay(attempt);
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) break;
+
+    await new Promise<void>((resolve) => {
+      const timer = setTimeout(resolve, Math.min(delay, remaining));
+      signal?.addEventListener(
+        "abort",
+        () => {
+          clearTimeout(timer);
+          resolve();
+        },
+        { once: true },
+      );
+    });
+
+    attempt++;
+  }
+
+  return {
+    name: check.name,
+    passed: false,
+    message: lastError ?? "Timed out waiting for health check",
+    expected: expectedStatus,
+    ...(lastStatus !== undefined ? { actual: lastStatus } : {}),
+  };
+}
+
+/**
+ * HealthVerifier — polls health check URLs with exponential backoff.
+ *
+ * Runs as part of the preflight phase. All checks must pass for
+ * the phase to succeed.
+ */
+export class HealthVerifier implements Verifier {
+  readonly name: string;
+  readonly phase = "preflight" as const;
+  private readonly config: HealthConfig;
+
+  constructor(config: HealthConfig, name?: string) {
+    this.config = config;
+    this.name = name ?? "health";
+  }
+
+  async run(context: VerifierContext): Promise<VerifierResult> {
+    const start = Date.now();
+    const timeoutMs = this.config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    const assertions: AssertionResult[] = [];
+
+    for (const check of this.config.checks) {
+      if (context.abortSignal?.aborted) {
+        assertions.push({ name: check.name, passed: false, message: "Aborted" });
+        continue;
+      }
+
+      const checkTimeout = check.timeoutMs ?? timeoutMs;
+      const result = await pollCheck(check, checkTimeout, context.abortSignal);
+      assertions.push(result);
+
+      // If a check fails, throw immediately for preflight gate
+      if (!result.passed) {
+        const elapsed = Date.now() - start;
+        const failedResult: VerifierResult = {
+          verifierName: this.name,
+          phase: this.phase,
+          status: "failed",
+          durationMs: elapsed,
+          assertions,
+          screenshots: [],
+        };
+
+        if (result.message === "Aborted") {
+          return failedResult;
+        }
+
+        // Check if this was a timeout
+        if (elapsed >= checkTimeout) {
+          throw new SelfTestTimeoutError(this.name, checkTimeout, elapsed);
+        }
+
+        throw new SelfTestHealthCheckFailedError(
+          check.name,
+          check.url,
+          typeof result.actual === "number" ? result.actual : undefined,
+        );
+      }
+    }
+
+    const allPassed = assertions.every((a) => a.passed);
+
+    return {
+      verifierName: this.name,
+      phase: this.phase,
+      status: allPassed ? "passed" : "failed",
+      durationMs: Date.now() - start,
+      assertions,
+      screenshots: [],
+    };
+  }
+}

--- a/packages/self-test/src/verifiers/smoke.ts
+++ b/packages/self-test/src/verifiers/smoke.ts
@@ -1,0 +1,145 @@
+import type {
+  AssertionResult,
+  SmokeConfig,
+  SmokeStep,
+  Verifier,
+  VerifierContext,
+  VerifierResult,
+} from "../types.js";
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+async function executeSmokeStep(step: SmokeStep, signal?: AbortSignal): Promise<AssertionResult> {
+  const stepName = `${step.action}${step.url ? ` ${step.url}` : ""}${step.selector ? ` ${step.selector}` : ""}`;
+
+  try {
+    switch (step.action) {
+      case "navigate": {
+        if (!step.url) {
+          return { name: stepName, passed: false, message: "navigate requires url" };
+        }
+        // Smoke-level navigate: just check the URL is reachable via fetch
+        const response = await fetch(step.url, { method: "GET", ...(signal ? { signal } : {}) });
+        const ok = response.status >= 200 && response.status < 400;
+        return {
+          name: stepName,
+          passed: ok,
+          ...(ok
+            ? {}
+            : {
+                message: `Navigate returned status ${response.status}`,
+                expected: "2xx/3xx",
+                actual: response.status,
+              }),
+        };
+      }
+      case "assertStatus": {
+        if (!step.url) {
+          return { name: stepName, passed: false, message: "assertStatus requires url" };
+        }
+        const expectedStatus = step.expectedStatus ?? 200;
+        const response = await fetch(step.url, { method: "GET", ...(signal ? { signal } : {}) });
+        const passed = response.status === expectedStatus;
+        return {
+          name: stepName,
+          passed,
+          expected: expectedStatus,
+          actual: response.status,
+          ...(passed ? {} : { message: `Expected ${expectedStatus}, got ${response.status}` }),
+        };
+      }
+      case "assertText": {
+        if (!step.url || !step.text) {
+          return { name: stepName, passed: false, message: "assertText requires url and text" };
+        }
+        const response = await fetch(step.url, { method: "GET", ...(signal ? { signal } : {}) });
+        const body = await response.text();
+        const found = body.includes(step.text);
+        return {
+          name: stepName,
+          passed: found,
+          ...(found
+            ? {}
+            : { message: `Text "${step.text}" not found in response body`, expected: step.text }),
+        };
+      }
+      case "waitFor": {
+        // In smoke mode without a browser, waitFor is a no-op success
+        // (it would require Playwright). We skip it gracefully.
+        return { name: stepName, passed: true, message: "waitFor skipped (no browser)" };
+      }
+      default: {
+        return {
+          name: stepName,
+          passed: false,
+          message: `Unknown smoke action: ${step.action as string}`,
+        };
+      }
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { name: stepName, passed: false, message };
+  }
+}
+
+/**
+ * SmokeVerifier — critical-path validation via fetch-based checks.
+ *
+ * Runs as part of the smoke phase. Orchestrates basic health + navigation
+ * checks using native fetch (no Playwright required). Falls back gracefully
+ * for browser-only actions like waitFor.
+ */
+export class SmokeVerifier implements Verifier {
+  readonly name: string;
+  readonly phase = "smoke" as const;
+  private readonly config: SmokeConfig;
+
+  constructor(config: SmokeConfig, name?: string) {
+    this.config = config;
+    this.name = name ?? "smoke";
+  }
+
+  async run(context: VerifierContext): Promise<VerifierResult> {
+    const start = Date.now();
+    const assertions: AssertionResult[] = [];
+
+    // Create a timeout controller
+    const timeoutMs = this.config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+    // Chain context abort signal
+    const contextAbortHandler = (): void => controller.abort();
+    context.abortSignal?.addEventListener("abort", contextAbortHandler, { once: true });
+
+    try {
+      for (const step of this.config.steps) {
+        if (controller.signal.aborted) {
+          assertions.push({
+            name: `${step.action}`,
+            passed: false,
+            message: "Aborted or timed out",
+          });
+          continue;
+        }
+
+        const result = await executeSmokeStep(step, controller.signal);
+        assertions.push(result);
+      }
+    } finally {
+      clearTimeout(timer);
+      context.abortSignal?.removeEventListener("abort", contextAbortHandler);
+    }
+
+    const allPassed = assertions.every((a) => a.passed);
+
+    return {
+      verifierName: this.name,
+      phase: this.phase,
+      status: allPassed ? "passed" : "failed",
+      durationMs: Date.now() - start,
+      assertions,
+      screenshots: [],
+    };
+  }
+}

--- a/packages/self-test/tsconfig.json
+++ b/packages/self-test/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": ["node"]
+  },
+  "include": ["src"],
+  "references": [{ "path": "../core" }, { "path": "../errors" }]
+}

--- a/packages/self-test/tsup.config.ts
+++ b/packages/self-test/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: { compilerOptions: { composite: false } },
+  clean: true,
+  treeshake: true,
+  target: "node22",
+});

--- a/packages/self-test/vitest.config.ts
+++ b/packages/self-test/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: "v8",
+      include: ["src/**/*.ts"],
+      exclude: ["src/**/__tests__/**", "src/**/index.ts", "src/types.ts"],
+      thresholds: {
+        branches: 80,
+        functions: 80,
+        lines: 80,
+        statements: 80,
+      },
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -520,6 +520,34 @@ importers:
         specifier: ^4.0.0
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(yaml@2.8.2)
 
+  packages/self-test:
+    dependencies:
+      '@templar/core':
+        specifier: workspace:*
+        version: link:../core
+      '@templar/errors':
+        specifier: workspace:*
+        version: link:../errors
+      zod:
+        specifier: ^3.24.0
+        version: 3.25.76
+    devDependencies:
+      '@templar/long-running':
+        specifier: workspace:*
+        version: link:../long-running
+      '@templar/test-utils':
+        specifier: workspace:*
+        version: link:../test-utils
+      '@types/node':
+        specifier: ^25.0.0
+        version: 25.2.2
+      playwright:
+        specifier: ^1.50.0
+        version: 1.58.2
+      vitest:
+        specifier: ^4.0.0
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.2.2)(yaml@2.8.2)
+
   packages/skills:
     dependencies:
       gray-matter:
@@ -2667,6 +2695,11 @@ packages:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -3326,6 +3359,16 @@ packages:
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  playwright-core@1.58.2:
+    resolution: {integrity: sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.58.2:
+    resolution: {integrity: sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss-load-config@6.0.1:
     resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
@@ -6245,6 +6288,9 @@ snapshots:
 
   fresh@2.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -6906,6 +6952,14 @@ snapshots:
       confbox: 0.1.8
       mlly: 1.8.0
       pathe: 2.0.3
+
+  playwright-core@1.58.2: {}
+
+  playwright@1.58.2:
+    dependencies:
+      playwright-core: 1.58.2
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss-load-config@6.0.1(postcss@8.5.6)(yaml@2.8.2):
     dependencies:


### PR DESCRIPTION
## Summary

- Adds new `@templar/self-test` package providing pluggable self-verification for AI agents — health checks, smoke tests, API testing, and browser automation integrated into the session lifecycle via `TemplarMiddleware`
- Implements phased pipeline (preflight → smoke → verification) with dual-mode execution: `SelfTestMiddleware` for automatic gates and `SelfTestTools` for agent-callable on-demand verification
- Adds 4 error types to `@templar/errors` catalog (`SELF_TEST_HEALTH_CHECK_FAILED`, `SELF_TEST_VERIFICATION_FAILED`, `SELF_TEST_TIMEOUT`, `SELF_TEST_CONFIGURATION_INVALID`)

## What's included

### Core verifiers
- **HealthVerifier**: Fetch-based polling with exponential backoff (100ms→2s cap, ±50ms jitter)
- **ApiVerifier**: Native fetch endpoint testing with status + body assertions
- **BrowserVerifier**: Lazy Playwright import, screenshot capture on failure, fresh context per run
- **SmokeVerifier**: Lightweight fetch-based checks (no Playwright dependency)

### Infrastructure
- **SelfTestRunner**: Immutable/fluent pipeline orchestrator — preflight (sequential gate) → smoke (sequential gate) → verification (parallel collect-all)
- **ProcessManager**: Dev server lifecycle management with graceful SIGTERM→5s→SIGKILL shutdown
- **ReportBuilder**: CTRF-compatible JSON report generation
- **Zod config validation**: Full schema with defaults resolution

### Integration
- **SelfTestMiddleware**: `TemplarMiddleware` implementation — gates session start on preflight+smoke
- **SelfTestTools**: Factory producing `runPreflight`, `runSmoke`, `runApiTest`, `runBrowserTest`, `runFullSuite`, `getLastReport`
- Integration tests verifying full pipeline lifecycle and long-running bridge

## Test plan

- [x] 115 unit/integration tests in `@templar/self-test` (12 test files)
- [x] 20 error tests in `@templar/errors` for self-test error classes
- [x] Coverage: 90.78% stmts, 80.13% branch, 87.5% funcs, 92.25% lines
- [x] Full monorepo build (28 packages), typecheck (36 tasks), all tests pass
- [ ] CI pipeline validates on push

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)