### PR TITLE
feat(discord): add webhook-based per-message identity

### DIFF
--- a/packages/channel-discord/src/__tests__/unit/capabilities.test.ts
+++ b/packages/channel-discord/src/__tests__/unit/capabilities.test.ts
@@ -75,4 +75,11 @@ describe("DISCORD_CAPABILITIES", () => {
   it("does not include readReceipts", () => {
     expect(DISCORD_CAPABILITIES.readReceipts).toBeUndefined();
   });
+
+  it("supports per-message identity via webhooks", () => {
+    expect(DISCORD_CAPABILITIES.identity).toEqual({
+      supported: true,
+      perMessage: true,
+    });
+  });
 });

--- a/packages/channel-discord/src/__tests__/unit/webhook-manager.test.ts
+++ b/packages/channel-discord/src/__tests__/unit/webhook-manager.test.ts
@@ -1,0 +1,353 @@
+import { ChannelSendError } from "@templar/errors";
+import { describe, expect, it, vi } from "vitest";
+import {
+  type DiscordWebhookInfo,
+  sanitizeWebhookUsername,
+  WebhookManager,
+  type WebhookManagerDeps,
+} from "../../webhook-manager.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createMockWebhook(overrides: Partial<DiscordWebhookInfo> = {}): DiscordWebhookInfo {
+  return {
+    id: overrides.id ?? "wh-001",
+    token: overrides.token ?? "wh-token-001",
+    owner: overrides.owner ?? { id: "bot-001" },
+    name: overrides.name ?? "Templar",
+    send: vi.fn().mockResolvedValue({ id: "sent-001" }),
+    ...overrides,
+  };
+}
+
+function createMockDeps(overrides: Partial<WebhookManagerDeps> = {}): WebhookManagerDeps {
+  return {
+    fetchWebhooks: vi.fn().mockResolvedValue([]),
+    createWebhook: vi.fn().mockResolvedValue(createMockWebhook()),
+    botUserId: "bot-001",
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// sanitizeWebhookUsername
+// ---------------------------------------------------------------------------
+
+describe("sanitizeWebhookUsername", () => {
+  it("strips 'clyde' substring (case-insensitive)", () => {
+    expect(sanitizeWebhookUsername("MyClydeBot")).toBe("MyBot");
+    expect(sanitizeWebhookUsername("CLYDE helper")).toBe("helper");
+  });
+
+  it("strips 'discord' substring (case-insensitive)", () => {
+    expect(sanitizeWebhookUsername("DiscordHelper")).toBe("Helper");
+    expect(sanitizeWebhookUsername("My DISCORD Bot")).toBe("My  Bot");
+  });
+
+  it("truncates to 80 characters", () => {
+    const longName = "A".repeat(100);
+    expect(sanitizeWebhookUsername(longName)).toHaveLength(80);
+  });
+
+  it("returns fallback 'Agent' when empty after sanitization", () => {
+    expect(sanitizeWebhookUsername("clyde")).toBe("Agent");
+    expect(sanitizeWebhookUsername("discord")).toBe("Agent");
+    expect(sanitizeWebhookUsername("   ")).toBe("Agent");
+  });
+
+  it("preserves valid names unchanged", () => {
+    expect(sanitizeWebhookUsername("Research Bot")).toBe("Research Bot");
+    expect(sanitizeWebhookUsername("Alex")).toBe("Alex");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// WebhookManager
+// ---------------------------------------------------------------------------
+
+describe("WebhookManager", () => {
+  // -----------------------------------------------------------------------
+  // Cache hit
+  // -----------------------------------------------------------------------
+
+  describe("cache hit", () => {
+    it("returns cached webhook on second call without API call", async () => {
+      const deps = createMockDeps();
+      const manager = new WebhookManager(deps);
+
+      const first = await manager.getOrCreate("ch-001");
+      const second = await manager.getOrCreate("ch-001");
+
+      expect(first).toBe(second);
+      expect(deps.fetchWebhooks).toHaveBeenCalledTimes(1);
+    });
+
+    it("caches different webhooks per channel", async () => {
+      const webhook1 = createMockWebhook({ id: "wh-001" });
+      const webhook2 = createMockWebhook({ id: "wh-002" });
+
+      const deps = createMockDeps({
+        createWebhook: vi.fn().mockResolvedValueOnce(webhook1).mockResolvedValueOnce(webhook2),
+      });
+      const manager = new WebhookManager(deps);
+
+      const first = await manager.getOrCreate("ch-001");
+      const second = await manager.getOrCreate("ch-002");
+
+      expect(first).not.toBe(second);
+      expect(deps.fetchWebhooks).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Cache miss → find existing
+  // -----------------------------------------------------------------------
+
+  describe("cache miss — find existing webhook", () => {
+    it("finds webhook owned by bot from existing webhooks", async () => {
+      const ownedWebhook = createMockWebhook({ owner: { id: "bot-001" }, token: "valid" });
+      const deps = createMockDeps({
+        fetchWebhooks: vi.fn().mockResolvedValue([ownedWebhook]),
+      });
+      const manager = new WebhookManager(deps);
+
+      const result = await manager.getOrCreate("ch-001");
+
+      expect(result).toBe(ownedWebhook);
+      expect(deps.createWebhook).not.toHaveBeenCalled();
+    });
+
+    it("filters out webhooks owned by other users", async () => {
+      const otherWebhook = createMockWebhook({ owner: { id: "other-user" } });
+      const ownedWebhook = createMockWebhook({ owner: { id: "bot-001" }, token: "valid" });
+      const deps = createMockDeps({
+        fetchWebhooks: vi.fn().mockResolvedValue([otherWebhook, ownedWebhook]),
+      });
+      const manager = new WebhookManager(deps);
+
+      const result = await manager.getOrCreate("ch-001");
+
+      expect(result).toBe(ownedWebhook);
+    });
+
+    it("skips webhooks with null token (channel follower type)", async () => {
+      const followerWebhook = createMockWebhook({
+        owner: { id: "bot-001" },
+        token: null,
+      });
+      const newWebhook = createMockWebhook({ id: "wh-new" });
+      const deps = createMockDeps({
+        fetchWebhooks: vi.fn().mockResolvedValue([followerWebhook]),
+        createWebhook: vi.fn().mockResolvedValue(newWebhook),
+      });
+      const manager = new WebhookManager(deps);
+
+      const result = await manager.getOrCreate("ch-001");
+
+      expect(result).toBe(newWebhook);
+      expect(deps.createWebhook).toHaveBeenCalled();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Cache miss → create new
+  // -----------------------------------------------------------------------
+
+  describe("cache miss — create new webhook", () => {
+    it("creates webhook when none exist for channel", async () => {
+      const newWebhook = createMockWebhook();
+      const deps = createMockDeps({
+        fetchWebhooks: vi.fn().mockResolvedValue([]),
+        createWebhook: vi.fn().mockResolvedValue(newWebhook),
+      });
+      const manager = new WebhookManager(deps);
+
+      const result = await manager.getOrCreate("ch-001");
+
+      expect(result).toBe(newWebhook);
+      expect(deps.createWebhook).toHaveBeenCalledWith("ch-001", "Templar");
+    });
+
+    it("uses custom webhookName when provided", async () => {
+      const deps = createMockDeps();
+      const manager = new WebhookManager(deps, "Research Bot");
+
+      await manager.getOrCreate("ch-001");
+
+      expect(deps.createWebhook).toHaveBeenCalledWith("ch-001", "Research Bot");
+    });
+
+    it("caches newly created webhook", async () => {
+      const newWebhook = createMockWebhook();
+      const deps = createMockDeps({
+        createWebhook: vi.fn().mockResolvedValue(newWebhook),
+      });
+      const manager = new WebhookManager(deps);
+
+      await manager.getOrCreate("ch-001");
+      const second = await manager.getOrCreate("ch-001");
+
+      expect(second).toBe(newWebhook);
+      expect(deps.createWebhook).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Cache invalidation
+  // -----------------------------------------------------------------------
+
+  describe("cache invalidation", () => {
+    it("invalidate() removes specific channel entry", async () => {
+      const deps = createMockDeps();
+      const manager = new WebhookManager(deps);
+
+      await manager.getOrCreate("ch-001");
+      manager.invalidate("ch-001");
+      await manager.getOrCreate("ch-001");
+
+      expect(deps.fetchWebhooks).toHaveBeenCalledTimes(2);
+    });
+
+    it("clear() empties entire cache", async () => {
+      const deps = createMockDeps();
+      const manager = new WebhookManager(deps);
+
+      await manager.getOrCreate("ch-001");
+      await manager.getOrCreate("ch-002");
+      manager.clear();
+      await manager.getOrCreate("ch-001");
+
+      expect(deps.fetchWebhooks).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Error: permission denied
+  // -----------------------------------------------------------------------
+
+  describe("error — permission denied", () => {
+    it("throws ChannelSendError when fetchWebhooks lacks permission", async () => {
+      const permError = Object.assign(new Error("Missing Permissions"), { code: 50013 });
+      const deps = createMockDeps({
+        fetchWebhooks: vi.fn().mockRejectedValue(permError),
+      });
+      const manager = new WebhookManager(deps);
+
+      await expect(manager.getOrCreate("ch-001")).rejects.toThrow(ChannelSendError);
+      await expect(manager.getOrCreate("ch-001")).rejects.toThrow(/MANAGE_WEBHOOKS/);
+    });
+
+    it("throws ChannelSendError when createWebhook lacks permission", async () => {
+      const permError = Object.assign(new Error("Missing Permissions"), { code: 50013 });
+      const deps = createMockDeps({
+        createWebhook: vi.fn().mockRejectedValue(permError),
+      });
+      const manager = new WebhookManager(deps);
+
+      await expect(manager.getOrCreate("ch-001")).rejects.toThrow(ChannelSendError);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Error: webhook limit (30007)
+  // -----------------------------------------------------------------------
+
+  describe("error — webhook limit", () => {
+    it("throws ChannelSendError with descriptive message for max webhooks", async () => {
+      const limitError = Object.assign(new Error("Max webhooks"), { code: 30007 });
+      const deps = createMockDeps({
+        createWebhook: vi.fn().mockRejectedValue(limitError),
+      });
+      const manager = new WebhookManager(deps);
+
+      await expect(manager.getOrCreate("ch-001")).rejects.toThrow(/maximum webhook limit/i);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Error: 10015 Unknown Webhook
+  // -----------------------------------------------------------------------
+
+  describe("error — 10015 Unknown Webhook", () => {
+    it("throws ChannelSendError with descriptive message", async () => {
+      const unknownError = Object.assign(new Error("Unknown Webhook"), { code: 10015 });
+      const deps = createMockDeps({
+        fetchWebhooks: vi.fn().mockRejectedValue(unknownError),
+      });
+      const manager = new WebhookManager(deps);
+
+      await expect(manager.getOrCreate("ch-001")).rejects.toThrow(/no longer exists/);
+    });
+
+    it("preserves original error as cause", async () => {
+      const unknownError = Object.assign(new Error("Unknown Webhook"), { code: 10015 });
+      const deps = createMockDeps({
+        fetchWebhooks: vi.fn().mockRejectedValue(unknownError),
+      });
+      const manager = new WebhookManager(deps);
+
+      try {
+        await manager.getOrCreate("ch-001");
+        expect.unreachable("Should have thrown");
+      } catch (err) {
+        expect(err).toBeInstanceOf(ChannelSendError);
+        expect((err as ChannelSendError).cause).toBe(unknownError);
+      }
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Concurrency dedup
+  // -----------------------------------------------------------------------
+
+  describe("concurrency dedup", () => {
+    it("deduplicates concurrent getOrCreate for same channel", async () => {
+      const newWebhook = createMockWebhook();
+      const deps = createMockDeps({
+        createWebhook: vi.fn().mockResolvedValue(newWebhook),
+      });
+      const manager = new WebhookManager(deps);
+
+      // Fire two concurrent requests for the same channel
+      const [result1, result2] = await Promise.all([
+        manager.getOrCreate("ch-001"),
+        manager.getOrCreate("ch-001"),
+      ]);
+
+      expect(result1).toBe(result2);
+      expect(deps.fetchWebhooks).toHaveBeenCalledTimes(1);
+    });
+
+    it("allows parallel execution for different channels", async () => {
+      let resolveFirst!: (value: DiscordWebhookInfo) => void;
+      const firstPromise = new Promise<DiscordWebhookInfo>((resolve) => {
+        resolveFirst = resolve;
+      });
+
+      const webhook1 = createMockWebhook({ id: "wh-001" });
+      const webhook2 = createMockWebhook({ id: "wh-002" });
+
+      const deps = createMockDeps({
+        fetchWebhooks: vi.fn().mockResolvedValue([]),
+        createWebhook: vi.fn().mockReturnValueOnce(firstPromise).mockResolvedValueOnce(webhook2),
+      });
+      const manager = new WebhookManager(deps);
+
+      const p1 = manager.getOrCreate("ch-001");
+      const p2 = manager.getOrCreate("ch-002");
+
+      // Channel 2 should resolve independently
+      const result2 = await p2;
+      expect(result2).toBe(webhook2);
+
+      // Now resolve channel 1
+      resolveFirst(webhook1);
+      const result1 = await p1;
+      expect(result1).toBe(webhook1);
+
+      expect(deps.fetchWebhooks).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/packages/channel-discord/src/__tests__/unit/webhook-renderer.test.ts
+++ b/packages/channel-discord/src/__tests__/unit/webhook-renderer.test.ts
@@ -1,0 +1,243 @@
+import type { OutboundMessage } from "@templar/core";
+import { ChannelSendError } from "@templar/errors";
+import { describe, expect, it, vi } from "vitest";
+import { renderWebhookMessage } from "../../renderer.js";
+import type { WebhookSendable } from "../../webhook-manager.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createMockWebhook(): {
+  webhook: WebhookSendable;
+  calls: Record<string, unknown>[];
+} {
+  const calls: Record<string, unknown>[] = [];
+  const webhook: WebhookSendable = {
+    send: vi.fn(async (payload: Record<string, unknown>) => {
+      calls.push(payload);
+      return { id: "sent-wh-001" };
+    }),
+  };
+  return { webhook, calls };
+}
+
+// ---------------------------------------------------------------------------
+// renderWebhookMessage
+// ---------------------------------------------------------------------------
+
+describe("renderWebhookMessage", () => {
+  // -----------------------------------------------------------------------
+  // Identity applied
+  // -----------------------------------------------------------------------
+
+  describe("identity applied", () => {
+    it("sets username from identity.name", async () => {
+      const { webhook, calls } = createMockWebhook();
+      const msg: OutboundMessage = {
+        channelId: "ch-001",
+        blocks: [{ type: "text", content: "Hello" }],
+        identity: { name: "Research Bot" },
+      };
+
+      await renderWebhookMessage(msg, webhook);
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0]).toHaveProperty("username", "Research Bot");
+      expect(calls[0]).not.toHaveProperty("avatarURL");
+    });
+
+    it("sets avatarURL from identity.avatar", async () => {
+      const { webhook, calls } = createMockWebhook();
+      const msg: OutboundMessage = {
+        channelId: "ch-001",
+        blocks: [{ type: "text", content: "Hello" }],
+        identity: { avatar: "https://example.com/avatar.png" },
+      };
+
+      await renderWebhookMessage(msg, webhook);
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0]).toHaveProperty("avatarURL", "https://example.com/avatar.png");
+      expect(calls[0]).not.toHaveProperty("username");
+    });
+
+    it("sets both username and avatarURL together", async () => {
+      const { webhook, calls } = createMockWebhook();
+      const msg: OutboundMessage = {
+        channelId: "ch-001",
+        blocks: [{ type: "text", content: "Hello" }],
+        identity: { name: "Alex", avatar: "https://example.com/alex.png" },
+      };
+
+      await renderWebhookMessage(msg, webhook);
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0]).toHaveProperty("username", "Alex");
+      expect(calls[0]).toHaveProperty("avatarURL", "https://example.com/alex.png");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Identity partial
+  // -----------------------------------------------------------------------
+
+  describe("identity partial", () => {
+    it("handles identity with only name (no avatar)", async () => {
+      const { webhook, calls } = createMockWebhook();
+      const msg: OutboundMessage = {
+        channelId: "ch-001",
+        blocks: [{ type: "text", content: "Hello" }],
+        identity: { name: "Bot" },
+      };
+
+      await renderWebhookMessage(msg, webhook);
+
+      expect(calls[0]).toHaveProperty("username", "Bot");
+      expect(calls[0]).not.toHaveProperty("avatarURL");
+    });
+
+    it("handles identity with only avatar (no name)", async () => {
+      const { webhook, calls } = createMockWebhook();
+      const msg: OutboundMessage = {
+        channelId: "ch-001",
+        blocks: [{ type: "text", content: "Hello" }],
+        identity: { avatar: "https://example.com/pic.png" },
+      };
+
+      await renderWebhookMessage(msg, webhook);
+
+      expect(calls[0]).not.toHaveProperty("username");
+      expect(calls[0]).toHaveProperty("avatarURL", "https://example.com/pic.png");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Identity absent
+  // -----------------------------------------------------------------------
+
+  describe("identity absent", () => {
+    it("omits username and avatarURL when no identity", async () => {
+      const { webhook, calls } = createMockWebhook();
+      const msg: OutboundMessage = {
+        channelId: "ch-001",
+        blocks: [{ type: "text", content: "Hello" }],
+      };
+
+      await renderWebhookMessage(msg, webhook);
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0]).not.toHaveProperty("username");
+      expect(calls[0]).not.toHaveProperty("avatarURL");
+      expect(calls[0]).toHaveProperty("content", "Hello");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Thread support
+  // -----------------------------------------------------------------------
+
+  describe("thread support", () => {
+    it("passes threadId to webhook payload", async () => {
+      const { webhook, calls } = createMockWebhook();
+      const msg: OutboundMessage = {
+        channelId: "ch-001",
+        threadId: "thread-001",
+        blocks: [{ type: "text", content: "In thread" }],
+        identity: { name: "Bot" },
+      };
+
+      await renderWebhookMessage(msg, webhook);
+
+      expect(calls[0]).toHaveProperty("threadId", "thread-001");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Batched send (split text)
+  // -----------------------------------------------------------------------
+
+  describe("batched send", () => {
+    it("applies identity to ALL chunks of split text", async () => {
+      const { webhook, calls } = createMockWebhook();
+      const longText = "a".repeat(4500);
+      const msg: OutboundMessage = {
+        channelId: "ch-001",
+        blocks: [{ type: "text", content: longText }],
+        identity: { name: "Bot", avatar: "https://example.com/a.png" },
+      };
+
+      await renderWebhookMessage(msg, webhook);
+
+      expect(calls.length).toBeGreaterThan(1);
+      for (const call of calls) {
+        expect(call).toHaveProperty("username", "Bot");
+        expect(call).toHaveProperty("avatarURL", "https://example.com/a.png");
+      }
+    });
+
+    it("attaches files and components only to the last chunk", async () => {
+      const { webhook, calls } = createMockWebhook();
+      const longText = "b".repeat(3000);
+      const msg: OutboundMessage = {
+        channelId: "ch-001",
+        blocks: [
+          { type: "text", content: longText },
+          { type: "image", url: "https://example.com/img.png" },
+        ],
+        identity: { name: "Bot" },
+      };
+
+      await renderWebhookMessage(msg, webhook);
+
+      expect(calls.length).toBeGreaterThan(1);
+
+      // First N-1 calls: no files
+      for (let i = 0; i < calls.length - 1; i++) {
+        expect(calls[i]).not.toHaveProperty("files");
+      }
+
+      // Last call: has files
+      const lastCall = calls.at(-1) as Record<string, unknown>;
+      expect(lastCall.files).toBeDefined();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Error handling
+  // -----------------------------------------------------------------------
+
+  describe("error handling", () => {
+    it("wraps webhook send error in ChannelSendError", async () => {
+      const webhook: WebhookSendable = {
+        send: vi.fn().mockRejectedValue(new Error("Network error")),
+      };
+      const msg: OutboundMessage = {
+        channelId: "ch-001",
+        blocks: [{ type: "text", content: "Hello" }],
+        identity: { name: "Bot" },
+      };
+
+      await expect(renderWebhookMessage(msg, webhook)).rejects.toThrow(ChannelSendError);
+    });
+
+    it("preserves original error as cause", async () => {
+      const originalError = new Error("Webhook API error");
+      const webhook: WebhookSendable = {
+        send: vi.fn().mockRejectedValue(originalError),
+      };
+      const msg: OutboundMessage = {
+        channelId: "ch-001",
+        blocks: [{ type: "text", content: "Hello" }],
+      };
+
+      try {
+        await renderWebhookMessage(msg, webhook);
+        expect.unreachable("Should have thrown");
+      } catch (err) {
+        expect(err).toBeInstanceOf(ChannelSendError);
+        expect((err as ChannelSendError).cause).toBe(originalError);
+      }
+    });
+  });
+});

--- a/packages/channel-discord/src/adapter.ts
+++ b/packages/channel-discord/src/adapter.ts
@@ -5,18 +5,24 @@ import { ChannelLoadError, ChannelSendError } from "@templar/errors";
 import { DISCORD_CAPABILITIES } from "./capabilities.js";
 import { type DiscordConfig, type IntentName, parseDiscordConfig } from "./config.js";
 import { normalizeMessage } from "./normalizer.js";
-import { type DiscordSendable, renderMessage } from "./renderer.js";
+import { type DiscordSendable, renderMessage, renderWebhookMessage } from "./renderer.js";
+import { type DiscordWebhookInfo, WebhookManager } from "./webhook-manager.js";
 
 // ---------------------------------------------------------------------------
 // Minimal discord.js types (avoid hard coupling to discord.js imports)
 // ---------------------------------------------------------------------------
+
+interface DiscordTextChannel extends DiscordSendable {
+  fetchWebhooks(): Promise<ReadonlyMap<string, DiscordWebhookInfo>>;
+  createWebhook(options: { name: string }): Promise<DiscordWebhookInfo>;
+}
 
 interface DiscordClient {
   login(token: string): Promise<string>;
   destroy(): void;
   on(event: string, handler: (...args: never[]) => void): void;
   channels: {
-    fetch(id: string): Promise<DiscordSendable | null>;
+    fetch(id: string): Promise<(DiscordSendable & Partial<DiscordTextChannel>) | null>;
   };
   user: { id: string } | null;
 }
@@ -86,6 +92,30 @@ function buildSweeperOptions(
 }
 
 // ---------------------------------------------------------------------------
+// Discord API error code extraction
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract the numeric Discord API error code from an error or its cause chain.
+ * ChannelSendError.code is the Templar catalog code (string like "CHANNEL_SEND_ERROR"),
+ * so we check the cause chain for the numeric Discord API code.
+ */
+function extractDiscordErrorCode(error: unknown): number | undefined {
+  // Direct numeric code (raw Discord error, not wrapped)
+  const directCode = (error as Record<string, unknown> | null)?.code;
+  if (typeof directCode === "number") return directCode;
+
+  // Check cause chain (ChannelSendError wraps the original Discord error as cause)
+  const cause = (error as { cause?: unknown })?.cause;
+  if (cause) {
+    const causeCode = (cause as Record<string, unknown>)?.code;
+    if (typeof causeCode === "number") return causeCode;
+  }
+
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
 // DiscordChannel adapter
 // ---------------------------------------------------------------------------
 
@@ -105,6 +135,7 @@ type DiscordMessage = never;
 export class DiscordChannel extends BaseChannelAdapter<DiscordMessage, DiscordSendable> {
   private readonly config: DiscordConfig;
   private client: DiscordClient | undefined;
+  private webhookManager: WebhookManager | undefined;
 
   constructor(rawConfig: Readonly<Record<string, unknown>>) {
     const config = parseDiscordConfig(rawConfig);
@@ -131,6 +162,11 @@ export class DiscordChannel extends BaseChannelAdapter<DiscordMessage, DiscordSe
       });
 
       await this.client.login(this.config.token);
+
+      // Initialize WebhookManager for identity-aware sends
+      if (this.client.user) {
+        this.webhookManager = this.createWebhookManager(this.client);
+      }
     } catch (error) {
       if (error instanceof ChannelLoadError) throw error;
       throw new ChannelLoadError(
@@ -141,6 +177,10 @@ export class DiscordChannel extends BaseChannelAdapter<DiscordMessage, DiscordSe
   }
 
   protected async doDisconnect(): Promise<void> {
+    if (this.webhookManager) {
+      this.webhookManager.clear();
+      this.webhookManager = undefined;
+    }
     if (!this.client) return;
     this.client.destroy();
     this.client = undefined;
@@ -151,6 +191,14 @@ export class DiscordChannel extends BaseChannelAdapter<DiscordMessage, DiscordSe
       throw new ChannelSendError("discord", "Client not initialized");
     }
 
+    // Identity-triggered webhook path (Decision #1A)
+    if (message.identity && this.webhookManager) {
+      const sent = await this.trySendViaWebhook(message);
+      if (sent) return;
+      // Fallback: continue to Gateway send below
+    }
+
+    // Gateway send path (default)
     const channel = await this.client.channels.fetch(message.channelId);
     if (!channel) {
       throw new ChannelSendError(
@@ -190,5 +238,76 @@ export class DiscordChannel extends BaseChannelAdapter<DiscordMessage, DiscordSe
    */
   getDiscordClient(): DiscordClient | undefined {
     return this.client;
+  }
+
+  // -------------------------------------------------------------------------
+  // Webhook identity helpers
+  // -------------------------------------------------------------------------
+
+  /**
+   * Create a WebhookManager wired to the Discord client.
+   * Protected for testing — subclasses can inject a mock manager.
+   */
+  protected createWebhookManager(client: DiscordClient): WebhookManager {
+    const botUserId = client.user?.id ?? "";
+    return new WebhookManager(
+      {
+        fetchWebhooks: async (channelId: string) => {
+          const channel = await client.channels.fetch(channelId);
+          if (!channel?.fetchWebhooks) return [];
+          const webhooks = await channel.fetchWebhooks();
+          return [...webhooks.values()];
+        },
+        createWebhook: async (channelId: string, name: string) => {
+          const channel = await client.channels.fetch(channelId);
+          if (!channel?.createWebhook) {
+            throw new ChannelSendError(
+              "discord",
+              `Channel ${channelId} does not support webhooks.`,
+            );
+          }
+          return channel.createWebhook({ name });
+        },
+        botUserId,
+      },
+      this.config.webhookName,
+    );
+  }
+
+  /**
+   * Attempt to send via webhook with identity. Returns true if successful,
+   * false if the caller should fall back to Gateway send.
+   */
+  private async trySendViaWebhook(message: OutboundMessage): Promise<boolean> {
+    if (!this.webhookManager) return false;
+
+    try {
+      const webhook = await this.webhookManager.getOrCreate(message.channelId);
+      await renderWebhookMessage(message, webhook);
+      return true;
+    } catch (error) {
+      // 10015 Unknown Webhook — invalidate cache and retry once.
+      // ChannelSendError.code is the Templar error code (string), not the Discord
+      // API code (number). Extract the numeric Discord code from the cause chain.
+      const discordCode = extractDiscordErrorCode(error);
+
+      if (discordCode === 10015) {
+        this.webhookManager.invalidate(message.channelId);
+        try {
+          const webhook = await this.webhookManager.getOrCreate(message.channelId);
+          await renderWebhookMessage(message, webhook);
+          return true;
+        } catch {
+          // Retry failed — fall through to Gateway
+        }
+      }
+
+      // 30007 (max webhooks) or permission errors — fall back to Gateway
+      console.warn(
+        `[DiscordChannel] Webhook send failed for channel ${message.channelId}, falling back to Gateway.`,
+        error instanceof Error ? error.message : String(error),
+      );
+      return false;
+    }
   }
 }

--- a/packages/channel-discord/src/capabilities.ts
+++ b/packages/channel-discord/src/capabilities.ts
@@ -25,4 +25,5 @@ export const DISCORD_CAPABILITIES: ChannelCapabilities = {
   threads: { supported: true, nested: false },
   reactions: { supported: true },
   groups: { supported: true, maxMembers: 500_000 },
+  identity: { supported: true, perMessage: true },
 } as const;

--- a/packages/channel-discord/src/config.ts
+++ b/packages/channel-discord/src/config.ts
@@ -70,6 +70,8 @@ export interface DiscordConfig {
   readonly intents: readonly IntentName[];
   readonly sweepers: SweepersConfig;
   readonly presence: PresenceConfig | undefined;
+  /** Name used when auto-creating webhooks for identity sends. Defaults to "Templar". */
+  readonly webhookName: string | undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -119,6 +121,7 @@ const DiscordConfigSchema = z.object({
   intents: z.array(IntentNameSchema).optional(),
   sweepers: SweepersConfigSchema,
   presence: PresenceConfigSchema,
+  webhookName: z.string().min(1).max(80).optional(),
 });
 
 // ---------------------------------------------------------------------------
@@ -166,5 +169,6 @@ export function parseDiscordConfig(raw: Readonly<Record<string, unknown>>): Disc
     intents: parsed.intents ?? DEFAULT_INTENTS,
     sweepers: toSweepersConfig(parsed.sweepers),
     presence: toPresenceConfig(parsed.presence),
+    webhookName: parsed.webhookName,
   };
 }

--- a/packages/channel-discord/src/index.ts
+++ b/packages/channel-discord/src/index.ts
@@ -1,3 +1,5 @@
 export { DiscordChannel, DiscordChannel as default } from "./adapter.js";
 export { DISCORD_CAPABILITIES } from "./capabilities.js";
 export type { DiscordConfig } from "./config.js";
+export type { DiscordWebhookInfo, WebhookManagerDeps, WebhookSendable } from "./webhook-manager.js";
+export { sanitizeWebhookUsername, WebhookManager } from "./webhook-manager.js";

--- a/packages/channel-discord/src/webhook-manager.ts
+++ b/packages/channel-discord/src/webhook-manager.ts
@@ -1,0 +1,214 @@
+import { ChannelSendError } from "@templar/errors";
+
+// ---------------------------------------------------------------------------
+// Minimal Discord.js types (injectable for testing)
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal interface for a Discord webhook that can send messages.
+ */
+export interface WebhookSendable {
+  send(options: Record<string, unknown>): Promise<unknown>;
+}
+
+/**
+ * Extended webhook info returned by Discord API (fetchWebhooks / createWebhook).
+ */
+export interface DiscordWebhookInfo extends WebhookSendable {
+  readonly id: string;
+  readonly token: string | null;
+  readonly owner: { readonly id: string } | null;
+  readonly name: string | null;
+}
+
+/**
+ * Injectable dependencies for WebhookManager.
+ * Keeps the manager testable without requiring a real Discord client.
+ */
+export interface WebhookManagerDeps {
+  readonly fetchWebhooks: (channelId: string) => Promise<readonly DiscordWebhookInfo[]>;
+  readonly createWebhook: (channelId: string, name: string) => Promise<DiscordWebhookInfo>;
+  readonly botUserId: string;
+}
+
+// ---------------------------------------------------------------------------
+// Discord error code constants (shared by renderer + webhook-manager)
+// ---------------------------------------------------------------------------
+
+/** Webhook no longer exists (deleted by admin) */
+export const DISCORD_ERROR_UNKNOWN_WEBHOOK = 10015;
+
+/** Maximum number of webhooks reached (15 per channel) */
+export const DISCORD_ERROR_MAX_WEBHOOKS = 30007;
+
+/** Bot lacks required permission */
+export const DISCORD_ERROR_MISSING_PERMISSIONS = 50013;
+
+/** Bot cannot access the resource */
+export const DISCORD_ERROR_MISSING_ACCESS = 50001;
+
+// ---------------------------------------------------------------------------
+// Username sanitization
+// ---------------------------------------------------------------------------
+
+const FORBIDDEN_SUBSTRINGS = [/clyde/gi, /discord/gi];
+const MAX_USERNAME_LENGTH = 80;
+const FALLBACK_USERNAME = "Agent";
+
+/**
+ * Sanitize a webhook username per Discord constraints:
+ * - Must not contain "clyde" or "discord" (case-insensitive)
+ * - Must be 1-80 characters
+ * - Falls back to "Agent" if empty after sanitization
+ */
+export function sanitizeWebhookUsername(name: string): string {
+  let sanitized = name;
+  for (const pattern of FORBIDDEN_SUBSTRINGS) {
+    sanitized = sanitized.replace(pattern, "");
+  }
+  sanitized = sanitized.trim();
+
+  if (sanitized.length === 0) {
+    return FALLBACK_USERNAME;
+  }
+
+  if (sanitized.length > MAX_USERNAME_LENGTH) {
+    return sanitized.slice(0, MAX_USERNAME_LENGTH);
+  }
+
+  return sanitized;
+}
+
+// ---------------------------------------------------------------------------
+// WebhookManager
+// ---------------------------------------------------------------------------
+
+/**
+ * Manages Discord webhooks for per-message identity.
+ *
+ * - Auto-creates webhooks per channel via MANAGE_WEBHOOKS permission
+ * - Caches webhooks in a Map for fast repeated sends
+ * - Deduplicates concurrent creates for the same channel (promise coalescing)
+ * - Sanitizes webhook usernames per Discord constraints
+ */
+export class WebhookManager {
+  private readonly cache = new Map<string, DiscordWebhookInfo>();
+  private readonly pending = new Map<string, Promise<DiscordWebhookInfo>>();
+  private readonly deps: WebhookManagerDeps;
+  private readonly webhookName: string;
+
+  constructor(deps: WebhookManagerDeps, webhookName?: string) {
+    this.deps = deps;
+    this.webhookName = webhookName ?? "Templar";
+  }
+
+  /**
+   * Get or create a webhook for a channel. Returns a cached webhook
+   * on subsequent calls. Deduplicates concurrent creates.
+   */
+  async getOrCreate(channelId: string): Promise<WebhookSendable> {
+    // 1. Cache hit
+    const cached = this.cache.get(channelId);
+    if (cached) return cached;
+
+    // 2. Dedup: await in-flight creation for same channel
+    const inflight = this.pending.get(channelId);
+    if (inflight) return inflight;
+
+    // 3. Create and cache
+    const promise = this.findOrCreate(channelId);
+    this.pending.set(channelId, promise);
+
+    try {
+      const webhook = await promise;
+      this.cache.set(channelId, webhook);
+      return webhook;
+    } finally {
+      this.pending.delete(channelId);
+    }
+  }
+
+  /**
+   * Invalidate a cached webhook for a specific channel.
+   * Called when a 10015 Unknown Webhook error is received.
+   */
+  invalidate(channelId: string): void {
+    this.cache.delete(channelId);
+  }
+
+  /**
+   * Clear all cached webhooks. Called on disconnect().
+   */
+  clear(): void {
+    this.cache.clear();
+    this.pending.clear();
+  }
+
+  // -------------------------------------------------------------------------
+  // Private
+  // -------------------------------------------------------------------------
+
+  private async findOrCreate(channelId: string): Promise<DiscordWebhookInfo> {
+    // Try to find an existing webhook owned by this bot
+    const existing = await this.fetchOwnedWebhook(channelId);
+    if (existing) return existing;
+
+    // Create a new webhook
+    return this.createNewWebhook(channelId);
+  }
+
+  private async fetchOwnedWebhook(channelId: string): Promise<DiscordWebhookInfo | undefined> {
+    try {
+      const webhooks = await this.deps.fetchWebhooks(channelId);
+      return webhooks.find((wh) => wh.owner?.id === this.deps.botUserId && wh.token !== null);
+    } catch (error) {
+      throw this.mapWebhookError(error, channelId, "fetch webhooks");
+    }
+  }
+
+  private async createNewWebhook(channelId: string): Promise<DiscordWebhookInfo> {
+    try {
+      return await this.deps.createWebhook(channelId, this.webhookName);
+    } catch (error) {
+      throw this.mapWebhookError(error, channelId, "create webhook");
+    }
+  }
+
+  private mapWebhookError(error: unknown, channelId: string, operation: string): ChannelSendError {
+    if (error instanceof ChannelSendError) return error;
+
+    const code = (error as Record<string, unknown> | null)?.code;
+    const message = error instanceof Error ? error.message : String(error);
+    const cause = error instanceof Error ? error : undefined;
+
+    if (code === DISCORD_ERROR_UNKNOWN_WEBHOOK) {
+      return new ChannelSendError(
+        "discord",
+        `Webhook for channel ${channelId} no longer exists (deleted). Will retry with a new webhook.`,
+        { cause },
+      );
+    }
+
+    if (code === DISCORD_ERROR_MAX_WEBHOOKS) {
+      return new ChannelSendError(
+        "discord",
+        `Channel ${channelId} has reached the maximum webhook limit (15). Identity will not be applied.`,
+        { cause },
+      );
+    }
+
+    if (code === DISCORD_ERROR_MISSING_PERMISSIONS) {
+      return new ChannelSendError(
+        "discord",
+        `Bot lacks MANAGE_WEBHOOKS permission in channel ${channelId}. Cannot ${operation} for identity. Grant the permission or identity will not be applied.`,
+        { cause },
+      );
+    }
+
+    return new ChannelSendError(
+      "discord",
+      `Failed to ${operation} for channel ${channelId}: ${message}`,
+      { cause },
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Implements **Issue #78** — Discord webhook-based per-message identity.

- **WebhookManager** (`webhook-manager.ts`): Auto-creates and caches Discord webhooks per channel via `MANAGE_WEBHOOKS` permission. Features lazy cache warm-up, promise deduplication for concurrent creates, username sanitization (strips "clyde"/"discord", 80-char limit), and structured error mapping for codes 10015/30007/50013.
- **Webhook Renderer** (`renderer.ts`): New `renderWebhookMessage()` applies `username` + `avatarURL` from `OutboundMessage.identity` on every chunk. Shares `buildBasePayload()` with the Gateway renderer (DRY). Warns once if `replyTo` is used (unsupported by Discord webhooks).
- **Adapter Integration** (`adapter.ts`): When `message.identity` is present, tries webhook path first. Handles 10015 (Unknown Webhook) with invalidate-and-retry. Falls back to Gateway on permission errors or webhook limit. Includes `extractDiscordErrorCode()` for traversing Templar error cause chains.
- **Capabilities** (`capabilities.ts`): Declares `identity: { supported: true, perMessage: true }`.
- **Config** (`config.ts`): Optional `webhookName` field for custom webhook display names.

### Design Decisions
- Identity-triggered webhook send; Gateway otherwise (zero-config)
- Unbounded `Map` cache, cleared on disconnect
- Promise dedup prevents duplicate webhook creation under concurrency
- Avatar URL validated as `https?://` before passing to Discord API

## Test plan

- [x] 22 unit tests for WebhookManager (cache, find/create, invalidation, errors, sanitization, concurrency dedup)
- [x] 11 unit tests for webhook renderer (identity applied/partial/absent, threads, batched sends, errors)
- [x] 5 integration tests for full adapter flow (webhook send, Gateway regression, permission fallback, 10015 retry, hot-reload identity change)
- [x] 1 capability test for identity declaration
- [x] All 134 Discord package tests pass
- [x] Full monorepo build (27/27 tasks)
- [x] Full monorepo tests (54/54 tasks)
- [ ] E2E with live Discord bot (requires `DISCORD_TOKEN`)

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)