### PR TITLE
feat(gateway): add session-level identity tracking

### DIFF
--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -16,6 +16,7 @@ import type {
   LaneMessageFrame,
   NodeDeregisterFrame,
   NodeRegisterFrame,
+  SessionIdentityContext,
 } from "./protocol/index.js";
 import { MessageBuffer } from "./queue/message-buffer.js";
 import { HealthMonitor } from "./registry/health-monitor.js";
@@ -177,6 +178,7 @@ export class TemplarGateway {
     this.wireConnectionHandlers();
     this.wireHealthMonitorHandlers();
     this.wireConfigWatcherHandlers();
+    this.wireSessionTransitionHandlers();
   }
 
   // -------------------------------------------------------------------------
@@ -294,6 +296,39 @@ export class TemplarGateway {
    */
   getConversationStore(): ConversationStore {
     return this.conversationStore;
+  }
+
+  /**
+   * Update the identity context for a session.
+   *
+   * Emits a `session.identity.update` frame to the node if the identity changed.
+   * Returns the updated session, or undefined if identity was unchanged.
+   * Throws if nodeId is not found.
+   */
+  updateSessionIdentity(
+    nodeId: string,
+    identityContext: SessionIdentityContext | undefined,
+  ): boolean {
+    const updated = this.sessionManager.updateIdentityContext(nodeId, identityContext);
+    if (!updated) return false;
+
+    // Emit identity update frame to the node (use frozen clone from session, not raw input)
+    const frame: GatewayFrame = {
+      kind: "session.identity.update",
+      sessionId: updated.sessionId,
+      nodeId,
+      identity: updated.identityContext?.identity ?? {},
+      timestamp: Date.now(),
+    };
+    this.sendToNode(nodeId, frame);
+    return true;
+  }
+
+  /**
+   * Get the identity context for a session.
+   */
+  getSessionIdentity(nodeId: string): SessionIdentityContext | undefined {
+    return this.sessionManager.getSession(nodeId)?.identityContext;
   }
 
   /**
@@ -440,6 +475,21 @@ export class TemplarGateway {
       for (const node of this.registry.all()) {
         this.sendToNode(node.nodeId, frame);
       }
+    });
+  }
+
+  private wireSessionTransitionHandlers(): void {
+    this.sessionManager.onTransition((nodeId, result, session) => {
+      if (!result.valid) return;
+
+      const frame: GatewayFrame = {
+        kind: "session.update",
+        sessionId: session.sessionId,
+        nodeId,
+        state: session.state,
+        timestamp: Date.now(),
+      };
+      this.sendToNode(nodeId, frame);
     });
   }
 
@@ -596,38 +646,36 @@ export class TemplarGateway {
       const ackFrame: GatewayFrame = {
         kind: "node.register.ack",
         nodeId,
-        sessionId: `${nodeId}-${session.connectedAt}`,
+        sessionId: session.sessionId,
       };
       this.server.sendFrame(connectionId, ackFrame);
 
       this.events.emit("node.registered", nodeId);
     } catch (err) {
-      const errorFrame: GatewayFrame = {
-        kind: "error",
-        error: {
-          type: "about:blank",
-          title: "Registration failed",
-          status: 409,
-          detail: err instanceof Error ? err.message : String(err),
-        },
-        timestamp: Date.now(),
-      };
-      this.server.sendFrame(connectionId, errorFrame);
+      this.sendErrorFrame(
+        connectionId,
+        "Registration failed",
+        409,
+        err instanceof Error ? err.message : String(err),
+      );
     }
   }
 
   private sendAuthError(connectionId: string, status: number, detail: string): void {
-    const errorFrame: GatewayFrame = {
+    this.sendErrorFrame(connectionId, "Authentication failed", status, detail);
+  }
+
+  private sendErrorFrame(
+    connectionId: string,
+    title: string,
+    status: number,
+    detail: string,
+  ): void {
+    this.server.sendFrame(connectionId, {
       kind: "error",
-      error: {
-        type: "about:blank",
-        title: "Authentication failed",
-        status,
-        detail,
-      },
+      error: { type: "about:blank", title, status, detail },
       timestamp: Date.now(),
-    };
-    this.server.sendFrame(connectionId, errorFrame);
+    });
   }
 
   private handleNodeDeregister(connectionId: string, frame: NodeDeregisterFrame): void {
@@ -636,17 +684,12 @@ export class TemplarGateway {
     // Verify the connection owns this node — prevent cross-node deregistration
     const ownerConnection = this.nodeToConnection.get(nodeId);
     if (ownerConnection && ownerConnection !== connectionId) {
-      const errorFrame: GatewayFrame = {
-        kind: "error",
-        error: {
-          type: "about:blank",
-          title: "Unauthorized deregistration",
-          status: 403,
-          detail: `Connection is not the owner of node '${nodeId}'`,
-        },
-        timestamp: Date.now(),
-      };
-      this.server.sendFrame(connectionId, errorFrame);
+      this.sendErrorFrame(
+        connectionId,
+        "Unauthorized deregistration",
+        403,
+        `Connection is not the owner of node '${nodeId}'`,
+      );
       return;
     }
 
@@ -665,17 +708,12 @@ export class TemplarGateway {
   private handleLaneMessage(connectionId: string, frame: LaneMessageFrame): void {
     const nodeId = this.connectionToNode.get(connectionId);
     if (!nodeId) {
-      const errorFrame: GatewayFrame = {
-        kind: "error",
-        error: {
-          type: "about:blank",
-          title: "Not registered",
-          status: 403,
-          detail: "Connection must register before sending lane messages",
-        },
-        timestamp: Date.now(),
-      };
-      this.server.sendFrame(connectionId, errorFrame);
+      this.sendErrorFrame(
+        connectionId,
+        "Not registered",
+        403,
+        "Connection must register before sending lane messages",
+      );
       return;
     }
 
@@ -692,18 +730,12 @@ export class TemplarGateway {
       };
       this.server.sendFrame(connectionId, ackFrame);
     } catch (err) {
-      // Send error frame back on routing failure
-      const errorFrame: GatewayFrame = {
-        kind: "error",
-        error: {
-          type: "about:blank",
-          title: "Message routing failed",
-          status: 500,
-          detail: err instanceof Error ? err.message : String(err),
-        },
-        timestamp: Date.now(),
-      };
-      this.server.sendFrame(connectionId, errorFrame);
+      this.sendErrorFrame(
+        connectionId,
+        "Message routing failed",
+        500,
+        err instanceof Error ? err.message : String(err),
+      );
     }
   }
 

--- a/packages/gateway/src/protocol/__tests__/frames.test.ts
+++ b/packages/gateway/src/protocol/__tests__/frames.test.ts
@@ -206,6 +206,136 @@ describe("GatewayFrame schemas", () => {
   });
 
   // -------------------------------------------------------------------------
+  // session.identity.update
+  // -------------------------------------------------------------------------
+  describe("session.identity.update", () => {
+    it("accepts a valid session identity update", () => {
+      const frame: GatewayFrame = {
+        kind: "session.identity.update",
+        sessionId: "sess-1",
+        nodeId: "node-1",
+        identity: { name: "Bot", avatar: "https://a.png" },
+        timestamp: Date.now(),
+      };
+      expect(parseFrame(frame)).toEqual(frame);
+    });
+
+    it("accepts identity with all fields", () => {
+      const frame: GatewayFrame = {
+        kind: "session.identity.update",
+        sessionId: "sess-1",
+        nodeId: "node-1",
+        identity: {
+          name: "Full Bot",
+          avatar: "https://avatar.png",
+          bio: "A helpful bot",
+          systemPromptPrefix: "You are helpful.",
+        },
+        timestamp: Date.now(),
+      };
+      expect(parseFrame(frame)).toEqual(frame);
+    });
+
+    it("accepts identity with minimal fields (empty object)", () => {
+      const frame: GatewayFrame = {
+        kind: "session.identity.update",
+        sessionId: "sess-1",
+        nodeId: "node-1",
+        identity: {},
+        timestamp: Date.now(),
+      };
+      expect(parseFrame(frame)).toEqual(frame);
+    });
+
+    it("rejects missing identity field", () => {
+      const result = safeParseFrame({
+        kind: "session.identity.update",
+        sessionId: "sess-1",
+        nodeId: "node-1",
+        timestamp: Date.now(),
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects empty sessionId", () => {
+      const result = safeParseFrame({
+        kind: "session.identity.update",
+        sessionId: "",
+        nodeId: "node-1",
+        identity: { name: "Bot" },
+        timestamp: Date.now(),
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects empty nodeId", () => {
+      const result = safeParseFrame({
+        kind: "session.identity.update",
+        sessionId: "sess-1",
+        nodeId: "",
+        identity: { name: "Bot" },
+        timestamp: Date.now(),
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects non-positive timestamp", () => {
+      const result = safeParseFrame({
+        kind: "session.identity.update",
+        sessionId: "sess-1",
+        nodeId: "node-1",
+        identity: { name: "Bot" },
+        timestamp: 0,
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects name exceeding 80 characters", () => {
+      const result = safeParseFrame({
+        kind: "session.identity.update",
+        sessionId: "sess-1",
+        nodeId: "node-1",
+        identity: { name: "x".repeat(81) },
+        timestamp: Date.now(),
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects invalid avatar URL", () => {
+      const result = safeParseFrame({
+        kind: "session.identity.update",
+        sessionId: "sess-1",
+        nodeId: "node-1",
+        identity: { avatar: "not-a-url" },
+        timestamp: Date.now(),
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects bio exceeding 512 characters", () => {
+      const result = safeParseFrame({
+        kind: "session.identity.update",
+        sessionId: "sess-1",
+        nodeId: "node-1",
+        identity: { bio: "x".repeat(513) },
+        timestamp: Date.now(),
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects systemPromptPrefix exceeding 4096 characters", () => {
+      const result = safeParseFrame({
+        kind: "session.identity.update",
+        sessionId: "sess-1",
+        nodeId: "node-1",
+        identity: { systemPromptPrefix: "x".repeat(4097) },
+        timestamp: Date.now(),
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // config.changed
   // -------------------------------------------------------------------------
   describe("config.changed", () => {

--- a/packages/gateway/src/protocol/__tests__/types.test.ts
+++ b/packages/gateway/src/protocol/__tests__/types.test.ts
@@ -234,6 +234,7 @@ describe("Sessions", () => {
 describe("SessionInfo", () => {
   it("accepts valid session info", () => {
     const info = {
+      sessionId: "550e8400-e29b-41d4-a716-446655440000",
       nodeId: "node-1",
       state: "connected" as const,
       connectedAt: Date.now(),
@@ -243,8 +244,51 @@ describe("SessionInfo", () => {
     expect(SessionInfoSchema.parse(info)).toEqual(info);
   });
 
+  it("accepts session info with identityContext", () => {
+    const info = {
+      sessionId: "550e8400-e29b-41d4-a716-446655440000",
+      nodeId: "node-1",
+      state: "connected" as const,
+      connectedAt: Date.now(),
+      lastActivityAt: Date.now(),
+      reconnectCount: 0,
+      identityContext: {
+        identity: { name: "Bot", avatar: "https://a.png" },
+        channelType: "slack",
+        agentId: "agent-1",
+      },
+    };
+    expect(SessionInfoSchema.parse(info)).toEqual(info);
+  });
+
+  it("accepts session info without identityContext", () => {
+    const info = {
+      sessionId: "550e8400-e29b-41d4-a716-446655440000",
+      nodeId: "node-1",
+      state: "connected" as const,
+      connectedAt: Date.now(),
+      lastActivityAt: Date.now(),
+      reconnectCount: 0,
+    };
+    const result = SessionInfoSchema.safeParse(info);
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects session info with invalid sessionId", () => {
+    const result = SessionInfoSchema.safeParse({
+      sessionId: "not-a-uuid",
+      nodeId: "node-1",
+      state: "connected",
+      connectedAt: Date.now(),
+      lastActivityAt: Date.now(),
+      reconnectCount: 0,
+    });
+    expect(result.success).toBe(false);
+  });
+
   it("rejects negative reconnectCount", () => {
     const result = SessionInfoSchema.safeParse({
+      sessionId: "550e8400-e29b-41d4-a716-446655440000",
       nodeId: "node-1",
       state: "connected",
       connectedAt: Date.now(),

--- a/packages/gateway/src/protocol/index.ts
+++ b/packages/gateway/src/protocol/index.ts
@@ -55,6 +55,8 @@ export {
   type NodeRegisterFrame,
   NodeRegisterFrameSchema,
   parseFrame,
+  type SessionIdentityUpdateFrame,
+  SessionIdentityUpdateFrameSchema,
   type SessionUpdateFrame,
   SessionUpdateFrameSchema,
   safeParseFrame,
@@ -74,11 +76,14 @@ export {
 } from "./lanes.js";
 // Sessions
 export {
+  ChannelIdentityConfigProtocolSchema,
   SESSION_EVENTS,
   SESSION_STATES,
   SESSION_TRANSITIONS,
   type SessionEvent,
   SessionEventSchema,
+  type SessionIdentityContext,
+  SessionIdentityContextSchema,
   type SessionInfo,
   SessionInfoSchema,
   type SessionState,

--- a/packages/middleware/src/identity/index.ts
+++ b/packages/middleware/src/identity/index.ts
@@ -1,4 +1,9 @@
-export { resolveChannelIdentity, resolveIdentity } from "./resolver.js";
+export {
+  mergeIdentityConfig,
+  resolveChannelIdentity,
+  resolveIdentity,
+  resolveIdentityWithSession,
+} from "./resolver.js";
 export {
   ChannelIdentityConfigSchema,
   IdentityConfigSchema,


### PR DESCRIPTION
## Summary

- Add `SessionIdentityContext` to gateway sessions with UUID-based session IDs, enabling per-session identity resolution via a 3-level cascade (session override → channel override → default)
- Add `session.identity.update` frame kind for real-time identity change propagation over WebSocket
- Add `updateSessionIdentity()` / `getSessionIdentity()` public API on `TemplarGateway` with deep-frozen immutable context and `isDeepStrictEqual`-based no-op detection
- Export `mergeIdentityConfig` and add `resolveIdentityWithSession()` to middleware identity resolver
- Extract `sendErrorFrame()` helper in gateway, reducing file from 807→787 lines

Closes #79

## Changes

### Protocol (`packages/gateway/src/protocol/`)
- `sessions.ts`: Add `SessionIdentityContext` interface + Zod schema, add `sessionId: string` to `SessionInfo`
- `frames.ts`: Add `session.identity.update` frame kind with schema
- `index.ts`: Export new types

### SessionManager (`packages/gateway/src/sessions/`)
- `session-manager.ts`: Accept `SessionCreateOptions` with optional `identityContext`, add `updateIdentityContext()`, use `deepFreeze()` for nested immutability, use `isDeepStrictEqual` (not `JSON.stringify`) for comparison

### Gateway (`packages/gateway/src/gateway.ts`)
- Wire `updateSessionIdentity()` / `getSessionIdentity()` public API
- Add `wireSessionTransitionHandlers()` emitting `session.update` frames
- Use frozen identity from session (not raw input) in frame emission
- Always emit frame on identity change (including clear → empty `{}`)
- Extract `sendErrorFrame()` + keep `sendAuthError()` as thin wrapper

### Identity Resolver (`packages/middleware/src/identity/`)
- Export `mergeIdentityConfig` (was private)
- Add `resolveIdentityWithSession()` for 3-level cascade

## Test plan

- [x] 67 new tests across 5 test files
- [x] Gateway: 554 tests passing (was 511)
- [x] Middleware: 482 tests passing (was 464)
- [x] Biome lint: clean
- [x] TypeScript: clean (`tsc --noEmit`)
- [ ] E2E: Nexus server not available for live validation (deferred)

🤖 Generated with [Claude Code](https://claude.com/claude-code)