### PR TITLE
ci: enforce @templar/core import boundaries via Biome lint

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -35,6 +35,36 @@
       "trailingCommas": "all"
     }
   },
+  "overrides": [
+    {
+      "includes": ["packages/core/src/**"],
+      "linter": {
+        "rules": {
+          "style": {
+            "noRestrictedImports": {
+              "level": "error",
+              "options": {
+                "paths": {
+                  "deepagents": {
+                    "message": "@templar/core is an interfaces-only kernel. DeepAgents runtime belongs in @templar/engine. See TEMPLAR.md Principle #1 and issue #125."
+                  },
+                  "@templar/engine": {
+                    "message": "@templar/engine depends on @templar/core, not vice versa. See TEMPLAR.md Principle #1 and issue #125."
+                  }
+                },
+                "patterns": [
+                  {
+                    "group": ["@langchain/*", "@langchain/**"],
+                    "message": "@templar/core must not import LangGraph/LangChain types. All LangGraph integration belongs in @templar/engine. See TEMPLAR.md Principle #1 and issue #125."
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    }
+  ],
   "files": {
     "includes": ["**", "!**/node_modules", "!**/dist", "!**/.turbo", "!**/coverage"]
   }


### PR DESCRIPTION
## Summary

- Add Biome `noRestrictedImports` override in root `biome.json` scoped to `packages/core/src/**`
- Blocks `@langchain/*` (glob), `deepagents` (exact), and `@templar/engine` (reverse dep) from the interfaces-only kernel
- Runs in existing CI lint step (`pnpm run check`) — zero new dependencies, zero CI pipeline changes

## Rationale

From TEMPLAR.md Principle #1: `@templar/core` is an interfaces-only kernel (~800 LOC) with zero runtime imports. If LangGraph types leak into core, every downstream consumer gets a transitive dependency on the full LangGraph runtime — defeating the slim kernel design.

## Verification

| Check | Result |
|-------|--------|
| Current core code (12 files) | 0 violations |
| Catches `@langchain/core/messages` (deep subpath) | Yes |
| Catches `@langchain/langgraph` (direct) | Yes |
| Catches `deepagents` | Yes |
| Catches `@templar/engine` (reverse dep) | Yes |
| Full monorepo lint (`pnpm run check`) | Pass |
| Build (`turbo build` core packages) | Pass |
| Tests (8 packages, 1,993 tests) | All green |

## Test plan

- [x] Verify rule catches all 4 violation categories
- [x] Verify existing core code passes cleanly
- [x] Run full CI pipeline locally (lint, build, typecheck, test)
- [x] E2E against live Nexus with permissions enabled (server-side 500s are pre-existing, unrelated)

Closes #125