### PR TITLE
feat(model-router): provider-aware error classification — 7-category failover (#31)

### DIFF
--- a/packages/errors/src/catalog.ts
+++ b/packages/errors/src/catalog.ts
@@ -1287,6 +1287,15 @@ export const ERROR_CATALOG = {
     title: "All model providers failed",
     description: "All providers in the fallback chain have been exhausted",
   },
+  MODEL_THINKING_FAILED: {
+    domain: "model",
+    httpStatus: 400,
+    grpcCode: "INVALID_ARGUMENT" as const,
+    baseType: "ExternalError" as const,
+    isExpected: true,
+    title: "Model thinking failed",
+    description: "Extended thinking request failed due to provider constraints",
+  },
   MODEL_INVALID_CONFIG: {
     domain: "model",
     httpStatus: 400,

--- a/packages/model-router/src/__tests__/classify.test.ts
+++ b/packages/model-router/src/__tests__/classify.test.ts
@@ -1,0 +1,416 @@
+import {
+  ExternalError,
+  PermissionError,
+  RateLimitError,
+  TimeoutError,
+  ValidationError,
+} from "@templar/errors";
+import { describe, expect, it } from "vitest";
+import { classifyError } from "../classify.js";
+
+// ---------------------------------------------------------------------------
+// TemplarError instances
+// ---------------------------------------------------------------------------
+
+describe("classifyError", () => {
+  describe("TemplarError instances", () => {
+    it("classifies MODEL_PROVIDER_AUTH_FAILED as auth", () => {
+      const error = new PermissionError<"MODEL_PROVIDER_AUTH_FAILED">({
+        code: "MODEL_PROVIDER_AUTH_FAILED",
+        message: "Invalid API key",
+      });
+      expect(classifyError(error)).toEqual({ category: "auth" });
+    });
+
+    it("classifies MODEL_PROVIDER_BILLING_FAILED as billing", () => {
+      const error = new ExternalError<"MODEL_PROVIDER_BILLING_FAILED">({
+        code: "MODEL_PROVIDER_BILLING_FAILED",
+        message: "Payment required",
+      });
+      expect(classifyError(error)).toEqual({ category: "billing" });
+    });
+
+    it("classifies MODEL_PROVIDER_RATE_LIMITED as rate_limit", () => {
+      const error = new RateLimitError<"MODEL_PROVIDER_RATE_LIMITED">({
+        code: "MODEL_PROVIDER_RATE_LIMITED",
+        message: "Rate limited",
+      });
+      expect(classifyError(error)).toEqual({ category: "rate_limit" });
+    });
+
+    it("classifies MODEL_PROVIDER_TIMEOUT as timeout", () => {
+      const error = new TimeoutError<"MODEL_PROVIDER_TIMEOUT">({
+        code: "MODEL_PROVIDER_TIMEOUT",
+        message: "Timeout",
+      });
+      expect(classifyError(error)).toEqual({ category: "timeout" });
+    });
+
+    it("classifies MODEL_CONTEXT_OVERFLOW as context_overflow", () => {
+      const error = new ValidationError<"MODEL_CONTEXT_OVERFLOW">({
+        code: "MODEL_CONTEXT_OVERFLOW",
+        message: "Context overflow",
+      });
+      expect(classifyError(error)).toEqual({ category: "context_overflow" });
+    });
+
+    it("classifies MODEL_PROVIDER_ERROR as model_error", () => {
+      const error = new ExternalError<"MODEL_PROVIDER_ERROR">({
+        code: "MODEL_PROVIDER_ERROR",
+        message: "Provider error",
+      });
+      expect(classifyError(error)).toEqual({ category: "model_error" });
+    });
+
+    it("classifies MODEL_THINKING_FAILED as thinking", () => {
+      const error = new ExternalError<"MODEL_THINKING_FAILED">({
+        code: "MODEL_THINKING_FAILED",
+        message: "Thinking failed",
+      });
+      expect(classifyError(error)).toEqual({ category: "thinking" });
+    });
+
+    it("classifies non-model PermissionError as auth", () => {
+      const error = new PermissionError<"AUTH_FORBIDDEN">({
+        code: "AUTH_FORBIDDEN",
+        message: "Forbidden",
+      });
+      expect(classifyError(error)).toEqual({ category: "auth" });
+    });
+
+    it("classifies non-model RateLimitError as rate_limit", () => {
+      const error = new RateLimitError<"RATE_LIMIT_EXCEEDED">({
+        code: "RATE_LIMIT_EXCEEDED",
+        message: "Rate limited",
+      });
+      expect(classifyError(error)).toEqual({ category: "rate_limit" });
+    });
+
+    it("classifies non-model ValidationError as unknown", () => {
+      const error = new ValidationError<"VALIDATION_FAILED">({
+        code: "VALIDATION_FAILED",
+        message: "Validation failed",
+      });
+      expect(classifyError(error)).toEqual({ category: "unknown" });
+    });
+
+    it("classifies non-model ExternalError as unknown", () => {
+      const error = new ExternalError<"INTERNAL_UNAVAILABLE">({
+        code: "INTERNAL_UNAVAILABLE",
+        message: "Unavailable",
+      });
+      expect(classifyError(error)).toEqual({ category: "unknown" });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Raw errors — Anthropic
+  // ---------------------------------------------------------------------------
+
+  describe("raw errors — Anthropic", () => {
+    it("classifies 401 as auth", () => {
+      const error = { status: 401, message: "authentication_error" };
+      expect(classifyError(error, "anthropic").category).toBe("auth");
+    });
+
+    it("classifies 403 as auth", () => {
+      const error = { status: 403, message: "permission_error" };
+      expect(classifyError(error, "anthropic").category).toBe("auth");
+    });
+
+    it("classifies 429 as rate_limit", () => {
+      const error = { status: 429, message: "rate_limit_error" };
+      expect(classifyError(error, "anthropic").category).toBe("rate_limit");
+    });
+
+    it("classifies 529 as rate_limit", () => {
+      const error = { status: 529, message: "overloaded_error" };
+      expect(classifyError(error, "anthropic").category).toBe("rate_limit");
+    });
+
+    it("classifies 400 with budget_tokens message as thinking", () => {
+      const error = {
+        status: 400,
+        message: "budget_tokens must be >= 1024",
+      };
+      expect(classifyError(error, "anthropic").category).toBe("thinking");
+    });
+
+    it("classifies 400 with thinking blocks message as thinking", () => {
+      const error = {
+        status: 400,
+        message: "Cannot modify thinking blocks in assistant messages",
+      };
+      expect(classifyError(error, "anthropic").category).toBe("thinking");
+    });
+
+    it("classifies 400 with context message as context_overflow", () => {
+      const error = {
+        status: 400,
+        message: "context window exceeded",
+      };
+      expect(classifyError(error, "anthropic").category).toBe("context_overflow");
+    });
+
+    it("classifies 400 with token message as context_overflow", () => {
+      const error = {
+        status: 400,
+        message: "maximum token limit exceeded",
+      };
+      expect(classifyError(error, "anthropic").category).toBe("context_overflow");
+    });
+
+    it("classifies 500 as model_error", () => {
+      const error = { status: 500, message: "api_error" };
+      expect(classifyError(error, "anthropic").category).toBe("model_error");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Raw errors — OpenAI
+  // ---------------------------------------------------------------------------
+
+  describe("raw errors — OpenAI", () => {
+    it("classifies 401 as auth", () => {
+      const error = { status: 401, message: "invalid_api_key" };
+      expect(classifyError(error, "openai").category).toBe("auth");
+    });
+
+    it("classifies 403 as auth", () => {
+      const error = { status: 403, message: "permission denied" };
+      expect(classifyError(error, "openai").category).toBe("auth");
+    });
+
+    it("classifies 429 with insufficient_quota as billing", () => {
+      const error = { status: 429, message: "insufficient_quota" };
+      expect(classifyError(error, "openai").category).toBe("billing");
+    });
+
+    it("classifies 429 without quota message as rate_limit", () => {
+      const error = { status: 429, message: "rate limit exceeded" };
+      expect(classifyError(error, "openai").category).toBe("rate_limit");
+    });
+
+    it("classifies 400 with context_length_exceeded as context_overflow", () => {
+      const error = {
+        status: 400,
+        message: "context_length_exceeded: maximum context length is 128000",
+      };
+      expect(classifyError(error, "openai").category).toBe("context_overflow");
+    });
+
+    it("classifies 400 with model_not_found as model_error", () => {
+      const error = { status: 400, message: "model_not_found" };
+      expect(classifyError(error, "openai").category).toBe("model_error");
+    });
+
+    it("classifies 500 as model_error", () => {
+      const error = { status: 500, message: "server_error" };
+      expect(classifyError(error, "openai").category).toBe("model_error");
+    });
+
+    it("classifies 503 as model_error", () => {
+      const error = { status: 503, message: "service unavailable" };
+      expect(classifyError(error, "openai").category).toBe("model_error");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Raw errors — Google
+  // ---------------------------------------------------------------------------
+
+  describe("raw errors — Google", () => {
+    it("classifies 401 as auth", () => {
+      const error = { status: 401, message: "UNAUTHENTICATED" };
+      expect(classifyError(error, "google").category).toBe("auth");
+    });
+
+    it("classifies 403 as auth", () => {
+      const error = { status: 403, message: "PERMISSION_DENIED" };
+      expect(classifyError(error, "google").category).toBe("auth");
+    });
+
+    it("classifies 429 as rate_limit", () => {
+      const error = { status: 429, message: "RESOURCE_EXHAUSTED" };
+      expect(classifyError(error, "google").category).toBe("rate_limit");
+    });
+
+    it("classifies 404 as model_error", () => {
+      const error = { status: 404, message: "NOT_FOUND" };
+      expect(classifyError(error, "google").category).toBe("model_error");
+    });
+
+    it("classifies 500 as model_error", () => {
+      const error = { status: 500, message: "INTERNAL" };
+      expect(classifyError(error, "google").category).toBe("model_error");
+    });
+
+    it("classifies 503 as model_error", () => {
+      const error = { status: 503, message: "UNAVAILABLE" };
+      expect(classifyError(error, "google").category).toBe("model_error");
+    });
+
+    it("classifies 400 with token message as context_overflow", () => {
+      const error = { status: 400, message: "token limit exceeded" };
+      expect(classifyError(error, "google").category).toBe("context_overflow");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Raw errors — Ollama
+  // ---------------------------------------------------------------------------
+
+  describe("raw errors — Ollama", () => {
+    it("classifies 404 as model_error", () => {
+      const error = { status: 404, message: "model not found" };
+      expect(classifyError(error, "ollama").category).toBe("model_error");
+    });
+
+    it("classifies 429 as rate_limit", () => {
+      const error = { status: 429, message: "too many requests" };
+      expect(classifyError(error, "ollama").category).toBe("rate_limit");
+    });
+
+    it("classifies 500 as model_error", () => {
+      const error = { status: 500, message: "internal server error" };
+      expect(classifyError(error, "ollama").category).toBe("model_error");
+    });
+
+    it("classifies 502 as model_error", () => {
+      const error = { status: 502, message: "bad gateway" };
+      expect(classifyError(error, "ollama").category).toBe("model_error");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Retry-After parsing
+  // ---------------------------------------------------------------------------
+
+  describe("Retry-After parsing", () => {
+    it("parses seconds string into retryAfterMs", () => {
+      const error = {
+        status: 429,
+        message: "rate limited",
+        headers: { "retry-after": "5" },
+      };
+      const result = classifyError(error, "openai");
+      expect(result.retryAfterMs).toBe(5000);
+    });
+
+    it("parses Retry-After header (capitalized)", () => {
+      const error = {
+        status: 429,
+        message: "rate limited",
+        headers: { "Retry-After": "10" },
+      };
+      const result = classifyError(error, "openai");
+      expect(result.retryAfterMs).toBe(10_000);
+    });
+
+    it("returns undefined retryAfterMs when header is absent", () => {
+      const error = { status: 429, message: "rate limited" };
+      const result = classifyError(error, "openai");
+      expect(result.retryAfterMs).toBeUndefined();
+    });
+
+    it("caps absurdly large retry-after to 5 minutes", () => {
+      const error = {
+        status: 429,
+        message: "rate limited",
+        headers: { "retry-after": "9999" },
+      };
+      const result = classifyError(error, "openai");
+      expect(result.retryAfterMs).toBe(300_000);
+    });
+
+    it("extracts retry-after from response.headers", () => {
+      const error = {
+        status: 429,
+        message: "rate limited",
+        response: {
+          headers: { "retry-after": "3" },
+        },
+      };
+      const result = classifyError(error, "openai");
+      expect(result.retryAfterMs).toBe(3000);
+    });
+
+    it("extracts retry-after from Headers-like .get() method", () => {
+      const headers = new Map([["retry-after", "7"]]);
+      const error = {
+        status: 429,
+        message: "rate limited",
+        headers,
+      };
+      const result = classifyError(error, "openai");
+      expect(result.retryAfterMs).toBe(7000);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Unknown provider / no provider
+  // ---------------------------------------------------------------------------
+
+  describe("unknown provider / no provider", () => {
+    it("falls back to HTTP status classification without provider", () => {
+      const error = { status: 429, message: "rate limited" };
+      expect(classifyError(error).category).toBe("rate_limit");
+    });
+
+    it("falls back to HTTP status for unknown provider", () => {
+      const error = { status: 401, message: "unauthorized" };
+      expect(classifyError(error, "custom-provider").category).toBe("auth");
+    });
+
+    it("classifies 408 as timeout via HTTP status", () => {
+      const error = { status: 408, message: "request timeout" };
+      expect(classifyError(error).category).toBe("timeout");
+    });
+
+    it("classifies 504 as timeout via HTTP status", () => {
+      const error = { status: 504, message: "gateway timeout" };
+      expect(classifyError(error).category).toBe("timeout");
+    });
+
+    it("classifies 500+ as model_error via HTTP status", () => {
+      const error = { status: 502, message: "bad gateway" };
+      expect(classifyError(error).category).toBe("model_error");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Edge cases
+  // ---------------------------------------------------------------------------
+
+  describe("edge cases", () => {
+    it("returns unknown for null", () => {
+      expect(classifyError(null).category).toBe("unknown");
+    });
+
+    it("returns unknown for undefined", () => {
+      expect(classifyError(undefined).category).toBe("unknown");
+    });
+
+    it("returns unknown for string thrown", () => {
+      expect(classifyError("some error").category).toBe("unknown");
+    });
+
+    it("returns unknown for error with no status", () => {
+      const error = new Error("generic error");
+      expect(classifyError(error).category).toBe("unknown");
+    });
+
+    it("returns unknown for number thrown", () => {
+      expect(classifyError(42).category).toBe("unknown");
+    });
+
+    it("handles error with nested error.message", () => {
+      const error = {
+        status: 400,
+        error: { message: "context_length_exceeded" },
+      };
+      // Without provider, generic HTTP 400 → unknown (only provider-specific matchers inspect body)
+      expect(classifyError(error).category).toBe("unknown");
+    });
+  });
+});

--- a/packages/model-router/src/__tests__/validation.test.ts
+++ b/packages/model-router/src/__tests__/validation.test.ts
@@ -97,4 +97,31 @@ describe("validateRouterConfig", () => {
     const result = validateRouterConfig(config);
     expect(result).toBeDefined();
   });
+
+  it("accepts 'thinking' as a valid error category in failoverStrategy", () => {
+    const config = {
+      ...validConfig,
+      failoverStrategy: { thinking: "thinking_downgrade" },
+    };
+    const result = validateRouterConfig(config);
+    expect(result.failoverStrategy).toEqual({ thinking: "thinking_downgrade" });
+  });
+
+  it("accepts 'thinking_downgrade' as a valid failover action", () => {
+    const config = {
+      ...validConfig,
+      failoverStrategy: { model_error: "thinking_downgrade" },
+    };
+    const result = validateRouterConfig(config);
+    expect(result.failoverStrategy).toEqual({ model_error: "thinking_downgrade" });
+  });
+
+  it("accepts config with onPreModelSelect callback", () => {
+    const config = {
+      ...validConfig,
+      onPreModelSelect: (candidates: unknown[]) => candidates,
+    };
+    const result = validateRouterConfig(config);
+    expect(result).toBeDefined();
+  });
 });

--- a/packages/model-router/src/classify.ts
+++ b/packages/model-router/src/classify.ts
@@ -1,0 +1,299 @@
+/**
+ * Provider-aware error classification for multi-provider LLM routing.
+ *
+ * Maps raw provider errors and @templar/errors instances into a unified
+ * {@link ClassificationResult} with category, optional retry-after delay,
+ * and metadata.
+ */
+
+import {
+  isExternalError,
+  isPermissionError,
+  isRateLimitError,
+  isTemplarError,
+  isTimeoutError,
+  isValidationError,
+} from "@templar/errors";
+import type { ClassificationResult, ProviderErrorCategory } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Classify an error into a {@link ClassificationResult}.
+ *
+ * 1. If the error is a `TemplarError`, classification is based on its code.
+ * 2. Otherwise, HTTP status and response body are extracted from the raw
+ *    error and matched against provider-specific tables.
+ */
+export function classifyError(error: unknown, provider?: string): ClassificationResult {
+  if (error === null || error === undefined || typeof error === "string") {
+    return { category: "unknown" };
+  }
+
+  if (isTemplarError(error)) {
+    return classifyByCode(error);
+  }
+
+  return classifyRawError(error, provider);
+}
+
+// ---------------------------------------------------------------------------
+// TemplarError classification
+// ---------------------------------------------------------------------------
+
+function classifyByCode(error: { readonly code: string }): ClassificationResult {
+  const code = error.code;
+
+  if (code === "MODEL_PROVIDER_AUTH_FAILED") return { category: "auth" };
+  if (code === "MODEL_PROVIDER_BILLING_FAILED") return { category: "billing" };
+  if (code === "MODEL_PROVIDER_RATE_LIMITED") return { category: "rate_limit" };
+  if (code === "MODEL_PROVIDER_TIMEOUT") return { category: "timeout" };
+  if (code === "MODEL_CONTEXT_OVERFLOW") return { category: "context_overflow" };
+  if (code === "MODEL_PROVIDER_ERROR") return { category: "model_error" };
+  if (code === "MODEL_THINKING_FAILED") return { category: "thinking" };
+
+  // Fall back to type guards for non-model errors
+  if (isPermissionError(error)) return { category: "auth" };
+  if (isRateLimitError(error)) return { category: "rate_limit" };
+  if (isTimeoutError(error)) return { category: "timeout" };
+  if (isValidationError(error)) return { category: "unknown" };
+  if (isExternalError(error)) return { category: "unknown" };
+
+  return { category: "unknown" };
+}
+
+// ---------------------------------------------------------------------------
+// Raw error classification (non-TemplarError)
+// ---------------------------------------------------------------------------
+
+function classifyRawError(error: unknown, provider?: string): ClassificationResult {
+  const status = extractHttpStatus(error);
+  const body = extractErrorBody(error);
+  const retryAfterMs = extractRetryAfter(error);
+
+  // Try provider-specific matcher first
+  if (provider && provider in PROVIDER_MATCHERS) {
+    const matcher = PROVIDER_MATCHERS[provider];
+    if (matcher) {
+      const result = matcher(status, body);
+      if (result !== "unknown") {
+        return {
+          category: result,
+          ...(retryAfterMs !== undefined ? { retryAfterMs } : {}),
+        };
+      }
+    }
+  }
+
+  // Fall back to generic HTTP status classification
+  const category = classifyByHttpStatus(status);
+  return {
+    category,
+    ...(retryAfterMs !== undefined ? { retryAfterMs } : {}),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// HTTP status extraction
+// ---------------------------------------------------------------------------
+
+function extractHttpStatus(error: unknown): number | undefined {
+  if (typeof error !== "object" || error === null) return undefined;
+
+  const e = error as Record<string, unknown>;
+
+  // Direct status field (most common)
+  if (typeof e.status === "number") return e.status;
+  if (typeof e.statusCode === "number") return e.statusCode;
+
+  // Nested in response object
+  const response = e.response;
+  if (typeof response === "object" && response !== null) {
+    const r = response as Record<string, unknown>;
+    if (typeof r.status === "number") return r.status;
+    if (typeof r.statusCode === "number") return r.statusCode;
+  }
+
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Error body extraction
+// ---------------------------------------------------------------------------
+
+function extractErrorBody(error: unknown): string {
+  if (typeof error !== "object" || error === null) return "";
+
+  const e = error as Record<string, unknown>;
+
+  // message field
+  if (typeof e.message === "string") return e.message;
+
+  // error.error.message (OpenAI / Anthropic patterns)
+  const errorField = e.error;
+  if (typeof errorField === "object" && errorField !== null) {
+    const ef = errorField as Record<string, unknown>;
+    if (typeof ef.message === "string") return ef.message;
+    if (typeof ef.type === "string") return ef.type;
+  }
+
+  // error.body (some SDKs)
+  if (typeof e.body === "string") return e.body;
+
+  return "";
+}
+
+// ---------------------------------------------------------------------------
+// Retry-After extraction
+// ---------------------------------------------------------------------------
+
+/** Maximum allowed retry-after in ms (5 minutes) */
+const MAX_RETRY_AFTER_MS = 300_000;
+
+function extractRetryAfter(error: unknown): number | undefined {
+  if (typeof error !== "object" || error === null) return undefined;
+
+  const e = error as Record<string, unknown>;
+
+  // Try error.headers['retry-after']
+  const retryAfter =
+    getRetryAfterFromHeaders(e.headers) ??
+    getRetryAfterFromHeaders((e.response as Record<string, unknown> | undefined)?.headers);
+
+  if (retryAfter === undefined) return undefined;
+
+  return parseRetryAfterValue(retryAfter);
+}
+
+function getRetryAfterFromHeaders(headers: unknown): string | undefined {
+  if (typeof headers === "object" && headers !== null) {
+    const h = headers as Record<string, unknown>;
+
+    // Map/Headers .get()
+    if (typeof h.get === "function") {
+      const val = (h as { get(name: string): unknown }).get("retry-after");
+      if (typeof val === "string") return val;
+    }
+
+    // Plain object
+    const val = h["retry-after"] ?? h["Retry-After"];
+    if (typeof val === "string") return val;
+  }
+  return undefined;
+}
+
+function parseRetryAfterValue(value: string): number | undefined {
+  // Try as integer seconds
+  const seconds = Number(value);
+  if (!Number.isNaN(seconds) && seconds >= 0) {
+    return Math.min(seconds * 1000, MAX_RETRY_AFTER_MS);
+  }
+
+  // Try as HTTP-date
+  const date = Date.parse(value);
+  if (!Number.isNaN(date)) {
+    const delayMs = Math.max(0, date - Date.now());
+    return Math.min(delayMs, MAX_RETRY_AFTER_MS);
+  }
+
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Provider-specific matchers
+// ---------------------------------------------------------------------------
+
+type ProviderMatcher = (status: number | undefined, body: string) => ProviderErrorCategory;
+
+const PROVIDER_MATCHERS: Readonly<Record<string, ProviderMatcher>> = {
+  anthropic: classifyAnthropic,
+  openai: classifyOpenAI,
+  google: classifyGoogle,
+  ollama: classifyOllama,
+};
+
+function classifyAnthropic(status: number | undefined, body: string): ProviderErrorCategory {
+  if (status === 401 || status === 403) return "auth";
+  if (status === 429 || status === 529) return "rate_limit";
+  if (status === 500) return "model_error";
+
+  if (status === 400) {
+    const lower = body.toLowerCase();
+    if (
+      lower.includes("budget_tokens") ||
+      lower.includes("thinking block") ||
+      lower.includes("thinking blocks")
+    ) {
+      return "thinking";
+    }
+    if (lower.includes("context") || lower.includes("token")) {
+      return "context_overflow";
+    }
+    return "unknown";
+  }
+
+  return "unknown";
+}
+
+function classifyOpenAI(status: number | undefined, body: string): ProviderErrorCategory {
+  if (status === 401) return "auth";
+  if (status === 403) return "auth";
+
+  if (status === 429) {
+    const lower = body.toLowerCase();
+    if (lower.includes("insufficient_quota")) return "billing";
+    return "rate_limit";
+  }
+
+  if (status === 400) {
+    const lower = body.toLowerCase();
+    if (lower.includes("context_length_exceeded")) return "context_overflow";
+    if (lower.includes("model_not_found")) return "model_error";
+    return "unknown";
+  }
+
+  if (status === 500 || status === 503) return "model_error";
+
+  return "unknown";
+}
+
+function classifyGoogle(status: number | undefined, body: string): ProviderErrorCategory {
+  if (status === 401 || status === 403) return "auth";
+  if (status === 429) return "rate_limit";
+  if (status === 404 || status === 500 || status === 503) return "model_error";
+
+  if (status === 400) {
+    const lower = body.toLowerCase();
+    if (lower.includes("token") || lower.includes("context")) {
+      return "context_overflow";
+    }
+    return "unknown";
+  }
+
+  return "unknown";
+}
+
+function classifyOllama(status: number | undefined, _body: string): ProviderErrorCategory {
+  if (status === 404) return "model_error";
+  if (status === 429) return "rate_limit";
+  if (status === 500 || status === 502) return "model_error";
+  return "unknown";
+}
+
+// ---------------------------------------------------------------------------
+// Generic HTTP status fallback
+// ---------------------------------------------------------------------------
+
+function classifyByHttpStatus(status: number | undefined): ProviderErrorCategory {
+  if (status === undefined) return "unknown";
+
+  if (status === 401 || status === 403) return "auth";
+  if (status === 429) return "rate_limit";
+  if (status === 408 || status === 504) return "timeout";
+  if (status === 413) return "context_overflow";
+  if (status >= 500) return "model_error";
+
+  return "unknown";
+}

--- a/packages/model-router/src/index.ts
+++ b/packages/model-router/src/index.ts
@@ -7,12 +7,14 @@
  */
 
 export { CircuitBreaker } from "./circuit-breaker.js";
+export { classifyError } from "./classify.js";
 export { KeyPool } from "./key-pool.js";
 export { formatModelId, normalizeModelSelection, parseModelId } from "./model-id.js";
 export { ModelRouter } from "./router.js";
 export type {
   CircuitBreakerConfig,
   CircuitState,
+  ClassificationResult,
   CompletionRequest,
   CompletionResponse,
   FailoverAction,
@@ -32,6 +34,7 @@ export type {
   RoutingStrategy,
   StreamChunk,
   StreamChunkType,
+  ThinkingLevel,
   TokenUsage,
   ToolCall,
   ToolDefinition,

--- a/packages/model-router/src/middleware.ts
+++ b/packages/model-router/src/middleware.ts
@@ -1,5 +1,11 @@
 import type { TemplarMiddleware, TurnContext } from "@templar/core";
 import type { ModelRouter } from "./router.js";
+import type { ModelRef } from "./types.js";
+
+/** Optional PreModelSelect hook stored in turn metadata */
+export type PreModelSelectHook = (
+  candidates: readonly ModelRef[],
+) => readonly ModelRef[] | Promise<readonly ModelRef[]>;
 
 /**
  * Thin middleware adapter that wires ModelRouter into the Templar lifecycle.
@@ -7,6 +13,7 @@ import type { ModelRouter } from "./router.js";
  * On each turn:
  * - Injects router diagnostics into turn metadata
  * - Wires onUsage events to track costs per-turn
+ * - Bridges PreModelSelect hook from metadata to router
  */
 export class ModelRouterMiddleware implements TemplarMiddleware {
   readonly name = "model-router";

--- a/packages/model-router/src/validation.ts
+++ b/packages/model-router/src/validation.ts
@@ -28,11 +28,18 @@ const ModelSelectionSchema = z.union([
     model: z.string().min(1),
     temperature: z.number().min(0).max(2).optional(),
     maxTokens: z.number().int().positive().optional(),
-    thinking: z.enum(["extended", "standard", "none"]).optional(),
+    thinking: z.enum(["adaptive", "extended", "standard", "none"]).optional(),
   }),
 ]);
 
-const FailoverActionSchema = z.enum(["rotate_key", "backoff", "retry", "compact", "fallback"]);
+const FailoverActionSchema = z.enum([
+  "rotate_key",
+  "backoff",
+  "retry",
+  "compact",
+  "fallback",
+  "thinking_downgrade",
+]);
 
 const ProviderErrorCategorySchema = z.enum([
   "auth",
@@ -41,6 +48,7 @@ const ProviderErrorCategorySchema = z.enum([
   "timeout",
   "context_overflow",
   "model_error",
+  "thinking",
   "unknown",
 ]);
 
@@ -62,6 +70,7 @@ const ModelRouterConfigSchema = z.object({
   maxRetries: z.number().int().nonnegative().optional(),
   retryBaseDelayMs: z.number().positive().optional(),
   retryMaxDelayMs: z.number().positive().optional(),
+  onPreModelSelect: z.function().optional(),
 });
 
 /**

--- a/packages/test-utils/src/mock-provider.ts
+++ b/packages/test-utils/src/mock-provider.ts
@@ -31,7 +31,7 @@ export interface MockCompletionRequest {
   readonly maxTokens?: number;
   readonly temperature?: number;
   readonly tools?: readonly unknown[];
-  readonly thinking?: "extended" | "standard" | "none";
+  readonly thinking?: "adaptive" | "extended" | "standard" | "none";
   readonly responseFormat?: unknown;
 }
 


### PR DESCRIPTION
## Summary

Implements Issue #31: Error Classification — 7-Category Model Failover for `@templar/model-router`.

- **Provider-aware error classifier** (`classify.ts`): Maps raw HTTP errors from Anthropic, OpenAI, Google, and Ollama to 8 semantic categories (auth, billing, rate_limit, timeout, context_overflow, model_error, thinking, unknown) with Retry-After header parsing
- **3-tier thinking downgrade chain**: `adaptive → standard → none` / `extended → standard → none` with configurable `thinkingDowngrade` flag
- **Full Jitter backoff**: Replaces equal jitter with `random(0, min(cap, base × 2^attempt))` + respects Retry-After headers (capped at 5min)
- **DRY failover resolution**: Extracted `resolveFailoverAction()` helper used by both `complete()` and `stream()`, eliminating duplicated error handling logic
- **PreModelSelect hook**: `onPreModelSelect` callback for candidate chain reordering before routing
- **Error catalog**: Added `MODEL_THINKING_FAILED` to `@templar/errors`
- **Validation**: Updated Zod schema with new categories, actions, and config options

### Stream: #31

### Architecture Alignment (Lego)

Each package remains self-contained and composable:
- `@templar/errors` — catalog entry only, no coupling to model-router
- `@templar/model-router` — classifier is a pure function, router consumes it via composition
- `@templar/test-utils` — updated MockProvider types for `ThinkingLevel`
- Middleware adapter bridges router to Templar lifecycle without tight coupling

### Files Changed (12 files, +1221 / -137)

| Package | File | Change |
|---------|------|--------|
| `@templar/errors` | `catalog.ts` | +`MODEL_THINKING_FAILED` entry |
| `@templar/model-router` | `classify.ts` | **NEW** — provider-aware classifier (~300 lines) |
| | `types.ts` | +`thinking` category, `ThinkingLevel`, `ClassificationResult`, `onPreModelSelect` |
| | `router.ts` | Refactored: DRY failover, 3-tier thinking chain, full jitter, async `buildTargetChain` |
| | `middleware.ts` | +`PreModelSelectHook` type |
| | `validation.ts` | +thinking/thinking_downgrade/adaptive/onPreModelSelect |
| | `index.ts` | +exports |
| `@templar/test-utils` | `mock-provider.ts` | +`adaptive` to thinking type |
| Tests | `classify.test.ts` | **NEW** — 56 tests |
| | `router.test.ts` | +12 tests (thinking chain, jitter, hooks) |
| | `validation.test.ts` | +3 tests |
| | `middleware.test.ts` | +1 test |

## Test plan

- [x] 56 classify tests covering all 4 providers + edge cases
- [x] 12 new router tests (thinking downgrade chain, full jitter, PreModelSelect hook)
- [x] 3 validation schema tests (new categories/actions)
- [x] 1 middleware hook test
- [x] All 393 tests pass (221 errors + 172 model-router)
- [x] Both packages build with DTS generation
- [x] Downstream `@templar/test-utils` builds clean
- [x] Biome lint passes on all changed files
- [ ] CI pipeline passes