### PR TITLE
feat(memory): add auto-save with pluggable LLM fact extraction

### DIFF
--- a/packages/middleware/src/memory/__tests__/e2e.test.ts
+++ b/packages/middleware/src/memory/__tests__/e2e.test.ts
@@ -1,0 +1,340 @@
+/**
+ * E2E test — exercises NexusMemoryMiddleware against a live Nexus
+ * server with authentication + permissions.
+ *
+ * Requires:
+ *   NEXUS_E2E_URL  (default: http://localhost:2028)
+ *   NEXUS_E2E_KEY  (admin API key)
+ *
+ * Skips automatically when the env vars are absent.
+ */
+
+import { NexusClient } from "@nexus/sdk";
+import type { SessionContext, TurnContext } from "@templar/core";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { NexusMemoryMiddleware } from "../middleware.js";
+import type {
+  ExtractedFact,
+  FactExtractionContext,
+  FactExtractor,
+  FactTurnSummary,
+  NexusMemoryConfig,
+} from "../types.js";
+
+// ============================================================================
+// ENV GUARD — skip when Nexus is not available
+// ============================================================================
+
+const NEXUS_URL = process.env.NEXUS_E2E_URL ?? "http://localhost:2028";
+const NEXUS_KEY = process.env.NEXUS_E2E_KEY ?? "";
+const E2E_ENABLED = NEXUS_KEY.length > 0;
+
+const describeE2E = E2E_ENABLED ? describe : describe.skip;
+
+// ============================================================================
+// Test helpers
+// ============================================================================
+
+/** Deterministic extractor returning canned facts for e2e */
+class E2EFactExtractor implements FactExtractor {
+  async extract(
+    turns: readonly FactTurnSummary[],
+    _context: FactExtractionContext,
+  ): Promise<readonly ExtractedFact[]> {
+    if (turns.length === 0) return [];
+    return turns.map((t) => ({
+      content: `E2E fact from turn ${t.turnNumber}: ${t.input.slice(0, 50)}`,
+      category: "experience" as const,
+      importance: 0.5,
+      pathKey: `e2e:turn-${t.turnNumber}`,
+    }));
+  }
+}
+
+function createClient(): NexusClient {
+  return new NexusClient({
+    apiKey: NEXUS_KEY,
+    baseUrl: NEXUS_URL,
+    timeout: 10_000,
+  });
+}
+
+function makeConfig(overrides: Partial<NexusMemoryConfig> = {}): NexusMemoryConfig {
+  return {
+    scope: "agent",
+    namespace: `e2e-mem-${Date.now()}`,
+    ...overrides,
+  };
+}
+
+function makeSession(overrides?: Partial<SessionContext>): SessionContext {
+  return {
+    sessionId: `e2e-session-${Date.now()}`,
+    agentId: "e2e-agent",
+    userId: "e2e-user",
+    ...overrides,
+  };
+}
+
+function makeTurn(overrides?: Partial<TurnContext>): TurnContext {
+  return {
+    sessionId: "e2e-session",
+    turnNumber: 1,
+    input: "What is the project status?",
+    output: "The project is on track. We shipped feature X yesterday.",
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// E2E TESTS
+// ============================================================================
+
+describeE2E("NexusMemory E2E (live Nexus)", () => {
+  let client: NexusClient;
+  const storedIds: string[] = [];
+
+  beforeAll(() => {
+    client = createClient();
+  });
+
+  afterAll(async () => {
+    for (const id of storedIds) {
+      try {
+        await client.memory.delete(id);
+      } catch {
+        // best-effort cleanup
+      }
+    }
+  });
+
+  // =========================================================================
+  // #1: Health check — Nexus server is reachable with auth
+  // =========================================================================
+
+  it("should connect to Nexus server with auth", async () => {
+    const response = await fetch(`${NEXUS_URL}/health`, {
+      headers: { Authorization: `Bearer ${NEXUS_KEY}` },
+    });
+    const data = (await response.json()) as { status: string; has_auth: boolean };
+    expect(data.status).toBe("healthy");
+    expect(data.has_auth).toBe(true);
+  });
+
+  // =========================================================================
+  // #2: Full session lifecycle — start → turns → end
+  // =========================================================================
+
+  it("should run full session lifecycle: start → turns → end", async () => {
+    const config = makeConfig({ autoSaveInterval: 1 });
+    const extractor = new E2EFactExtractor();
+    const mw = new NexusMemoryMiddleware(client, config, extractor);
+
+    const session = makeSession();
+
+    // Session start — loads from Nexus (empty initially)
+    await mw.onSessionStart(session);
+
+    // Turn 1
+    const turn1 = makeTurn({ sessionId: session.sessionId, turnNumber: 1 });
+    await mw.onBeforeTurn(turn1);
+    await mw.onAfterTurn(turn1);
+
+    // Allow async to settle
+    await new Promise((r) => setTimeout(r, 200));
+
+    // Turn 2
+    const turn2 = makeTurn({
+      sessionId: session.sessionId,
+      turnNumber: 2,
+      input: "Can you refactor the auth module?",
+      output: "Sure, I'll restructure the auth module using the middleware pattern.",
+    });
+    await mw.onBeforeTurn(turn2);
+    await mw.onAfterTurn(turn2);
+    await new Promise((r) => setTimeout(r, 200));
+
+    // Session end — final flush
+    await mw.onSessionEnd(session);
+  });
+
+  // =========================================================================
+  // #3: Fact storage and query verification
+  // =========================================================================
+
+  it("should store facts queryable from Nexus", async () => {
+    const namespace = `e2e-fact-query-${Date.now()}`;
+    const config = makeConfig({
+      namespace,
+      autoSaveInterval: 1,
+    });
+    const extractor = new E2EFactExtractor();
+    const mw = new NexusMemoryMiddleware(client, config, extractor);
+
+    const session = makeSession();
+    await mw.onSessionStart(session);
+
+    // Generate a fact
+    await mw.onAfterTurn(
+      makeTurn({
+        sessionId: session.sessionId,
+        turnNumber: 1,
+        input: "Queryable fact test",
+      }),
+    );
+
+    // Wait for store to complete
+    await new Promise((r) => setTimeout(r, 500));
+
+    await mw.onSessionEnd(session);
+    await new Promise((r) => setTimeout(r, 500));
+
+    // Query facts from Nexus
+    const result = await client.memory.query({
+      memory_type: "experience",
+      namespace,
+      limit: 10,
+    });
+
+    expect(result.results.length).toBeGreaterThan(0);
+
+    // Track for cleanup
+    for (const entry of result.results) {
+      storedIds.push(entry.memory_id);
+    }
+  });
+
+  // =========================================================================
+  // #4: Dedup verification — same content not stored twice
+  // =========================================================================
+
+  it("should deduplicate identical content within a session", async () => {
+    const namespace = `e2e-dedup-${Date.now()}`;
+    const config = makeConfig({
+      namespace,
+      autoSaveInterval: 3,
+      autoSave: { deduplication: true },
+    });
+
+    // Extractor that returns identical content for all turns
+    const dupExtractor: FactExtractor = {
+      async extract(turns: readonly FactTurnSummary[]): Promise<readonly ExtractedFact[]> {
+        return turns.map(() => ({
+          content: "Identical fact content for dedup test",
+          category: "fact" as const,
+          importance: 0.6,
+        }));
+      },
+    };
+
+    const mw = new NexusMemoryMiddleware(client, config, dupExtractor);
+    const session = makeSession();
+    await mw.onSessionStart(session);
+
+    // 3 turns with identical extracted content
+    for (let i = 1; i <= 3; i++) {
+      await mw.onAfterTurn(
+        makeTurn({
+          sessionId: session.sessionId,
+          turnNumber: i,
+          input: `Dedup test turn ${i}`,
+        }),
+      );
+    }
+
+    await new Promise((r) => setTimeout(r, 500));
+    await mw.onSessionEnd(session);
+    await new Promise((r) => setTimeout(r, 500));
+
+    // Query stored facts
+    const result = await client.memory.query({
+      memory_type: "fact",
+      namespace,
+      limit: 10,
+    });
+
+    // Should have only 1 unique fact (not 3)
+    expect(result.results.length).toBe(1);
+
+    for (const entry of result.results) {
+      storedIds.push(entry.memory_id);
+    }
+  });
+
+  // =========================================================================
+  // #5: Performance — session start + per-turn latency
+  // =========================================================================
+
+  it("should meet performance targets (start < 500ms, per-turn < 50ms)", async () => {
+    const config = makeConfig({ autoSaveInterval: 5 });
+    const extractor = new E2EFactExtractor();
+    const mw = new NexusMemoryMiddleware(client, config, extractor);
+
+    const session = makeSession();
+
+    // Measure session start latency
+    const startTime = performance.now();
+    await mw.onSessionStart(session);
+    const sessionStartMs = performance.now() - startTime;
+
+    expect(sessionStartMs).toBeLessThan(500);
+    console.log(`[e2e] Session start: ${Math.round(sessionStartMs)}ms`);
+
+    // Measure per-turn latency (onBeforeTurn + onAfterTurn, excluding async extraction)
+    const turnTimes: number[] = [];
+    for (let i = 1; i <= 5; i++) {
+      const turnStart = performance.now();
+      const ctx = makeTurn({ sessionId: session.sessionId, turnNumber: i });
+      await mw.onBeforeTurn(ctx);
+      await mw.onAfterTurn(ctx);
+      turnTimes.push(performance.now() - turnStart);
+    }
+
+    const avgTurnMs = turnTimes.reduce((a, b) => a + b, 0) / turnTimes.length;
+    expect(avgTurnMs).toBeLessThan(50);
+    console.log(`[e2e] Avg per-turn: ${avgTurnMs.toFixed(2)}ms`);
+
+    await mw.onSessionEnd(session);
+  });
+
+  // =========================================================================
+  // #6: Session distillation stored correctly
+  // =========================================================================
+
+  it("should store session distillation on session end", async () => {
+    const namespace = `e2e-distill-${Date.now()}`;
+    const config = makeConfig({ namespace, autoSaveInterval: 10 });
+    const extractor = new E2EFactExtractor();
+    const mw = new NexusMemoryMiddleware(client, config, extractor);
+
+    const session = makeSession();
+    await mw.onSessionStart(session);
+
+    // A few turns
+    for (let i = 1; i <= 3; i++) {
+      await mw.onAfterTurn(
+        makeTurn({
+          sessionId: session.sessionId,
+          turnNumber: i,
+          input: `Distillation test turn ${i}`,
+        }),
+      );
+    }
+
+    await mw.onSessionEnd(session);
+    await new Promise((r) => setTimeout(r, 500));
+
+    // Query for distillation
+    const result = await client.memory.query({
+      namespace,
+      limit: 20,
+    });
+
+    // Should have facts + distillation
+    expect(result.results.length).toBeGreaterThan(0);
+
+    for (const entry of result.results) {
+      storedIds.push(entry.memory_id);
+    }
+  });
+});

--- a/packages/middleware/src/memory/__tests__/extractor.test.ts
+++ b/packages/middleware/src/memory/__tests__/extractor.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it, vi } from "vitest";
+import { LlmFactExtractor } from "../extractor.js";
+import { FACT_EXTRACTION_SYSTEM_PROMPT } from "../fact-prompt.js";
+import type { FactExtractionContext, FactTurnSummary, ModelCallFn } from "../types.js";
+
+function makeTurn(overrides: Partial<FactTurnSummary> = {}): FactTurnSummary {
+  return {
+    turnNumber: 1,
+    input: "What is the project status?",
+    output: "The project is on track. We shipped feature X yesterday.",
+    timestamp: "2025-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function makeContext(overrides: Partial<FactExtractionContext> = {}): FactExtractionContext {
+  return {
+    sessionId: "test-session-1",
+    ...overrides,
+  };
+}
+
+describe("LlmFactExtractor", () => {
+  it("should extract facts from well-formed LLM output", async () => {
+    const mockModelCall: ModelCallFn = vi
+      .fn()
+      .mockResolvedValue(
+        [
+          "fact | 0.8 | Project uses Next.js 14 with app router",
+          "preference | 0.9 | User prefers TypeScript strict mode",
+        ].join("\n"),
+      );
+
+    const extractor = new LlmFactExtractor(mockModelCall);
+    const result = await extractor.extract([makeTurn()], makeContext());
+
+    expect(result).toHaveLength(2);
+    expect(result[0]?.category).toBe("fact");
+    expect(result[0]?.importance).toBe(0.8);
+    expect(result[1]?.category).toBe("preference");
+  });
+
+  it("should return empty array for empty turns", async () => {
+    const mockModelCall: ModelCallFn = vi.fn();
+    const extractor = new LlmFactExtractor(mockModelCall);
+    const result = await extractor.extract([], makeContext());
+
+    expect(result).toHaveLength(0);
+    expect(mockModelCall).not.toHaveBeenCalled();
+  });
+
+  it("should pass system prompt to model call", async () => {
+    const mockModelCall: ModelCallFn = vi.fn().mockResolvedValue("fact | 0.5 | Some fact");
+
+    const extractor = new LlmFactExtractor(mockModelCall);
+    await extractor.extract([makeTurn()], makeContext());
+
+    expect(mockModelCall).toHaveBeenCalledWith(
+      FACT_EXTRACTION_SYSTEM_PROMPT,
+      expect.stringContaining("Turn 1"),
+    );
+  });
+
+  it("should include turn input and output in user prompt", async () => {
+    const mockModelCall: ModelCallFn = vi.fn().mockResolvedValue("");
+
+    const extractor = new LlmFactExtractor(mockModelCall);
+    await extractor.extract(
+      [makeTurn({ input: "My custom input", output: "My custom output" })],
+      makeContext(),
+    );
+
+    const userPrompt = (mockModelCall as ReturnType<typeof vi.fn>).mock.calls[0]?.[1] as string;
+    expect(userPrompt).toContain("My custom input");
+    expect(userPrompt).toContain("My custom output");
+  });
+
+  it("should return empty on LLM error (graceful degradation)", async () => {
+    const mockModelCall: ModelCallFn = vi.fn().mockRejectedValue(new Error("LLM API timeout"));
+
+    const extractor = new LlmFactExtractor(mockModelCall);
+    const result = await extractor.extract([makeTurn()], makeContext());
+
+    expect(result).toHaveLength(0);
+  });
+
+  it("should handle empty LLM response", async () => {
+    const mockModelCall: ModelCallFn = vi.fn().mockResolvedValue("");
+
+    const extractor = new LlmFactExtractor(mockModelCall);
+    const result = await extractor.extract([makeTurn()], makeContext());
+
+    expect(result).toHaveLength(0);
+  });
+
+  it("should truncate long turn content", async () => {
+    const longInput = "x".repeat(2000);
+    const longOutput = "y".repeat(2000);
+    const mockModelCall: ModelCallFn = vi.fn().mockResolvedValue("fact | 0.5 | Truncated");
+
+    const extractor = new LlmFactExtractor(mockModelCall);
+    await extractor.extract([makeTurn({ input: longInput, output: longOutput })], makeContext());
+
+    const userPrompt = (mockModelCall as ReturnType<typeof vi.fn>).mock.calls[0]?.[1] as string;
+    // Should be truncated — not contain the full 2000-char strings
+    expect(userPrompt.length).toBeLessThan(longInput.length + longOutput.length);
+  });
+
+  it("should return empty on LLM timeout (never-resolving promise)", async () => {
+    const neverResolves: ModelCallFn = vi.fn().mockImplementation(
+      () => new Promise(() => {}), // Never resolves
+    );
+
+    const extractor = new LlmFactExtractor(neverResolves);
+
+    // When used via middleware, safeNexusCall applies a timeout.
+    // The extractor itself returns [] on any error (including AbortError from timeout).
+    // Direct call: wrapping with a manual timeout to verify graceful degradation.
+    const result = await Promise.race([
+      extractor.extract([makeTurn()], makeContext()),
+      new Promise<readonly []>((resolve) => setTimeout(() => resolve([] as const), 100)),
+    ]);
+
+    expect(result).toHaveLength(0);
+  });
+
+  it("should handle multiple turns", async () => {
+    const mockModelCall: ModelCallFn = vi
+      .fn()
+      .mockResolvedValue(
+        [
+          "decision | 0.7 | Decided to use middleware pattern",
+          "experience | 0.5 | Build succeeded after fixing imports",
+        ].join("\n"),
+      );
+
+    const extractor = new LlmFactExtractor(mockModelCall);
+    const turns = [
+      makeTurn({ turnNumber: 1, input: "First turn" }),
+      makeTurn({ turnNumber: 2, input: "Second turn" }),
+    ];
+    const result = await extractor.extract(turns, makeContext());
+
+    expect(result).toHaveLength(2);
+
+    const userPrompt = (mockModelCall as ReturnType<typeof vi.fn>).mock.calls[0]?.[1] as string;
+    expect(userPrompt).toContain("Turn 1");
+    expect(userPrompt).toContain("Turn 2");
+  });
+});

--- a/packages/middleware/src/memory/__tests__/parser.test.ts
+++ b/packages/middleware/src/memory/__tests__/parser.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import { parseFacts } from "../parser.js";
+
+describe("parseFacts", () => {
+  it("should parse well-formed lines", () => {
+    const input = "fact | 0.8 | User prefers TypeScript over JavaScript";
+    const result = parseFacts(input);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      content: "User prefers TypeScript over JavaScript",
+      category: "fact",
+      importance: 0.8,
+    });
+  });
+
+  it("should parse multiple lines", () => {
+    const input = [
+      "preference | 0.9 | User wants dark mode by default",
+      "decision | 0.7 | Chose React over Vue for the frontend",
+      "experience | 0.5 | Session involved debugging a CSS issue",
+    ].join("\n");
+
+    const result = parseFacts(input);
+    expect(result).toHaveLength(3);
+    expect(result[0]?.category).toBe("preference");
+    expect(result[1]?.category).toBe("decision");
+    expect(result[2]?.category).toBe("experience");
+  });
+
+  it("should return empty array for empty input", () => {
+    expect(parseFacts("")).toEqual([]);
+    expect(parseFacts("   ")).toEqual([]);
+    expect(parseFacts("\n\n")).toEqual([]);
+  });
+
+  it("should skip lines without pipes", () => {
+    const input = "This is just a plain sentence without pipes";
+    expect(parseFacts(input)).toEqual([]);
+  });
+
+  it("should skip lines with only one pipe (missing importance)", () => {
+    const input = "fact | some content without importance";
+    // This has a pipe but only two parts instead of three
+    expect(parseFacts(input)).toEqual([]);
+  });
+
+  it("should handle embedded pipes in content", () => {
+    const input = "fact | 0.6 | User said: use foo | bar as separator";
+    const result = parseFacts(input);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.content).toBe("User said: use foo | bar as separator");
+  });
+
+  it("should skip lines with invalid category", () => {
+    const input = "unknown_cat | 0.5 | Some content here";
+    expect(parseFacts(input)).toEqual([]);
+  });
+
+  it("should skip lines with non-numeric importance", () => {
+    const input = "fact | high | Some content here";
+    expect(parseFacts(input)).toEqual([]);
+  });
+
+  it("should handle case-insensitive categories", () => {
+    const input = [
+      "FACT | 0.8 | Upper case category",
+      "Preference | 0.7 | Mixed case category",
+    ].join("\n");
+
+    const result = parseFacts(input);
+    expect(result).toHaveLength(2);
+    expect(result[0]?.category).toBe("fact");
+    expect(result[1]?.category).toBe("preference");
+  });
+
+  it("should skip lines with empty content", () => {
+    const input = "fact | 0.5 |   ";
+    expect(parseFacts(input)).toEqual([]);
+  });
+
+  it("should clamp importance to [0, 1] range", () => {
+    const input = ["fact | 1.5 | Over max importance", "fact | -0.3 | Under min importance"].join(
+      "\n",
+    );
+
+    const result = parseFacts(input);
+    expect(result).toHaveLength(2);
+    expect(result[0]?.importance).toBe(1.0);
+    expect(result[1]?.importance).toBe(0.0);
+  });
+
+  it("should trim whitespace from all parts", () => {
+    const input = "  fact  |  0.75  |  Trimmed content here  ";
+    const result = parseFacts(input);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.category).toBe("fact");
+    expect(result[0]?.importance).toBe(0.75);
+    expect(result[0]?.content).toBe("Trimmed content here");
+  });
+});

--- a/packages/middleware/src/memory/__tests__/simple-extractor.test.ts
+++ b/packages/middleware/src/memory/__tests__/simple-extractor.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import { SimpleFactExtractor } from "../simple-extractor.js";
+import type { FactExtractionContext, FactTurnSummary } from "../types.js";
+
+function makeTurn(overrides: Partial<FactTurnSummary> = {}): FactTurnSummary {
+  return {
+    turnNumber: 1,
+    input: "What is the project status?",
+    output: "The project is progressing well. We completed the auth module yesterday.",
+    timestamp: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function makeContext(overrides: Partial<FactExtractionContext> = {}): FactExtractionContext {
+  return {
+    sessionId: "test-session-1",
+    ...overrides,
+  };
+}
+
+describe("SimpleFactExtractor", () => {
+  const extractor = new SimpleFactExtractor();
+
+  it("should extract a fact from a string output", async () => {
+    const turns = [makeTurn()];
+    const result = await extractor.extract(turns, makeContext());
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.category).toBe("experience");
+    expect(result[0]?.importance).toBe(0.5);
+    expect(result[0]?.content).toBe(turns[0]?.output);
+  });
+
+  it("should skip short outputs (< 20 chars)", async () => {
+    const turns = [makeTurn({ output: "ok" })];
+    const result = await extractor.extract(turns, makeContext());
+
+    expect(result).toHaveLength(0);
+  });
+
+  it("should skip null/undefined outputs", async () => {
+    const turns = [
+      makeTurn({ output: null as unknown as string }),
+      makeTurn({ output: undefined as unknown as string }),
+    ];
+    const result = await extractor.extract(turns, makeContext());
+
+    expect(result).toHaveLength(0);
+  });
+
+  it("should return empty for empty turns array", async () => {
+    const result = await extractor.extract([], makeContext());
+    expect(result).toHaveLength(0);
+  });
+
+  it("should handle JSON object output", async () => {
+    const jsonOutput = JSON.stringify({ result: "success", data: [1, 2, 3] });
+    const turns = [makeTurn({ output: jsonOutput })];
+    const result = await extractor.extract(turns, makeContext());
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.content).toBe(jsonOutput);
+  });
+
+  it("should extract facts from multiple turns", async () => {
+    const turns = [
+      makeTurn({ turnNumber: 1, output: "First response with sufficient length for extraction." }),
+      makeTurn({ turnNumber: 2, output: "Second response also long enough to be extracted." }),
+      makeTurn({ turnNumber: 3, output: "ok" }), // too short — skipped
+    ];
+    const result = await extractor.extract(turns, makeContext());
+
+    expect(result).toHaveLength(2);
+  });
+
+  it("should generate pathKey from output content", async () => {
+    const turns = [makeTurn({ output: "A sufficiently long output for path key generation." })];
+    const result = await extractor.extract(turns, makeContext());
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.pathKey).toBeDefined();
+    expect(typeof result[0]?.pathKey).toBe("string");
+    expect(result[0]?.pathKey?.length).toBeGreaterThan(0);
+  });
+
+  it("should generate same pathKey for same content", async () => {
+    const output = "Deterministic content for path key verification.";
+    const turns1 = [makeTurn({ output })];
+    const turns2 = [makeTurn({ output })];
+
+    const result1 = await extractor.extract(turns1, makeContext());
+    const result2 = await extractor.extract(turns2, makeContext());
+
+    expect(result1[0]?.pathKey).toBe(result2[0]?.pathKey);
+  });
+
+  it("should generate different pathKey for different content", async () => {
+    const turns1 = [makeTurn({ output: "First unique output for path key test." })];
+    const turns2 = [makeTurn({ output: "Second unique output for path key test." })];
+
+    const result1 = await extractor.extract(turns1, makeContext());
+    const result2 = await extractor.extract(turns2, makeContext());
+
+    expect(result1[0]?.pathKey).not.toBe(result2[0]?.pathKey);
+  });
+});

--- a/packages/middleware/src/memory/extractor.ts
+++ b/packages/middleware/src/memory/extractor.ts
@@ -1,0 +1,101 @@
+/**
+ * LlmFactExtractor — extracts categorized facts from conversation turns
+ * using an LLM call.
+ *
+ * Follows the LlmObservationExtractor pattern from observational memory:
+ * a pluggable interface with a default LLM-based implementation.
+ */
+
+import { FACT_EXTRACTION_SYSTEM_PROMPT } from "./fact-prompt.js";
+import { parseFacts } from "./parser.js";
+import type {
+  ExtractedFact,
+  FactExtractionContext,
+  FactExtractor,
+  FactTurnSummary,
+  ModelCallFn,
+} from "./types.js";
+
+/** Maximum characters per turn field sent to LLM (truncation limit) */
+const MAX_TURN_CONTENT_LENGTH = 500;
+
+/** Maximum total user prompt length sent to LLM */
+const MAX_USER_PROMPT_LENGTH = 15_000;
+
+/**
+ * LLM-based fact extractor.
+ *
+ * Uses a model-call function (injected) to extract structured facts
+ * from conversation turn summaries. The model-call function abstracts the
+ * LLM provider — callers can inject Haiku, Gemini Flash, or any cheap model.
+ */
+export class LlmFactExtractor implements FactExtractor {
+  private readonly modelCall: ModelCallFn;
+
+  constructor(modelCall: ModelCallFn) {
+    this.modelCall = modelCall;
+  }
+
+  async extract(
+    turns: readonly FactTurnSummary[],
+    _context: FactExtractionContext,
+  ): Promise<readonly ExtractedFact[]> {
+    if (turns.length === 0) {
+      return [];
+    }
+
+    const userPrompt = buildUserPrompt(turns);
+
+    try {
+      const llmOutput = await this.modelCall(FACT_EXTRACTION_SYSTEM_PROMPT, userPrompt);
+      return parseFacts(llmOutput);
+    } catch {
+      // Graceful degradation — extraction failure should never interrupt the agent
+      return [];
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Prompt construction
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the user prompt from turn summaries.
+ */
+function buildUserPrompt(turns: readonly FactTurnSummary[]): string {
+  const parts: string[] = [];
+
+  parts.push("## Turns to Analyze");
+  parts.push("");
+
+  for (const turn of turns) {
+    parts.push(`### Turn ${turn.turnNumber} (${turn.timestamp})`);
+
+    const inputPreview = truncate(
+      typeof turn.input === "string" ? turn.input : String(turn.input),
+      MAX_TURN_CONTENT_LENGTH,
+    );
+    parts.push(`**Input:** ${inputPreview}`);
+
+    const outputPreview = truncate(
+      typeof turn.output === "string" ? turn.output : String(turn.output),
+      MAX_TURN_CONTENT_LENGTH,
+    );
+    parts.push(`**Output:** ${outputPreview}`);
+    parts.push("");
+  }
+
+  const fullPrompt = parts.join("\n");
+  return truncate(fullPrompt, MAX_USER_PROMPT_LENGTH);
+}
+
+/**
+ * Truncate a string to maxLength, appending "..." if truncated.
+ */
+function truncate(text: string, maxLength: number): string {
+  if (text.length <= maxLength) {
+    return text;
+  }
+  return `${text.slice(0, maxLength - 3)}...`;
+}

--- a/packages/middleware/src/memory/fact-prompt.ts
+++ b/packages/middleware/src/memory/fact-prompt.ts
@@ -1,0 +1,48 @@
+/**
+ * System prompt for fact extraction — extracts categorized facts from conversation turns.
+ *
+ * Categories: fact, preference, decision, experience
+ * Format: CATEGORY | IMPORTANCE | content
+ */
+export const FACT_EXTRACTION_SYSTEM_PROMPT = `You are a fact extractor for an AI agent's conversation history.
+
+Your task is to analyze conversation turns and extract key facts. Each fact should be a dense, specific note that captures important information.
+
+## Output Format
+
+Output one fact per line, using this exact format:
+CATEGORY | IMPORTANCE | fact content
+
+Where CATEGORY is one of:
+- fact — Objective information, key data points, established truths
+- preference — User preferences, style choices, stated constraints
+- decision — Decisions made during the conversation and their rationale
+- experience — Session experiences, tool interactions, workflow patterns
+
+Where IMPORTANCE is a decimal between 0.0 and 1.0:
+- 0.9-1.0 — Critical: key decisions, user requirements, errors
+- 0.7-0.8 — Important: notable preferences, significant context
+- 0.4-0.6 — Moderate: useful background, routine interactions
+- 0.1-0.3 — Low: minor details, acknowledgements
+
+## What to Extract
+
+1. **Facts** — Key data points, file paths, API endpoints, configurations
+2. **Preferences** — User preferences for tools, styles, approaches
+3. **Decisions** — What was decided and why, chosen approaches
+4. **Experiences** — What worked, what failed, tool interaction results
+
+## Rules
+
+- Be concise: each fact should be 1-2 sentences max
+- Be specific: include file paths, function names, error messages, exact values
+- Don't duplicate: if a fact repeats earlier information, skip it
+- Don't summarize: extract specific, actionable facts, not generic summaries
+- Output only the formatted lines — no headers, no explanations
+
+## Example Output
+
+preference | 0.9 | User prefers TypeScript with strict mode enabled
+fact | 0.8 | Project uses Next.js 14 with app router at /src/app
+decision | 0.7 | Chose Zustand over Redux for client-side state management
+experience | 0.5 | Build succeeded after fixing import paths in auth module`;

--- a/packages/middleware/src/memory/index.ts
+++ b/packages/middleware/src/memory/index.ts
@@ -1,12 +1,13 @@
 import type { NexusClient } from "@nexus/sdk";
 import { NexusMemoryMiddleware, validateMemoryConfig } from "./middleware.js";
-import type { NexusMemoryConfig } from "./types.js";
+import type { FactExtractor, NexusMemoryConfig } from "./types.js";
 
 /**
  * Create a NexusMemoryMiddleware instance.
  *
  * @param client - Initialized NexusClient from @nexus/sdk
  * @param config - Memory middleware configuration
+ * @param extractor - Optional pluggable fact extractor (default: SimpleFactExtractor)
  * @returns A configured NexusMemoryMiddleware instance
  * @throws {MemoryConfigurationError} if config is invalid
  *
@@ -17,22 +18,49 @@ import type { NexusMemoryConfig } from "./types.js";
  *
  * const client = new NexusClient({ apiKey: process.env.NEXUS_API_KEY });
  *
+ * // Basic usage (SimpleFactExtractor)
  * const memoryMiddleware = createNexusMemoryMiddleware(client, {
  *   scope: 'agent',
  *   injectionStrategy: 'session_start',
  *   autoSaveInterval: 5,
  * });
+ *
+ * // With LLM-based extraction
+ * import { LlmFactExtractor } from '@templar/middleware/memory';
+ * const llmExtractor = new LlmFactExtractor(myModelCallFn);
+ * const memoryMiddleware = createNexusMemoryMiddleware(client, {
+ *   scope: 'agent',
+ *   autoSave: { useLlmExtraction: true, deduplication: true },
+ * }, llmExtractor);
  * ```
  */
 export function createNexusMemoryMiddleware(
   client: NexusClient,
   config: NexusMemoryConfig,
+  extractor?: FactExtractor,
 ): NexusMemoryMiddleware {
   validateMemoryConfig(config);
-  return new NexusMemoryMiddleware(client, config);
+  return new NexusMemoryMiddleware(client, config, extractor);
 }
 
-// Re-export types and class
+// Re-export extractors
+export { LlmFactExtractor } from "./extractor.js";
+// Re-export middleware class and validation
 export { NexusMemoryMiddleware, validateMemoryConfig } from "./middleware.js";
-export type { InjectionStrategy, NexusMemoryConfig } from "./types.js";
-export { DEFAULT_CONFIG } from "./types.js";
+// Re-export parser
+export { parseFacts } from "./parser.js";
+export { SimpleFactExtractor } from "./simple-extractor.js";
+
+// Re-export types
+export type {
+  AutoSaveConfig,
+  ExtractedFact,
+  FactExtractionContext,
+  FactExtractor,
+  FactTurnSummary,
+  InjectionStrategy,
+  MemoryCategory,
+  ModelCallFn,
+  NexusMemoryConfig,
+} from "./types.js";
+export { DEFAULT_AUTO_SAVE_CONFIG, DEFAULT_CONFIG } from "./types.js";

--- a/packages/middleware/src/memory/parser.ts
+++ b/packages/middleware/src/memory/parser.ts
@@ -1,0 +1,92 @@
+/**
+ * Parsing utilities for fact extraction LLM output.
+ *
+ * Handles well-formed, malformed, and empty LLM responses gracefully.
+ */
+
+import type { ExtractedFact, MemoryCategory } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Fact parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse LLM output into ExtractedFact[].
+ *
+ * Expected format per line:
+ *   CATEGORY | IMPORTANCE | fact content
+ *
+ * Lines that don't match are silently skipped (graceful degradation).
+ */
+export function parseFacts(llmOutput: string): readonly ExtractedFact[] {
+  if (!llmOutput.trim()) {
+    return [];
+  }
+
+  const lines = llmOutput.split("\n").filter((line) => line.trim().length > 0);
+  const facts: ExtractedFact[] = [];
+
+  for (const line of lines) {
+    const parsed = parseFactLine(line.trim());
+    if (parsed !== undefined) {
+      facts.push(parsed);
+    }
+  }
+
+  return facts;
+}
+
+/**
+ * Parse a single fact line.
+ * Returns undefined if the line doesn't match the expected format.
+ */
+function parseFactLine(line: string): ExtractedFact | undefined {
+  // Split on first two pipes to preserve content with embedded pipes
+  const firstPipe = line.indexOf("|");
+  if (firstPipe === -1) return undefined;
+
+  const secondPipe = line.indexOf("|", firstPipe + 1);
+  if (secondPipe === -1) return undefined;
+
+  const categoryRaw = line.slice(0, firstPipe).trim().toLowerCase();
+  const importanceRaw = line.slice(firstPipe + 1, secondPipe).trim();
+  const content = line.slice(secondPipe + 1).trim();
+
+  if (!content) {
+    return undefined;
+  }
+
+  const category = parseCategory(categoryRaw);
+  if (category === undefined) {
+    return undefined;
+  }
+
+  const importance = Number.parseFloat(importanceRaw);
+  if (!Number.isFinite(importance)) {
+    return undefined;
+  }
+
+  return {
+    content,
+    category,
+    importance: Math.max(0, Math.min(1, importance)),
+  };
+}
+
+/**
+ * Parse category string into MemoryCategory.
+ */
+function parseCategory(raw: string): MemoryCategory | undefined {
+  switch (raw) {
+    case "fact":
+      return "fact";
+    case "preference":
+      return "preference";
+    case "decision":
+      return "decision";
+    case "experience":
+      return "experience";
+    default:
+      return undefined;
+  }
+}

--- a/packages/middleware/src/memory/simple-extractor.ts
+++ b/packages/middleware/src/memory/simple-extractor.ts
@@ -1,0 +1,71 @@
+/**
+ * SimpleFactExtractor — wraps the existing heuristic extraction logic
+ * into the pluggable FactExtractor interface.
+ *
+ * Preserves v1 behavior: raw output as "experience" category with 0.5 importance.
+ * Adds pathKey generation for cross-session dedup via Nexus upsert.
+ */
+
+import type {
+  ExtractedFact,
+  FactExtractionContext,
+  FactExtractor,
+  FactTurnSummary,
+} from "./types.js";
+
+/** Minimum output length to be considered for extraction */
+const MIN_OUTPUT_LENGTH = 20;
+
+/**
+ * Simple heuristic-based fact extractor.
+ *
+ * Extracts raw agent output as "experience" facts — no LLM call needed.
+ * Generates a deterministic pathKey from content for cross-session dedup.
+ */
+export class SimpleFactExtractor implements FactExtractor {
+  async extract(
+    turns: readonly FactTurnSummary[],
+    _context: FactExtractionContext,
+  ): Promise<readonly ExtractedFact[]> {
+    const facts: ExtractedFact[] = [];
+
+    for (const turn of turns) {
+      const output = turn.output;
+      if (output === null || output === undefined) {
+        continue;
+      }
+
+      const text = typeof output === "string" ? output : String(output);
+      if (text.length < MIN_OUTPUT_LENGTH) {
+        continue;
+      }
+
+      facts.push({
+        content: text,
+        category: "experience",
+        importance: 0.5,
+        pathKey: generatePathKey(text),
+      });
+    }
+
+    return facts;
+  }
+}
+
+/**
+ * Generate a deterministic path_key from content for cross-session dedup.
+ *
+ * Uses a simple DJB2 hash — fast, deterministic, no crypto dependency.
+ * Returns a stable fallback for empty/invalid input.
+ */
+function generatePathKey(content: string): string {
+  if (!content || typeof content !== "string") {
+    return "mem:00000000";
+  }
+  let hash = 5381;
+  for (let i = 0; i < content.length; i++) {
+    hash = ((hash << 5) + hash + content.charCodeAt(i)) | 0;
+  }
+  // Convert to unsigned hex string
+  return `mem:${(hash >>> 0).toString(16)}`;
+}

--- a/packages/middleware/src/memory/types.ts
+++ b/packages/middleware/src/memory/types.ts
@@ -9,6 +9,81 @@ import type { MemoryScope } from "@nexus/sdk";
  */
 export type InjectionStrategy = "session_start" | "every_turn" | "on_demand";
 
+// ---------------------------------------------------------------------------
+// Memory categories and extracted facts
+// ---------------------------------------------------------------------------
+
+/** Memory category for extracted facts */
+export type MemoryCategory = "fact" | "preference" | "decision" | "experience";
+
+/** A single fact extracted from conversation turns */
+export interface ExtractedFact {
+  /** The fact content */
+  readonly content: string;
+  /** Category of the fact */
+  readonly category: MemoryCategory;
+  /** Importance score (0-1) */
+  readonly importance: number;
+  /** Optional path_key for cross-session dedup via Nexus upsert */
+  readonly pathKey?: string;
+}
+
+/** Summary of a single turn, provided to the fact extractor */
+export interface FactTurnSummary {
+  /** Sequential turn number */
+  readonly turnNumber: number;
+  /** Turn input (user message) */
+  readonly input: string;
+  /** Turn output (agent response) */
+  readonly output: string;
+  /** When this turn occurred (ISO-8601) */
+  readonly timestamp: string;
+}
+
+/** Context provided to the fact extractor */
+export interface FactExtractionContext {
+  /** Current session ID */
+  readonly sessionId: string;
+}
+
+// ---------------------------------------------------------------------------
+// Extractor interface (pluggable, follows ObservationExtractor pattern)
+// ---------------------------------------------------------------------------
+
+/** Pluggable fact extractor interface */
+export interface FactExtractor {
+  /** Extract facts from a batch of turn summaries */
+  extract(
+    turns: readonly FactTurnSummary[],
+    context: FactExtractionContext,
+  ): Promise<readonly ExtractedFact[]>;
+}
+
+/** Function type for making LLM calls (injected into extractor) */
+export type ModelCallFn = (systemPrompt: string, userPrompt: string) => Promise<string>;
+
+// ---------------------------------------------------------------------------
+// Auto-save configuration
+// ---------------------------------------------------------------------------
+
+/** Configuration for auto-save behavior */
+export interface AutoSaveConfig {
+  /** Categories to extract (default: all) */
+  readonly categories?: readonly MemoryCategory[];
+  /** Use LLM-based extraction (default: false — uses SimpleFactExtractor) */
+  readonly useLlmExtraction?: boolean;
+  /** Enable content-hash deduplication (default: true) */
+  readonly deduplication?: boolean;
+  /** Timeout for extraction in ms (default: 10000) */
+  readonly extractionTimeoutMs?: number;
+  /** Maximum pending memories in buffer (default: 100) */
+  readonly maxPendingMemories?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
 /**
  * Configuration for NexusMemoryMiddleware
  */
@@ -33,7 +108,23 @@ export interface NexusMemoryConfig {
 
   /** Optional namespace prefix for memory queries */
   namespace?: string;
+
+  /** Auto-save configuration for fact extraction */
+  autoSave?: AutoSaveConfig;
 }
+
+// ---------------------------------------------------------------------------
+// Defaults
+// ---------------------------------------------------------------------------
+
+/** Default auto-save configuration */
+export const DEFAULT_AUTO_SAVE_CONFIG: Required<AutoSaveConfig> = {
+  categories: ["fact", "preference", "decision", "experience"],
+  useLlmExtraction: false,
+  deduplication: false,
+  extractionTimeoutMs: 10000,
+  maxPendingMemories: 100,
+} as const;
 
 /**
  * Default configuration values


### PR DESCRIPTION
## Summary

Closes #93. Upgrades `NexusMemoryMiddleware` from simple heuristic extraction to a pluggable `FactExtractor` interface with LLM-based categorized extraction, content-hash deduplication, and bounded buffering.

- **Pluggable extractors:** `SimpleFactExtractor` (default, heuristic) and `LlmFactExtractor` (opt-in, LLM-based) via `FactExtractor` interface
- **Categorized facts:** `fact | preference | decision | experience` with importance scores (0–1)
- **Deduplication:** In-session content-hash (DJB2) + cross-session `path_key` upsert via Nexus
- **Turn buffering:** Buffer turns, extract at configurable intervals, flush via `batchStore`
- **Bounded buffer:** `maxPendingMemories` cap (default 100) prevents unbounded growth
- **Race condition guard:** `isExtracting` flag prevents concurrent extraction
- **Consistent error handling:** All Nexus calls use `safeNexusCall` (including distillation)
- **Backward compatible:** All new config fields optional, existing tests pass unchanged

### New files (7)
- `parser.ts` — parse `CATEGORY | IMPORTANCE | content` lines
- `fact-prompt.ts` — LLM extraction system prompt
- `simple-extractor.ts` — heuristic extractor (wraps v1 logic)
- `extractor.ts` — LLM-based extractor
- `parser.test.ts`, `simple-extractor.test.ts`, `extractor.test.ts`, `e2e.test.ts`

### Modified files (4)
- `types.ts` — `MemoryCategory`, `ExtractedFact`, `FactExtractor`, `AutoSaveConfig`, `ModelCallFn`
- `middleware.ts` — pluggable extractor, turn buffer, dedup, race guard, `safeNexusCall`
- `index.ts` — updated factory + new exports
- `middleware.test.ts` — +23 new test sections

## Test plan

- [x] 608 tests pass, 0 failures, 11 skipped (E2E — requires live Nexus)
- [x] Typecheck clean (only pre-existing chokidar/yaml errors)
- [x] ESM build succeeds
- [x] Code review: all 5 HIGH issues addressed
- [ ] E2E with `NEXUS_E2E_KEY` against live Nexus server

🤖 Generated with [Claude Code](https://claude.com/claude-code)