### PR TITLE
feat(code-mode): add LLM code execution middleware via Monty sandbox (#111)

### DIFF
--- a/packages/code-mode/package.json
+++ b/packages/code-mode/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@templar/code-mode",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check .",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@templar/core": "workspace:*",
+    "@templar/errors": "workspace:*",
+    "@nexus/sdk": "workspace:*"
+  },
+  "devDependencies": {
+    "@templar/test-utils": "workspace:*",
+    "@types/node": "^25.2.2"
+  }
+}

--- a/packages/code-mode/src/__tests__/edge-cases.test.ts
+++ b/packages/code-mode/src/__tests__/edge-cases.test.ts
@@ -1,0 +1,297 @@
+import type { SessionContext } from "@templar/core";
+import {
+  CodeModeError,
+  CodeRuntimeError,
+  CodeSandboxNotFoundError,
+  CodeSyntaxError,
+} from "@templar/errors";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createCodeModeMiddleware } from "../middleware.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createMockClient(overrides?: Record<string, unknown>) {
+  return {
+    sandbox: {
+      create: vi.fn().mockResolvedValue({
+        sandbox_id: "sbx-edge",
+        name: "code-mode-edge",
+        status: "running",
+        provider: "monty",
+        created_at: "2024-06-01T12:00:00Z",
+      }),
+      runCode: vi.fn().mockResolvedValue({
+        stdout: '{"ok": true}',
+        stderr: "",
+        exit_code: 0,
+        execution_time: 0.01,
+      }),
+      destroy: vi.fn().mockResolvedValue({
+        sandbox_id: "sbx-edge",
+        status: "destroyed",
+        provider: "monty",
+        created_at: "2024-06-01T12:00:00Z",
+      }),
+      ...overrides,
+    },
+  };
+}
+
+function ctx(): SessionContext {
+  return { sessionId: "sess-edge" };
+}
+
+function codeBlock(code: string): string {
+  return `\`\`\`python-code-mode\n${code}\n\`\`\``;
+}
+
+describe("edge cases", () => {
+  let mockClient: ReturnType<typeof createMockClient>;
+
+  beforeEach(() => {
+    mockClient = createMockClient();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // =========================================================================
+  // Empty / whitespace code
+  // =========================================================================
+
+  describe("empty code", () => {
+    it("should handle code block with only whitespace", async () => {
+      mockClient.sandbox.runCode.mockResolvedValue({
+        stdout: "",
+        stderr: "",
+        exit_code: 0,
+        execution_time: 0.001,
+      });
+
+      // biome-ignore lint/suspicious/noExplicitAny: test mock
+      const mw = createCodeModeMiddleware(mockClient as any);
+      await mw.onSessionStart?.(ctx());
+
+      // Empty code after trim still gets sent to sandbox
+      const next = vi.fn().mockResolvedValue({ content: codeBlock("  "), model: "test" });
+      const response = await mw.wrapModelCall?.(
+        { messages: [{ role: "user", content: "test" }] },
+        next,
+      );
+
+      // Empty stdout → raw output
+      expect(response.metadata?.codeModeExecuted).toBe(true);
+    });
+  });
+
+  // =========================================================================
+  // Non-JSON output
+  // =========================================================================
+
+  describe("non-JSON output", () => {
+    it("should handle plain text stdout", async () => {
+      mockClient.sandbox.runCode.mockResolvedValue({
+        stdout: "hello world",
+        stderr: "",
+        exit_code: 0,
+        execution_time: 0.01,
+      });
+
+      // biome-ignore lint/suspicious/noExplicitAny: test mock
+      const mw = createCodeModeMiddleware(mockClient as any);
+      await mw.onSessionStart?.(ctx());
+
+      const next = vi.fn().mockResolvedValue({
+        content: codeBlock('print("hello world")'),
+        model: "test",
+      });
+      const response = await mw.wrapModelCall?.(
+        { messages: [{ role: "user", content: "test" }] },
+        next,
+      );
+
+      // Non-JSON output is stringified
+      expect(response.content).toBeDefined();
+      expect(response.metadata?.codeModeExecuted).toBe(true);
+    });
+  });
+
+  // =========================================================================
+  // Sandbox unavailable
+  // =========================================================================
+
+  describe("sandbox unavailable", () => {
+    it("should pass through when sandbox was never created", async () => {
+      // biome-ignore lint/suspicious/noExplicitAny: test mock
+      const mw = createCodeModeMiddleware(mockClient as any, { enabled: false });
+      // Never call onSessionStart
+
+      const next = vi.fn().mockResolvedValue({
+        content: codeBlock("print(1)"),
+        model: "test",
+      });
+
+      const response = await mw.wrapModelCall?.(
+        { messages: [{ role: "user", content: "test" }] },
+        next,
+      );
+
+      // Should pass through because disabled
+      expect(response.content).toContain("python-code-mode");
+      expect(mockClient.sandbox.runCode).not.toHaveBeenCalled();
+    });
+
+    it("should handle sandbox create failure gracefully in session start", async () => {
+      mockClient.sandbox.create.mockRejectedValue(new Error("Service unavailable"));
+
+      // biome-ignore lint/suspicious/noExplicitAny: test mock
+      const mw = createCodeModeMiddleware(mockClient as any);
+
+      await expect(mw.onSessionStart?.(ctx())).rejects.toThrow("Service unavailable");
+    });
+  });
+
+  // =========================================================================
+  // Multiple code blocks
+  // =========================================================================
+
+  describe("multiple code blocks", () => {
+    it("should only extract the first code-mode block", async () => {
+      // biome-ignore lint/suspicious/noExplicitAny: test mock
+      const mw = createCodeModeMiddleware(mockClient as any);
+      await mw.onSessionStart?.(ctx());
+
+      const content = `First:
+\`\`\`python-code-mode
+print(json.dumps({"first": true}))
+\`\`\`
+
+Second:
+\`\`\`python-code-mode
+print(json.dumps({"second": true}))
+\`\`\``;
+
+      const next = vi.fn().mockResolvedValue({ content, model: "test" });
+      await mw.wrapModelCall?.({ messages: [{ role: "user", content: "test" }] }, next);
+
+      expect(mockClient.sandbox.runCode).toHaveBeenCalledTimes(1);
+      // biome-ignore lint/style/noNonNullAssertion: test assertion after toHaveBeenCalledTimes(1)
+      const calledCode = mockClient.sandbox.runCode.mock.calls[0]![1].code;
+      expect(calledCode).toContain('"first"');
+    });
+  });
+
+  // =========================================================================
+  // Sequential sessions
+  // =========================================================================
+
+  describe("sequential sessions", () => {
+    it("should handle start-end-start-end lifecycle correctly", async () => {
+      // biome-ignore lint/suspicious/noExplicitAny: test mock
+      const mw = createCodeModeMiddleware(mockClient as any);
+
+      // Session 1
+      await mw.onSessionStart?.(ctx());
+      expect(mockClient.sandbox.create).toHaveBeenCalledTimes(1);
+      await mw.onSessionEnd?.(ctx());
+      expect(mockClient.sandbox.destroy).toHaveBeenCalledTimes(1);
+
+      // Session 2
+      mockClient.sandbox.create.mockResolvedValue({
+        sandbox_id: "sbx-edge-2",
+        name: "code-mode-edge-2",
+        status: "running",
+        provider: "monty",
+        created_at: "2024-06-01T13:00:00Z",
+      });
+
+      await mw.onSessionStart?.(ctx());
+      expect(mockClient.sandbox.create).toHaveBeenCalledTimes(2);
+      await mw.onSessionEnd?.(ctx());
+      expect(mockClient.sandbox.destroy).toHaveBeenCalledTimes(2);
+      expect(mockClient.sandbox.destroy).toHaveBeenLastCalledWith("sbx-edge-2");
+    });
+  });
+
+  // =========================================================================
+  // Config edge cases
+  // =========================================================================
+
+  describe("config edge cases", () => {
+    it("should accept minimum valid maxCodeLength", () => {
+      expect(() =>
+        // biome-ignore lint/suspicious/noExplicitAny: test mock
+        createCodeModeMiddleware(mockClient as any, { maxCodeLength: 1 }),
+      ).not.toThrow();
+    });
+
+    it("should accept maximum valid maxCodeLength", () => {
+      expect(() =>
+        // biome-ignore lint/suspicious/noExplicitAny: test mock
+        createCodeModeMiddleware(mockClient as any, { maxCodeLength: 100_000 }),
+      ).not.toThrow();
+    });
+
+    it("should accept empty hostFunctions array", () => {
+      expect(() =>
+        // biome-ignore lint/suspicious/noExplicitAny: test mock
+        createCodeModeMiddleware(mockClient as any, { hostFunctions: [] }),
+      ).not.toThrow();
+    });
+  });
+
+  // =========================================================================
+  // Error type inheritance
+  // =========================================================================
+
+  describe("error inheritance", () => {
+    it("all code-mode errors should extend CodeModeError", async () => {
+      const errors = [
+        new CodeSyntaxError("x", 1, "bad"),
+        new CodeRuntimeError("x", "bad"),
+        new CodeSandboxNotFoundError("sbx-1"),
+      ];
+
+      for (const err of errors) {
+        expect(err).toBeInstanceOf(CodeModeError);
+        expect(err).toBeInstanceOf(Error);
+      }
+    });
+  });
+
+  // =========================================================================
+  // Stderr with line numbers
+  // =========================================================================
+
+  describe("line number extraction", () => {
+    it("should extract line number from SyntaxError stderr", async () => {
+      mockClient.sandbox.runCode.mockResolvedValue({
+        stdout: "",
+        stderr: '  File "<code>", line 5\n    x =\n       ^\nSyntaxError: invalid syntax',
+        exit_code: 1,
+        execution_time: 0.001,
+      });
+
+      // biome-ignore lint/suspicious/noExplicitAny: test mock
+      const mw = createCodeModeMiddleware(mockClient as any);
+      await mw.onSessionStart?.(ctx());
+
+      const next = vi.fn().mockResolvedValue({
+        content: codeBlock("x ="),
+        model: "test",
+      });
+
+      try {
+        await mw.wrapModelCall?.({ messages: [{ role: "user", content: "test" }] }, next);
+        expect.fail("Should have thrown");
+      } catch (e) {
+        expect(e).toBeInstanceOf(CodeSyntaxError);
+        expect((e as CodeSyntaxError).lineNumber).toBe(5);
+      }
+    });
+  });
+});

--- a/packages/code-mode/src/__tests__/middleware.test.ts
+++ b/packages/code-mode/src/__tests__/middleware.test.ts
@@ -1,0 +1,405 @@
+import type { ModelHandler, ModelRequest, ModelResponse, SessionContext } from "@templar/core";
+import {
+  CodeExecutionTimeoutError,
+  CodeResourceExceededError,
+  CodeRuntimeError,
+  CodeSandboxNotFoundError,
+  CodeSyntaxError,
+} from "@templar/errors";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createCodeModeMiddleware } from "../middleware.js";
+
+// ---------------------------------------------------------------------------
+// Mock NexusClient
+// ---------------------------------------------------------------------------
+
+function createMockClient() {
+  return {
+    sandbox: {
+      create: vi.fn().mockResolvedValue({
+        sandbox_id: "sbx-test-123",
+        name: "code-mode-test",
+        status: "running",
+        provider: "monty",
+        created_at: "2024-06-01T12:00:00Z",
+      }),
+      runCode: vi.fn().mockResolvedValue({
+        stdout: '{"result": 42}',
+        stderr: "",
+        exit_code: 0,
+        execution_time: 0.01,
+      }),
+      destroy: vi.fn().mockResolvedValue({
+        sandbox_id: "sbx-test-123",
+        status: "destroyed",
+        provider: "monty",
+        created_at: "2024-06-01T12:00:00Z",
+      }),
+    },
+  };
+}
+
+function createMockContext(overrides?: Partial<SessionContext>): SessionContext {
+  return {
+    sessionId: "sess-test-123",
+    ...overrides,
+  };
+}
+
+function createMockModelRequest(content?: string): ModelRequest {
+  return {
+    messages: [{ role: "user", content: content ?? "hello" }],
+    model: "claude-3",
+  };
+}
+
+function createMockNext(responseContent: string): ModelHandler {
+  return vi.fn().mockResolvedValue({
+    content: responseContent,
+    model: "claude-3",
+  } satisfies ModelResponse);
+}
+
+describe("CodeModeMiddleware", () => {
+  let mockClient: ReturnType<typeof createMockClient>;
+
+  beforeEach(() => {
+    mockClient = createMockClient();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // =========================================================================
+  // Factory
+  // =========================================================================
+
+  describe("createCodeModeMiddleware", () => {
+    it("should create middleware with default config", () => {
+      // biome-ignore lint/suspicious/noExplicitAny: test mock
+      const mw = createCodeModeMiddleware(mockClient as any);
+      expect(mw.name).toBe("code-mode");
+    });
+
+    it("should create middleware with partial config override", () => {
+      // biome-ignore lint/suspicious/noExplicitAny: test mock
+      const mw = createCodeModeMiddleware(mockClient as any, {
+        maxCodeLength: 5000,
+      });
+      expect(mw.name).toBe("code-mode");
+    });
+
+    it("should throw on invalid config", () => {
+      expect(() =>
+        // biome-ignore lint/suspicious/noExplicitAny: test mock
+        createCodeModeMiddleware(mockClient as any, {
+          maxCodeLength: -1,
+        }),
+      ).toThrow("Invalid code-mode config");
+    });
+  });
+
+  // =========================================================================
+  // Lifecycle
+  // =========================================================================
+
+  describe("onSessionStart", () => {
+    it("should create sandbox on session start", async () => {
+      // biome-ignore lint/suspicious/noExplicitAny: test mock
+      const mw = createCodeModeMiddleware(mockClient as any);
+      await mw.onSessionStart?.(createMockContext());
+
+      expect(mockClient.sandbox.create).toHaveBeenCalledWith({
+        name: "code-mode-sess-test-123",
+        provider: "monty",
+        securityProfile: "standard",
+      });
+    });
+
+    it("should skip sandbox creation when disabled", async () => {
+      // biome-ignore lint/suspicious/noExplicitAny: test mock
+      const mw = createCodeModeMiddleware(mockClient as any, {
+        enabled: false,
+      });
+      await mw.onSessionStart?.(createMockContext());
+
+      expect(mockClient.sandbox.create).not.toHaveBeenCalled();
+    });
+
+    it("should use configured security profile", async () => {
+      // biome-ignore lint/suspicious/noExplicitAny: test mock
+      const mw = createCodeModeMiddleware(mockClient as any, {
+        resourceProfile: "strict",
+      });
+      await mw.onSessionStart?.(createMockContext());
+
+      expect(mockClient.sandbox.create).toHaveBeenCalledWith(
+        expect.objectContaining({ securityProfile: "strict" }),
+      );
+    });
+  });
+
+  describe("onSessionEnd", () => {
+    it("should destroy sandbox on session end", async () => {
+      // biome-ignore lint/suspicious/noExplicitAny: test mock
+      const mw = createCodeModeMiddleware(mockClient as any);
+      await mw.onSessionStart?.(createMockContext());
+      await mw.onSessionEnd?.(createMockContext());
+
+      expect(mockClient.sandbox.destroy).toHaveBeenCalledWith("sbx-test-123");
+    });
+
+    it("should handle no sandbox gracefully", async () => {
+      // biome-ignore lint/suspicious/noExplicitAny: test mock
+      const mw = createCodeModeMiddleware(mockClient as any, {
+        enabled: false,
+      });
+
+      // No session start — should not throw
+      await expect(mw.onSessionEnd?.(createMockContext())).resolves.toBeUndefined();
+      expect(mockClient.sandbox.destroy).not.toHaveBeenCalled();
+    });
+
+    it("should clear sandboxId even if destroy fails", async () => {
+      mockClient.sandbox.destroy.mockRejectedValue(new Error("destroy failed"));
+      // biome-ignore lint/suspicious/noExplicitAny: test mock
+      const mw = createCodeModeMiddleware(mockClient as any);
+      await mw.onSessionStart?.(createMockContext());
+
+      await expect(mw.onSessionEnd?.(createMockContext())).rejects.toThrow("destroy failed");
+
+      // sandboxId should be null now — subsequent destroy should not call API
+      mockClient.sandbox.destroy.mockReset();
+      await mw.onSessionEnd?.(createMockContext());
+      expect(mockClient.sandbox.destroy).not.toHaveBeenCalled();
+    });
+  });
+
+  // =========================================================================
+  // wrapModelCall
+  // =========================================================================
+
+  describe("wrapModelCall — passthrough", () => {
+    it("should pass through normal text responses unchanged", async () => {
+      // biome-ignore lint/suspicious/noExplicitAny: test mock
+      const mw = createCodeModeMiddleware(mockClient as any);
+      await mw.onSessionStart?.(createMockContext());
+
+      const req = createMockModelRequest();
+      const next = createMockNext("Just a normal response.");
+
+      const response = await mw.wrapModelCall?.(req, next);
+      expect(response.content).toBe("Just a normal response.");
+    });
+
+    it("should inject code-mode prompt into system prompt", async () => {
+      // biome-ignore lint/suspicious/noExplicitAny: test mock
+      const mw = createCodeModeMiddleware(mockClient as any);
+      await mw.onSessionStart?.(createMockContext());
+
+      const req: ModelRequest = {
+        messages: [{ role: "user", content: "hello" }],
+        systemPrompt: "You are helpful.",
+      };
+      const next = createMockNext("Normal response");
+      await mw.wrapModelCall?.(req, next);
+
+      // biome-ignore lint/style/noNonNullAssertion: test assertion after mock call
+      const calledReq = (next as ReturnType<typeof vi.fn>).mock.calls[0]![0] as ModelRequest;
+      expect(calledReq.systemPrompt).toContain("You are helpful.");
+      expect(calledReq.systemPrompt).toContain("## Code Mode");
+    });
+
+    it("should set code-mode prompt when no system prompt exists", async () => {
+      // biome-ignore lint/suspicious/noExplicitAny: test mock
+      const mw = createCodeModeMiddleware(mockClient as any);
+      await mw.onSessionStart?.(createMockContext());
+
+      const req = createMockModelRequest();
+      const next = createMockNext("Normal response");
+      await mw.wrapModelCall?.(req, next);
+
+      // biome-ignore lint/style/noNonNullAssertion: test assertion after mock call
+      const calledReq = (next as ReturnType<typeof vi.fn>).mock.calls[0]![0] as ModelRequest;
+      expect(calledReq.systemPrompt).toContain("## Code Mode");
+    });
+
+    it("should pass through when disabled", async () => {
+      // biome-ignore lint/suspicious/noExplicitAny: test mock
+      const mw = createCodeModeMiddleware(mockClient as any, { enabled: false });
+
+      const req = createMockModelRequest();
+      const next = createMockNext("Normal response");
+      const response = await mw.wrapModelCall?.(req, next);
+
+      expect(response.content).toBe("Normal response");
+      // biome-ignore lint/style/noNonNullAssertion: test assertion after mock call
+      const calledReq = (next as ReturnType<typeof vi.fn>).mock.calls[0]![0] as ModelRequest;
+      // Should NOT inject code-mode prompt
+      expect(calledReq.systemPrompt).toBeUndefined();
+    });
+  });
+
+  describe("wrapModelCall — code execution", () => {
+    it("should execute code blocks and return parsed result", async () => {
+      // biome-ignore lint/suspicious/noExplicitAny: test mock
+      const mw = createCodeModeMiddleware(mockClient as any);
+      await mw.onSessionStart?.(createMockContext());
+
+      const codeResponse = `Here's the result:
+
+\`\`\`python-code-mode
+result = read_file("src/main.ts")
+print(json.dumps({"content": result}))
+\`\`\``;
+
+      const req = createMockModelRequest();
+      const next = createMockNext(codeResponse);
+
+      const response = await mw.wrapModelCall?.(req, next);
+
+      expect(mockClient.sandbox.runCode).toHaveBeenCalledWith("sbx-test-123", {
+        language: "python",
+        code: 'result = read_file("src/main.ts")\nprint(json.dumps({"content": result}))',
+        host_functions: ["read_file", "search", "memory_query"],
+      });
+      expect(response.metadata?.codeModeExecuted).toBe(true);
+    });
+
+    it("should throw CodeSyntaxError for syntax errors in execution", async () => {
+      mockClient.sandbox.runCode.mockResolvedValue({
+        stdout: "",
+        stderr: "SyntaxError: invalid syntax at line 3",
+        exit_code: 1,
+        execution_time: 0.001,
+      });
+
+      // biome-ignore lint/suspicious/noExplicitAny: test mock
+      const mw = createCodeModeMiddleware(mockClient as any);
+      await mw.onSessionStart?.(createMockContext());
+
+      const codeResponse = "```python-code-mode\nx =\n```";
+      const req = createMockModelRequest();
+      const next = createMockNext(codeResponse);
+
+      await expect(mw.wrapModelCall?.(req, next)).rejects.toBeInstanceOf(CodeSyntaxError);
+    });
+
+    it("should throw CodeRuntimeError for runtime errors", async () => {
+      mockClient.sandbox.runCode.mockResolvedValue({
+        stdout: "",
+        stderr: "NameError: name 'x' is not defined",
+        exit_code: 1,
+        execution_time: 0.001,
+      });
+
+      // biome-ignore lint/suspicious/noExplicitAny: test mock
+      const mw = createCodeModeMiddleware(mockClient as any);
+      await mw.onSessionStart?.(createMockContext());
+
+      const codeResponse = "```python-code-mode\nprint(x)\n```";
+      const req = createMockModelRequest();
+      const next = createMockNext(codeResponse);
+
+      await expect(mw.wrapModelCall?.(req, next)).rejects.toBeInstanceOf(CodeRuntimeError);
+    });
+
+    it("should throw CodeSyntaxError for oversized code", async () => {
+      // biome-ignore lint/suspicious/noExplicitAny: test mock
+      const mw = createCodeModeMiddleware(mockClient as any, {
+        maxCodeLength: 10,
+      });
+      await mw.onSessionStart?.(createMockContext());
+
+      const longCode = "x = 1\n".repeat(100);
+      const codeResponse = `\`\`\`python-code-mode\n${longCode}\`\`\``;
+      const req = createMockModelRequest();
+      const next = createMockNext(codeResponse);
+
+      await expect(mw.wrapModelCall?.(req, next)).rejects.toBeInstanceOf(CodeSyntaxError);
+    });
+  });
+
+  // =========================================================================
+  // Error mapping
+  // =========================================================================
+
+  describe("error mapping", () => {
+    it("should map timeout stderr to CodeExecutionTimeoutError", async () => {
+      mockClient.sandbox.runCode.mockResolvedValue({
+        stdout: "",
+        stderr: "TimeoutError: execution timed out",
+        exit_code: 1,
+        execution_time: 30,
+      });
+
+      // biome-ignore lint/suspicious/noExplicitAny: test mock
+      const mw = createCodeModeMiddleware(mockClient as any);
+      await mw.onSessionStart?.(createMockContext());
+
+      const codeResponse = "```python-code-mode\nwhile True: pass\n```";
+      const req = createMockModelRequest();
+      const next = createMockNext(codeResponse);
+
+      await expect(mw.wrapModelCall?.(req, next)).rejects.toBeInstanceOf(CodeExecutionTimeoutError);
+    });
+
+    it("should map memory stderr to CodeResourceExceededError", async () => {
+      mockClient.sandbox.runCode.mockResolvedValue({
+        stdout: "",
+        stderr: "MemoryError: out of memory",
+        exit_code: 1,
+        execution_time: 0.5,
+      });
+
+      // biome-ignore lint/suspicious/noExplicitAny: test mock
+      const mw = createCodeModeMiddleware(mockClient as any);
+      await mw.onSessionStart?.(createMockContext());
+
+      const codeResponse = "```python-code-mode\nx = [0] * 10**9\n```";
+      const req = createMockModelRequest();
+      const next = createMockNext(codeResponse);
+
+      const error = await mw.wrapModelCall?.(req, next).catch((e: unknown) => e);
+      expect(error).toBeInstanceOf(CodeResourceExceededError);
+      expect((error as CodeResourceExceededError).resource).toBe("memory");
+    });
+
+    it("should map recursion stderr to CodeResourceExceededError", async () => {
+      mockClient.sandbox.runCode.mockResolvedValue({
+        stdout: "",
+        stderr: "RecursionError: maximum recursion depth exceeded",
+        exit_code: 1,
+        execution_time: 0.1,
+      });
+
+      // biome-ignore lint/suspicious/noExplicitAny: test mock
+      const mw = createCodeModeMiddleware(mockClient as any);
+      await mw.onSessionStart?.(createMockContext());
+
+      const codeResponse = "```python-code-mode\ndef f(): f()\nf()\n```";
+      const req = createMockModelRequest();
+      const next = createMockNext(codeResponse);
+
+      const error = await mw.wrapModelCall?.(req, next).catch((e: unknown) => e);
+      expect(error).toBeInstanceOf(CodeResourceExceededError);
+      expect((error as CodeResourceExceededError).resource).toBe("recursion");
+    });
+
+    it("should map 404 API error to CodeSandboxNotFoundError", async () => {
+      mockClient.sandbox.runCode.mockRejectedValue(new Error("HTTP 404: not found"));
+
+      // biome-ignore lint/suspicious/noExplicitAny: test mock
+      const mw = createCodeModeMiddleware(mockClient as any);
+      await mw.onSessionStart?.(createMockContext());
+
+      const codeResponse = "```python-code-mode\nprint(1)\n```";
+      const req = createMockModelRequest();
+      const next = createMockNext(codeResponse);
+
+      await expect(mw.wrapModelCall?.(req, next)).rejects.toBeInstanceOf(CodeSandboxNotFoundError);
+    });
+  });
+});

--- a/packages/code-mode/src/__tests__/prompt.test.ts
+++ b/packages/code-mode/src/__tests__/prompt.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { generateCodeModePrompt, generateFunctionSignatures } from "../prompt.js";
+
+describe("generateFunctionSignatures", () => {
+  it("should generate signatures for known host functions", () => {
+    const sigs = generateFunctionSignatures(["read_file", "search"]);
+    expect(sigs).toContain("def read_file(path: str) -> str:");
+    expect(sigs).toContain("def search(query: str");
+  });
+
+  it("should skip unknown host functions", () => {
+    const sigs = generateFunctionSignatures(["read_file", "unknown_fn"]);
+    expect(sigs).toContain("def read_file");
+    expect(sigs).not.toContain("unknown_fn");
+  });
+
+  it("should generate all default function signatures", () => {
+    const sigs = generateFunctionSignatures(["read_file", "search", "memory_query"]);
+    expect(sigs).toContain("def read_file");
+    expect(sigs).toContain("def search");
+    expect(sigs).toContain("def memory_query");
+  });
+
+  it("should return empty string for empty host functions", () => {
+    const sigs = generateFunctionSignatures([]);
+    expect(sigs).toBe("");
+  });
+
+  it("should return empty string for all unknown functions", () => {
+    const sigs = generateFunctionSignatures(["foo", "bar"]);
+    expect(sigs).toBe("");
+  });
+});
+
+describe("generateCodeModePrompt", () => {
+  it("should include code mode header", () => {
+    const prompt = generateCodeModePrompt(["read_file"]);
+    expect(prompt).toContain("## Code Mode");
+  });
+
+  it("should include function signatures", () => {
+    const prompt = generateCodeModePrompt(["read_file", "search"]);
+    expect(prompt).toContain("def read_file");
+    expect(prompt).toContain("def search");
+  });
+
+  it("should include rules section", () => {
+    const prompt = generateCodeModePrompt(["read_file"]);
+    expect(prompt).toContain("### Rules:");
+    expect(prompt).toContain("json.dumps");
+    expect(prompt).toContain("Do NOT import");
+  });
+
+  it("should include output format with python-code-mode fence", () => {
+    const prompt = generateCodeModePrompt(["read_file"]);
+    expect(prompt).toContain("python-code-mode");
+  });
+});

--- a/packages/code-mode/src/__tests__/validation.test.ts
+++ b/packages/code-mode/src/__tests__/validation.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_CONFIG } from "../types.js";
+import { extractCodeBlock, validateCodeModeConfig, validateCodeOutput } from "../validation.js";
+
+describe("validateCodeModeConfig", () => {
+  it("should accept a valid default config", () => {
+    const errors = validateCodeModeConfig(DEFAULT_CONFIG);
+    expect(errors).toEqual([]);
+  });
+
+  it("should reject invalid resourceProfile", () => {
+    const errors = validateCodeModeConfig({
+      ...DEFAULT_CONFIG,
+      resourceProfile: "invalid" as "strict",
+    });
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0]).toContain("resourceProfile");
+  });
+
+  it("should reject non-positive maxCodeLength", () => {
+    const errors = validateCodeModeConfig({
+      ...DEFAULT_CONFIG,
+      maxCodeLength: 0,
+    });
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0]).toContain("maxCodeLength");
+  });
+
+  it("should reject negative maxCodeLength", () => {
+    const errors = validateCodeModeConfig({
+      ...DEFAULT_CONFIG,
+      maxCodeLength: -100,
+    });
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it("should reject excessively large maxCodeLength", () => {
+    const errors = validateCodeModeConfig({
+      ...DEFAULT_CONFIG,
+      maxCodeLength: 200_000,
+    });
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0]).toContain("100,000");
+  });
+
+  it("should reject empty string in hostFunctions", () => {
+    const errors = validateCodeModeConfig({
+      ...DEFAULT_CONFIG,
+      hostFunctions: ["read_file", ""],
+    });
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0]).toContain("non-empty");
+  });
+
+  it("should accept custom valid config", () => {
+    const errors = validateCodeModeConfig({
+      enabled: false,
+      resourceProfile: "strict",
+      maxCodeLength: 5000,
+      hostFunctions: ["read_file"],
+    });
+    expect(errors).toEqual([]);
+  });
+
+  it("should accept permissive profile", () => {
+    const errors = validateCodeModeConfig({
+      ...DEFAULT_CONFIG,
+      resourceProfile: "permissive",
+    });
+    expect(errors).toEqual([]);
+  });
+});
+
+describe("validateCodeOutput", () => {
+  it("should parse valid JSON stdout", () => {
+    const result = validateCodeOutput('{"result": 42}', "");
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual({ result: 42 });
+  });
+
+  it("should handle empty stdout", () => {
+    const result = validateCodeOutput("", "");
+    expect(result.success).toBe(false);
+    expect(result.data).toBeNull();
+  });
+
+  it("should handle whitespace-only stdout", () => {
+    const result = validateCodeOutput("   \n  ", "");
+    expect(result.success).toBe(false);
+    expect(result.data).toBeNull();
+  });
+
+  it("should handle non-JSON stdout", () => {
+    const result = validateCodeOutput("hello world", "");
+    expect(result.success).toBe(false);
+    expect(result.data).toBe("hello world");
+  });
+
+  it("should preserve stderr", () => {
+    const result = validateCodeOutput('{"ok": true}', "warning: something");
+    expect(result.success).toBe(true);
+    expect(result.stderr).toBe("warning: something");
+  });
+
+  it("should preserve rawStdout", () => {
+    const result = validateCodeOutput('  {"ok": true}  ', "");
+    expect(result.rawStdout).toBe('  {"ok": true}  ');
+  });
+
+  it("should parse JSON arrays", () => {
+    const result = validateCodeOutput("[1, 2, 3]", "");
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual([1, 2, 3]);
+  });
+
+  it("should parse JSON strings", () => {
+    const result = validateCodeOutput('"hello"', "");
+    expect(result.success).toBe(true);
+    expect(result.data).toBe("hello");
+  });
+});
+
+describe("extractCodeBlock", () => {
+  it("should extract code from python-code-mode block", () => {
+    const content = `Here's the code:
+
+\`\`\`python-code-mode
+result = read_file("src/main.ts")
+print(json.dumps({"content": result}))
+\`\`\`
+
+That will read the file.`;
+
+    const code = extractCodeBlock(content);
+    expect(code).toBe('result = read_file("src/main.ts")\nprint(json.dumps({"content": result}))');
+  });
+
+  it("should return null when no code-mode block exists", () => {
+    const content = "Just a normal response with no code.";
+    expect(extractCodeBlock(content)).toBeNull();
+  });
+
+  it("should not match regular python blocks", () => {
+    const content = "```python\nprint('hello')\n```";
+    expect(extractCodeBlock(content)).toBeNull();
+  });
+
+  it("should trim whitespace from extracted code", () => {
+    const content = "```python-code-mode\n  x = 1  \n```";
+    const code = extractCodeBlock(content);
+    expect(code).toBe("x = 1");
+  });
+
+  it("should handle multi-line code blocks", () => {
+    const content = `\`\`\`python-code-mode
+a = read_file("a.ts")
+b = read_file("b.ts")
+c = search("*.test.ts")
+print(json.dumps({"a": a, "b": b, "tests": c}))
+\`\`\``;
+
+    const code = extractCodeBlock(content);
+    expect(code).toContain("a = read_file");
+    expect(code).toContain("b = read_file");
+    expect(code).toContain("c = search");
+  });
+});

--- a/packages/code-mode/src/index.ts
+++ b/packages/code-mode/src/index.ts
@@ -1,0 +1,13 @@
+/**
+ * @templar/code-mode
+ *
+ * Code mode middleware for Templar agents — replaces sequential tool calls
+ * with LLM-generated Python code executed in a Monty sandbox.
+ */
+
+export { CodeModeMiddleware, createCodeModeMiddleware } from "./middleware.js";
+export { generateCodeModePrompt, generateFunctionSignatures } from "./prompt.js";
+export type { CodeModeConfig } from "./types.js";
+export { DEFAULT_CONFIG } from "./types.js";
+export type { CodeOutputResult } from "./validation.js";
+export { extractCodeBlock, validateCodeModeConfig, validateCodeOutput } from "./validation.js";

--- a/packages/code-mode/src/middleware.ts
+++ b/packages/code-mode/src/middleware.ts
@@ -1,0 +1,209 @@
+/**
+ * CodeModeMiddleware — TemplarMiddleware that enables LLM code execution
+ *
+ * Instead of sequential tool calls, the LLM writes Python code that
+ * programmatically calls tools as functions. Pydantic's Monty interpreter
+ * (Rust, sub-microsecond startup, deny-by-default) executes this safely.
+ */
+
+import type { NexusClient } from "@nexus/sdk";
+import type {
+  ModelHandler,
+  ModelRequest,
+  ModelResponse,
+  SessionContext,
+  TemplarMiddleware,
+} from "@templar/core";
+import {
+  CodeExecutionTimeoutError,
+  CodeModeError,
+  CodeResourceExceededError,
+  CodeRuntimeError,
+  CodeSandboxNotFoundError,
+  CodeSyntaxError,
+} from "@templar/errors";
+
+import { generateCodeModePrompt } from "./prompt.js";
+import type { CodeModeConfig } from "./types.js";
+import { DEFAULT_CONFIG } from "./types.js";
+import { extractCodeBlock, validateCodeModeConfig, validateCodeOutput } from "./validation.js";
+
+/**
+ * Middleware that intercepts LLM model calls and executes code-mode blocks
+ * in a Monty sandbox via the Nexus Sandbox API.
+ */
+export class CodeModeMiddleware implements TemplarMiddleware {
+  readonly name = "code-mode";
+
+  private readonly client: NexusClient;
+  private readonly config: CodeModeConfig;
+  private readonly codeModePrompt: string;
+  private sandboxId: string | null = null;
+
+  constructor(client: NexusClient, config: CodeModeConfig) {
+    const errors = validateCodeModeConfig(config);
+    if (errors.length > 0) {
+      throw new Error(`Invalid code-mode config: ${errors.join("; ")}`);
+    }
+
+    this.client = client;
+    this.config = config;
+    this.codeModePrompt = generateCodeModePrompt(config.hostFunctions);
+  }
+
+  /**
+   * Create sandbox on session start.
+   */
+  async onSessionStart(context: SessionContext): Promise<void> {
+    if (!this.config.enabled) return;
+
+    const result = await this.client.sandbox.create({
+      name: `code-mode-${context.sessionId}`,
+      provider: "monty",
+      securityProfile: this.config.resourceProfile,
+    });
+
+    this.sandboxId = result.sandbox_id;
+  }
+
+  /**
+   * Destroy sandbox on session end.
+   */
+  async onSessionEnd(_context: SessionContext): Promise<void> {
+    if (this.sandboxId === null) return;
+
+    try {
+      await this.client.sandbox.destroy(this.sandboxId);
+    } finally {
+      this.sandboxId = null;
+    }
+  }
+
+  /**
+   * Intercept model calls to inject code-mode prompt and execute code blocks.
+   */
+  async wrapModelCall(req: ModelRequest, next: ModelHandler): Promise<ModelResponse> {
+    if (!this.config.enabled || this.sandboxId === null) {
+      return next(req);
+    }
+
+    // Inject code-mode system prompt
+    const augmentedReq: ModelRequest = {
+      ...req,
+      systemPrompt: req.systemPrompt
+        ? `${req.systemPrompt}\n\n${this.codeModePrompt}`
+        : this.codeModePrompt,
+    };
+
+    const response = await next(augmentedReq);
+
+    // Check if response contains a code-mode block
+    const code = extractCodeBlock(response.content);
+    if (code === null) {
+      return response;
+    }
+
+    // Validate code length
+    if (code.length > this.config.maxCodeLength) {
+      throw new CodeSyntaxError(
+        code,
+        0,
+        `Code length ${code.length} exceeds maximum ${this.config.maxCodeLength}`,
+      );
+    }
+
+    // Execute in sandbox
+    const executionResult = await this.executeCode(code);
+
+    // Return a new response with the execution result
+    return {
+      ...response,
+      content: JSON.stringify(executionResult.data ?? executionResult.rawStdout),
+      metadata: {
+        ...response.metadata,
+        codeModeExecuted: true,
+        executionStderr: executionResult.stderr,
+      },
+    };
+  }
+
+  /**
+   * Execute code in the sandbox and map errors to CodeMode error types.
+   */
+  private async executeCode(code: string) {
+    if (this.sandboxId === null) {
+      throw new CodeSandboxNotFoundError("no-sandbox");
+    }
+
+    try {
+      const result = await this.client.sandbox.runCode(this.sandboxId, {
+        language: "python",
+        code,
+        host_functions: [...this.config.hostFunctions],
+      });
+
+      if (result.exit_code !== 0) {
+        this.throwCodeError(code, result.stderr, result.exit_code);
+      }
+
+      return validateCodeOutput(result.stdout, result.stderr);
+    } catch (error) {
+      // Re-throw code-mode errors as-is
+      if (error instanceof CodeModeError) {
+        throw error;
+      }
+
+      // Map Nexus API errors
+      const message = error instanceof Error ? error.message : String(error);
+      if (message.includes("not found") || message.includes("404")) {
+        throw new CodeSandboxNotFoundError(this.sandboxId);
+      }
+      if (message.includes("timeout") || message.includes("408")) {
+        throw new CodeExecutionTimeoutError(30);
+      }
+      throw new CodeRuntimeError(code, message);
+    }
+  }
+
+  /**
+   * Map non-zero exit codes to specific error types based on stderr content.
+   */
+  private throwCodeError(code: string, stderr: string, _exitCode: number): never {
+    const lower = stderr.toLowerCase();
+
+    if (lower.includes("syntaxerror") || lower.includes("syntax error")) {
+      const lineMatch = /line (\d+)/.exec(stderr);
+      const line = lineMatch?.[1] ? Number.parseInt(lineMatch[1], 10) : 0;
+      throw new CodeSyntaxError(code, line, stderr);
+    }
+
+    if (lower.includes("timeout") || lower.includes("timed out")) {
+      throw new CodeExecutionTimeoutError(30);
+    }
+
+    if (lower.includes("memory") || lower.includes("memoryerror")) {
+      throw new CodeResourceExceededError("memory");
+    }
+
+    if (lower.includes("recursion") || lower.includes("recursionerror")) {
+      throw new CodeResourceExceededError("recursion");
+    }
+
+    throw new CodeRuntimeError(code, stderr);
+  }
+}
+
+/**
+ * Factory function for creating a CodeModeMiddleware instance.
+ */
+export function createCodeModeMiddleware(
+  client: NexusClient,
+  config?: Partial<CodeModeConfig>,
+): CodeModeMiddleware {
+  const merged: CodeModeConfig = {
+    ...DEFAULT_CONFIG,
+    ...config,
+  };
+
+  return new CodeModeMiddleware(client, merged);
+}

--- a/packages/code-mode/src/prompt.ts
+++ b/packages/code-mode/src/prompt.ts
@@ -1,0 +1,62 @@
+/**
+ * Code-mode system prompt generation
+ *
+ * Generates the system prompt that instructs the LLM to produce Python code
+ * instead of sequential tool calls.
+ */
+
+/** Python signature definitions for host functions */
+const HOST_FUNCTION_SIGNATURES: Readonly<Record<string, string>> = {
+  read_file: 'def read_file(path: str) -> str:\n    """Read a file and return its contents."""',
+  search:
+    'def search(query: str, path: str = ".") -> list[str]:\n    """Search for files matching a query pattern. Returns list of file paths."""',
+  memory_query:
+    'def memory_query(query: str, limit: int = 10) -> list[dict]:\n    """Query agent memory. Returns list of memory entries."""',
+};
+
+/**
+ * Generate Python function signatures for the configured host functions.
+ */
+export function generateFunctionSignatures(hostFunctions: readonly string[]): string {
+  return hostFunctions
+    .map((fn) => HOST_FUNCTION_SIGNATURES[fn])
+    .filter((sig): sig is string => sig !== undefined)
+    .join("\n\n");
+}
+
+/**
+ * Generate the complete code-mode system prompt.
+ *
+ * This prompt is injected into model calls to instruct the LLM to emit
+ * Python code blocks instead of sequential tool calls when beneficial.
+ */
+export function generateCodeModePrompt(hostFunctions: readonly string[]): string {
+  const signatures = generateFunctionSignatures(hostFunctions);
+
+  return `## Code Mode
+
+When a task requires 3+ sequential tool calls, you may write a Python code block instead.
+The code will execute in a secure Monty sandbox with sub-microsecond startup.
+
+### Available functions:
+
+\`\`\`python
+${signatures}
+\`\`\`
+
+### Rules:
+- Output results as JSON to stdout via \`print(json.dumps(...))\`
+- Do NOT import modules (json is pre-loaded)
+- Do NOT define classes
+- Use only the provided host functions
+- Keep code under 10,000 characters
+
+### Output format:
+Wrap your code in a fenced code block with the language \`python-code-mode\`:
+
+\`\`\`python-code-mode
+result = read_file("src/main.ts")
+files = search("*.test.ts")
+print(json.dumps({"content": result, "test_files": files}))
+\`\`\``;
+}

--- a/packages/code-mode/src/types.ts
+++ b/packages/code-mode/src/types.ts
@@ -1,0 +1,21 @@
+/**
+ * Code mode configuration types
+ */
+
+export interface CodeModeConfig {
+  /** Whether code mode is enabled */
+  readonly enabled: boolean;
+  /** Monty security profile */
+  readonly resourceProfile: "strict" | "standard" | "permissive";
+  /** Maximum length of generated code (characters) */
+  readonly maxCodeLength: number;
+  /** Host functions available to generated code */
+  readonly hostFunctions: readonly string[];
+}
+
+export const DEFAULT_CONFIG: CodeModeConfig = {
+  enabled: true,
+  resourceProfile: "standard",
+  maxCodeLength: 10_000,
+  hostFunctions: ["read_file", "search", "memory_query"],
+} as const;

--- a/packages/code-mode/src/validation.ts
+++ b/packages/code-mode/src/validation.ts
@@ -1,0 +1,90 @@
+/**
+ * Code-mode validation utilities
+ *
+ * Config validation and post-execution output parsing.
+ */
+
+import type { CodeModeConfig } from "./types.js";
+
+/**
+ * Validate code-mode configuration.
+ * Returns an array of validation error messages (empty if valid).
+ */
+export function validateCodeModeConfig(config: CodeModeConfig): readonly string[] {
+  const validProfiles = ["strict", "standard", "permissive"] as const;
+
+  return [
+    typeof config.enabled !== "boolean" ? "enabled must be a boolean" : null,
+    !validProfiles.includes(config.resourceProfile)
+      ? `resourceProfile must be one of: ${validProfiles.join(", ")}; got "${config.resourceProfile}"`
+      : null,
+    typeof config.maxCodeLength !== "number" || config.maxCodeLength <= 0
+      ? "maxCodeLength must be a positive number"
+      : null,
+    config.maxCodeLength > 100_000 ? "maxCodeLength must not exceed 100,000" : null,
+    !Array.isArray(config.hostFunctions)
+      ? "hostFunctions must be an array"
+      : config.hostFunctions.some((fn) => typeof fn !== "string" || fn.length === 0)
+        ? "hostFunctions entries must be non-empty strings"
+        : null,
+  ].filter((err): err is string => err !== null);
+}
+
+/** Result of parsing code execution output */
+export interface CodeOutputResult {
+  readonly success: boolean;
+  readonly data: unknown;
+  readonly rawStdout: string;
+  readonly stderr: string;
+}
+
+/**
+ * Parse and validate the output from code execution.
+ *
+ * Expects JSON in stdout. Returns parsed data on success,
+ * or the raw stdout if JSON parsing fails.
+ */
+export function validateCodeOutput(stdout: string, stderr: string): CodeOutputResult {
+  const trimmed = stdout.trim();
+
+  if (trimmed.length === 0) {
+    return {
+      success: false,
+      data: null,
+      rawStdout: stdout,
+      stderr,
+    };
+  }
+
+  try {
+    const data: unknown = JSON.parse(trimmed);
+    return {
+      success: true,
+      data,
+      rawStdout: stdout,
+      stderr,
+    };
+  } catch {
+    return {
+      success: false,
+      data: trimmed,
+      rawStdout: stdout,
+      stderr,
+    };
+  }
+}
+
+/** Code block regex: matches ```python-code-mode ... ``` */
+const CODE_BLOCK_REGEX = /```python-code-mode\n([\s\S]*?)```/;
+
+/**
+ * Extract Python code from an LLM response content string.
+ * Returns the code if a code-mode block is found, null otherwise.
+ */
+export function extractCodeBlock(content: string): string | null {
+  const match = CODE_BLOCK_REGEX.exec(content);
+  if (!match?.[1]) {
+    return null;
+  }
+  return match[1].trim();
+}

--- a/packages/code-mode/tsconfig.json
+++ b/packages/code-mode/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": ["node"],
+    "isolatedDeclarations": false
+  },
+  "include": ["src/**/*"],
+  "references": [{ "path": "../core" }, { "path": "../nexus-sdk" }, { "path": "../errors" }]
+}

--- a/packages/code-mode/tsup.config.ts
+++ b/packages/code-mode/tsup.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: {
+    index: "src/index.ts",
+  },
+  format: ["esm"],
+  dts: {
+    compilerOptions: {
+      composite: false,
+      isolatedDeclarations: false,
+    },
+  },
+  clean: true,
+  treeshake: true,
+  target: "node22",
+});

--- a/packages/errors/src/__tests__/unit/code-mode.test.ts
+++ b/packages/errors/src/__tests__/unit/code-mode.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, it } from "vitest";
+import {
+  CodeExecutionTimeoutError,
+  CodeModeError,
+  CodeResourceExceededError,
+  CodeRuntimeError,
+  CodeSandboxNotFoundError,
+  CodeSyntaxError,
+  TemplarError,
+} from "../../index.js";
+
+describe("CodeModeError hierarchy", () => {
+  describe("CodeSyntaxError", () => {
+    it("should carry generatedCode and lineNumber", () => {
+      const error = new CodeSyntaxError("print(", 1, "unexpected EOF");
+      expect(error.generatedCode).toBe("print(");
+      expect(error.lineNumber).toBe(1);
+    });
+
+    it("should have correct error code", () => {
+      const error = new CodeSyntaxError("x =", 3, "invalid syntax");
+      expect(error.code).toBe("CODE_SYNTAX_ERROR");
+    });
+
+    it("should have HTTP status 400", () => {
+      const error = new CodeSyntaxError("x =", 3, "invalid syntax");
+      expect(error.httpStatus).toBe(400);
+    });
+
+    it("should have _tag ValidationError", () => {
+      const error = new CodeSyntaxError("x =", 3, "invalid syntax");
+      expect(error._tag).toBe("ValidationError");
+    });
+
+    it("should mention line number in message", () => {
+      const error = new CodeSyntaxError("x =", 3, "invalid syntax");
+      expect(error.message).toContain("line 3");
+    });
+
+    it("should be isExpected", () => {
+      const error = new CodeSyntaxError("x =", 3, "invalid syntax");
+      expect(error.isExpected).toBe(true);
+    });
+
+    it("should be instanceof CodeModeError and TemplarError", () => {
+      const error = new CodeSyntaxError("x =", 3, "invalid syntax");
+      expect(error).toBeInstanceOf(CodeModeError);
+      expect(error).toBeInstanceOf(TemplarError);
+    });
+  });
+
+  describe("CodeRuntimeError", () => {
+    it("should carry generatedCode and runtimeMessage", () => {
+      const error = new CodeRuntimeError("1/0", "ZeroDivisionError: division by zero");
+      expect(error.generatedCode).toBe("1/0");
+      expect(error.runtimeMessage).toBe("ZeroDivisionError: division by zero");
+    });
+
+    it("should have correct error code", () => {
+      const error = new CodeRuntimeError("1/0", "ZeroDivisionError");
+      expect(error.code).toBe("CODE_RUNTIME_ERROR");
+    });
+
+    it("should have HTTP status 400", () => {
+      const error = new CodeRuntimeError("1/0", "ZeroDivisionError");
+      expect(error.httpStatus).toBe(400);
+    });
+
+    it("should have _tag ExternalError", () => {
+      const error = new CodeRuntimeError("1/0", "ZeroDivisionError");
+      expect(error._tag).toBe("ExternalError");
+    });
+
+    it("should be instanceof CodeModeError and TemplarError", () => {
+      const error = new CodeRuntimeError("1/0", "ZeroDivisionError");
+      expect(error).toBeInstanceOf(CodeModeError);
+      expect(error).toBeInstanceOf(TemplarError);
+    });
+  });
+
+  describe("CodeExecutionTimeoutError", () => {
+    it("should carry timeoutSeconds", () => {
+      const error = new CodeExecutionTimeoutError(30);
+      expect(error.timeoutSeconds).toBe(30);
+    });
+
+    it("should have correct error code", () => {
+      const error = new CodeExecutionTimeoutError(30);
+      expect(error.code).toBe("CODE_EXECUTION_TIMEOUT");
+    });
+
+    it("should have HTTP status 408", () => {
+      const error = new CodeExecutionTimeoutError(30);
+      expect(error.httpStatus).toBe(408);
+    });
+
+    it("should have _tag TimeoutError", () => {
+      const error = new CodeExecutionTimeoutError(30);
+      expect(error._tag).toBe("TimeoutError");
+    });
+
+    it("should mention timeout in message", () => {
+      const error = new CodeExecutionTimeoutError(30);
+      expect(error.message).toContain("30s");
+    });
+
+    it("should be instanceof CodeModeError and TemplarError", () => {
+      const error = new CodeExecutionTimeoutError(30);
+      expect(error).toBeInstanceOf(CodeModeError);
+      expect(error).toBeInstanceOf(TemplarError);
+    });
+  });
+
+  describe("CodeResourceExceededError", () => {
+    it("should carry resource type", () => {
+      const error = new CodeResourceExceededError("memory");
+      expect(error.resource).toBe("memory");
+    });
+
+    it("should accept all resource types", () => {
+      expect(new CodeResourceExceededError("memory").resource).toBe("memory");
+      expect(new CodeResourceExceededError("allocations").resource).toBe("allocations");
+      expect(new CodeResourceExceededError("recursion").resource).toBe("recursion");
+    });
+
+    it("should have correct error code", () => {
+      const error = new CodeResourceExceededError("memory");
+      expect(error.code).toBe("CODE_RESOURCE_EXCEEDED");
+    });
+
+    it("should have HTTP status 413", () => {
+      const error = new CodeResourceExceededError("memory");
+      expect(error.httpStatus).toBe(413);
+    });
+
+    it("should have _tag ExternalError", () => {
+      const error = new CodeResourceExceededError("memory");
+      expect(error._tag).toBe("ExternalError");
+    });
+
+    it("should be instanceof CodeModeError and TemplarError", () => {
+      const error = new CodeResourceExceededError("memory");
+      expect(error).toBeInstanceOf(CodeModeError);
+      expect(error).toBeInstanceOf(TemplarError);
+    });
+  });
+
+  describe("CodeSandboxNotFoundError", () => {
+    it("should carry sandboxId", () => {
+      const error = new CodeSandboxNotFoundError("sbx-123");
+      expect(error.sandboxId).toBe("sbx-123");
+    });
+
+    it("should have correct error code", () => {
+      const error = new CodeSandboxNotFoundError("sbx-123");
+      expect(error.code).toBe("CODE_SANDBOX_NOT_FOUND");
+    });
+
+    it("should have HTTP status 404", () => {
+      const error = new CodeSandboxNotFoundError("sbx-123");
+      expect(error.httpStatus).toBe(404);
+    });
+
+    it("should have _tag NotFoundError", () => {
+      const error = new CodeSandboxNotFoundError("sbx-123");
+      expect(error._tag).toBe("NotFoundError");
+    });
+
+    it("should mention sandboxId in message", () => {
+      const error = new CodeSandboxNotFoundError("sbx-123");
+      expect(error.message).toContain("sbx-123");
+    });
+
+    it("should be instanceof CodeModeError and TemplarError", () => {
+      const error = new CodeSandboxNotFoundError("sbx-123");
+      expect(error).toBeInstanceOf(CodeModeError);
+      expect(error).toBeInstanceOf(TemplarError);
+    });
+  });
+
+  describe("generic CodeModeError catch", () => {
+    it("should catch all code-mode errors with instanceof CodeModeError", () => {
+      const errors: CodeModeError[] = [
+        new CodeSyntaxError("x =", 1, "invalid syntax"),
+        new CodeRuntimeError("1/0", "ZeroDivisionError"),
+        new CodeExecutionTimeoutError(30),
+        new CodeResourceExceededError("memory"),
+        new CodeSandboxNotFoundError("sbx-123"),
+      ];
+
+      for (const error of errors) {
+        expect(error).toBeInstanceOf(CodeModeError);
+        expect(error).toBeInstanceOf(TemplarError);
+        expect(error).toBeInstanceOf(Error);
+      }
+    });
+
+    it("should have domain 'code' for all code-mode errors", () => {
+      const errors: CodeModeError[] = [
+        new CodeSyntaxError("x =", 1, "invalid syntax"),
+        new CodeRuntimeError("1/0", "ZeroDivisionError"),
+        new CodeExecutionTimeoutError(30),
+        new CodeResourceExceededError("memory"),
+        new CodeSandboxNotFoundError("sbx-123"),
+      ];
+
+      for (const error of errors) {
+        expect((error as unknown as { domain: string }).domain).toBe("code");
+      }
+    });
+  });
+});

--- a/packages/errors/src/catalog.ts
+++ b/packages/errors/src/catalog.ts
@@ -1992,6 +1992,65 @@ export const ERROR_CATALOG = {
     title: "A2A unsupported operation",
     description: "The remote A2A agent does not support the requested operation or capability",
   },
+
+  // ============================================================================
+  // CODE MODE ERRORS — LLM-generated code execution via Monty sandbox (#111)
+  // ============================================================================
+  CODE_SYNTAX_ERROR: {
+    domain: "code",
+    httpStatus: 400,
+    grpcCode: "INVALID_ARGUMENT" as const,
+    baseType: "ValidationError" as const,
+    isExpected: true,
+    title: "Code syntax error",
+    description: "The LLM-generated Python code contains syntax errors",
+  },
+  CODE_RUNTIME_ERROR: {
+    domain: "code",
+    httpStatus: 400,
+    grpcCode: "INTERNAL" as const,
+    baseType: "ExternalError" as const,
+    isExpected: true,
+    title: "Code runtime error",
+    description: "The LLM-generated code raised an exception during execution",
+  },
+  CODE_EXECUTION_TIMEOUT: {
+    domain: "code",
+    httpStatus: 408,
+    grpcCode: "DEADLINE_EXCEEDED" as const,
+    baseType: "TimeoutError" as const,
+    isExpected: true,
+    title: "Code execution timeout",
+    description: "The code execution exceeded the configured timeout",
+  },
+  CODE_RESOURCE_EXCEEDED: {
+    domain: "code",
+    httpStatus: 413,
+    grpcCode: "RESOURCE_EXHAUSTED" as const,
+    baseType: "ExternalError" as const,
+    isExpected: true,
+    title: "Code resource exceeded",
+    description: "The code execution exceeded resource limits (memory, allocations, or recursion)",
+  },
+  CODE_SANDBOX_NOT_FOUND: {
+    domain: "code",
+    httpStatus: 404,
+    grpcCode: "NOT_FOUND" as const,
+    baseType: "NotFoundError" as const,
+    isExpected: true,
+    title: "Code sandbox not found",
+    description: "The sandbox session does not exist or has expired",
+  },
+  CODE_ESCALATION_NEEDED: {
+    domain: "code",
+    httpStatus: 502,
+    grpcCode: "INTERNAL" as const,
+    baseType: "ExternalError" as const,
+    isExpected: false,
+    title: "Code escalation needed",
+    description:
+      "Code execution failed and the operation should fall back to sequential tool calls",
+  },
 } as const;
 
 // ============================================================================

--- a/packages/errors/src/code-mode.ts
+++ b/packages/errors/src/code-mode.ts
@@ -1,0 +1,158 @@
+import { TemplarError } from "./base.js";
+import {
+  ERROR_CATALOG,
+  type ErrorDomain,
+  type GrpcStatusCode,
+  type HttpStatusCode,
+} from "./catalog.js";
+
+// ---------------------------------------------------------------------------
+// Base class for all code-mode errors
+// ---------------------------------------------------------------------------
+
+/**
+ * Abstract base class for code-mode errors.
+ *
+ * Enables generic catch: `if (e instanceof CodeModeError)`
+ * while specific subclasses allow precise handling.
+ */
+export abstract class CodeModeError extends TemplarError {}
+
+// ---------------------------------------------------------------------------
+// Code syntax error
+// ---------------------------------------------------------------------------
+
+/**
+ * Thrown when LLM-generated Python code contains syntax errors.
+ */
+export class CodeSyntaxError extends CodeModeError {
+  readonly _tag = "ValidationError" as const;
+  readonly code = "CODE_SYNTAX_ERROR" as const;
+  readonly httpStatus: HttpStatusCode;
+  readonly grpcCode: GrpcStatusCode;
+  readonly domain: ErrorDomain;
+  readonly isExpected: boolean;
+  readonly generatedCode: string;
+  readonly lineNumber: number;
+
+  constructor(generatedCode: string, lineNumber: number, message: string) {
+    super(`Code syntax error at line ${lineNumber}: ${message}`);
+    const entry = ERROR_CATALOG.CODE_SYNTAX_ERROR;
+    this.httpStatus = entry.httpStatus as HttpStatusCode;
+    this.grpcCode = entry.grpcCode as GrpcStatusCode;
+    this.domain = entry.domain as ErrorDomain;
+    this.isExpected = entry.isExpected;
+    this.generatedCode = generatedCode;
+    this.lineNumber = lineNumber;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Code runtime error
+// ---------------------------------------------------------------------------
+
+/**
+ * Thrown when LLM-generated code raises an exception during execution.
+ */
+export class CodeRuntimeError extends CodeModeError {
+  readonly _tag = "ExternalError" as const;
+  readonly code = "CODE_RUNTIME_ERROR" as const;
+  readonly httpStatus: HttpStatusCode;
+  readonly grpcCode: GrpcStatusCode;
+  readonly domain: ErrorDomain;
+  readonly isExpected: boolean;
+  readonly generatedCode: string;
+  readonly runtimeMessage: string;
+
+  constructor(generatedCode: string, runtimeMessage: string) {
+    super(`Code runtime error: ${runtimeMessage}`);
+    const entry = ERROR_CATALOG.CODE_RUNTIME_ERROR;
+    this.httpStatus = entry.httpStatus as HttpStatusCode;
+    this.grpcCode = entry.grpcCode as GrpcStatusCode;
+    this.domain = entry.domain as ErrorDomain;
+    this.isExpected = entry.isExpected;
+    this.generatedCode = generatedCode;
+    this.runtimeMessage = runtimeMessage;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Code execution timeout
+// ---------------------------------------------------------------------------
+
+/**
+ * Thrown when code execution exceeds the configured timeout.
+ */
+export class CodeExecutionTimeoutError extends CodeModeError {
+  readonly _tag = "TimeoutError" as const;
+  readonly code = "CODE_EXECUTION_TIMEOUT" as const;
+  readonly httpStatus: HttpStatusCode;
+  readonly grpcCode: GrpcStatusCode;
+  readonly domain: ErrorDomain;
+  readonly isExpected: boolean;
+  readonly timeoutSeconds: number;
+
+  constructor(timeoutSeconds: number) {
+    super(`Code execution timed out after ${timeoutSeconds}s`);
+    const entry = ERROR_CATALOG.CODE_EXECUTION_TIMEOUT;
+    this.httpStatus = entry.httpStatus as HttpStatusCode;
+    this.grpcCode = entry.grpcCode as GrpcStatusCode;
+    this.domain = entry.domain as ErrorDomain;
+    this.isExpected = entry.isExpected;
+    this.timeoutSeconds = timeoutSeconds;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Code resource exceeded
+// ---------------------------------------------------------------------------
+
+/**
+ * Thrown when code execution exceeds resource limits.
+ */
+export class CodeResourceExceededError extends CodeModeError {
+  readonly _tag = "ExternalError" as const;
+  readonly code = "CODE_RESOURCE_EXCEEDED" as const;
+  readonly httpStatus: HttpStatusCode;
+  readonly grpcCode: GrpcStatusCode;
+  readonly domain: ErrorDomain;
+  readonly isExpected: boolean;
+  readonly resource: "memory" | "allocations" | "recursion";
+
+  constructor(resource: "memory" | "allocations" | "recursion") {
+    super(`Code execution exceeded ${resource} limit`);
+    const entry = ERROR_CATALOG.CODE_RESOURCE_EXCEEDED;
+    this.httpStatus = entry.httpStatus as HttpStatusCode;
+    this.grpcCode = entry.grpcCode as GrpcStatusCode;
+    this.domain = entry.domain as ErrorDomain;
+    this.isExpected = entry.isExpected;
+    this.resource = resource;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Code sandbox not found
+// ---------------------------------------------------------------------------
+
+/**
+ * Thrown when the sandbox session does not exist or has expired.
+ */
+export class CodeSandboxNotFoundError extends CodeModeError {
+  readonly _tag = "NotFoundError" as const;
+  readonly code = "CODE_SANDBOX_NOT_FOUND" as const;
+  readonly httpStatus: HttpStatusCode;
+  readonly grpcCode: GrpcStatusCode;
+  readonly domain: ErrorDomain;
+  readonly isExpected: boolean;
+  readonly sandboxId: string;
+
+  constructor(sandboxId: string) {
+    super(`Sandbox not found: ${sandboxId}`);
+    const entry = ERROR_CATALOG.CODE_SANDBOX_NOT_FOUND;
+    this.httpStatus = entry.httpStatus as HttpStatusCode;
+    this.grpcCode = entry.grpcCode as GrpcStatusCode;
+    this.domain = entry.domain as ErrorDomain;
+    this.isExpected = entry.isExpected;
+    this.sandboxId = sandboxId;
+  }
+}

--- a/packages/errors/src/index.ts
+++ b/packages/errors/src/index.ts
@@ -210,6 +210,19 @@ export {
 } from "./a2a.js";
 
 // ============================================================================
+// CODE MODE ERRORS — LLM-generated code execution via Monty sandbox (#111)
+// ============================================================================
+
+export {
+  CodeExecutionTimeoutError,
+  CodeModeError,
+  CodeResourceExceededError,
+  CodeRuntimeError,
+  CodeSandboxNotFoundError,
+  CodeSyntaxError,
+} from "./code-mode.js";
+
+// ============================================================================
 // WEB SEARCH ERRORS — Pluggable search providers (#119)
 // ============================================================================
 

--- a/packages/nexus-sdk/package.json
+++ b/packages/nexus-sdk/package.json
@@ -29,6 +29,10 @@
       "types": "./dist/resources/permissions.d.ts",
       "import": "./dist/resources/permissions.js"
     },
+    "./sandbox": {
+      "types": "./dist/resources/sandbox.d.ts",
+      "import": "./dist/resources/sandbox.js"
+    },
     "./http": {
       "types": "./dist/http/index.d.ts",
       "import": "./dist/http/index.js"

--- a/packages/nexus-sdk/src/client.ts
+++ b/packages/nexus-sdk/src/client.ts
@@ -11,6 +11,7 @@ import { EventLogResource } from "./resources/eventlog.js";
 import { MemoryResource } from "./resources/memory.js";
 import { PayResource } from "./resources/pay.js";
 import { PermissionsResource } from "./resources/permissions.js";
+import { SandboxResource } from "./resources/sandbox.js";
 import { ToolsResource } from "./resources/tools.js";
 import type { ClientConfig, RetryOptions } from "./types/index.js";
 
@@ -93,6 +94,11 @@ export class NexusClient {
   public readonly permissions: PermissionsResource;
 
   /**
+   * Sandbox resource (code execution via Monty, Docker, E2B)
+   */
+  public readonly sandbox: SandboxResource;
+
+  /**
    * ACE resource (Adaptive Context Engine — trajectories, playbooks, reflection, etc.)
    */
   public readonly ace: AceResource;
@@ -120,6 +126,7 @@ export class NexusClient {
     this.pay = new PayResource(this._http);
     this.eventLog = new EventLogResource(this._http);
     this.permissions = new PermissionsResource(this._http);
+    this.sandbox = new SandboxResource(this._http);
     this.ace = new AceResource(this._http);
   }
 

--- a/packages/nexus-sdk/src/index.ts
+++ b/packages/nexus-sdk/src/index.ts
@@ -36,6 +36,7 @@ export { EventLogResource } from "./resources/eventlog.js";
 export { MemoryResource } from "./resources/memory.js";
 export { PayResource } from "./resources/pay.js";
 export { PermissionsResource } from "./resources/permissions.js";
+export { SandboxResource } from "./resources/sandbox.js";
 export { ToolsResource } from "./resources/tools.js";
 // ACE types
 export type {
@@ -168,6 +169,13 @@ export type {
   ListNamespaceToolsParams,
   ListNamespaceToolsResponse,
 } from "./types/permissions.js";
+export type {
+  CreateSandboxParams,
+  CreateSandboxResponse,
+  RunCodeParams,
+  RunCodeResponse,
+  SandboxInfoResponse,
+} from "./types/sandbox.js";
 export type {
   CreateToolParams,
   ListToolsParams,

--- a/packages/nexus-sdk/src/resources/__tests__/sandbox.test.ts
+++ b/packages/nexus-sdk/src/resources/__tests__/sandbox.test.ts
@@ -1,0 +1,390 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { NexusClient } from "../../client.js";
+import type {
+  CreateSandboxResponse,
+  RunCodeResponse,
+  SandboxInfoResponse,
+} from "../../types/sandbox.js";
+
+describe("SandboxResource", () => {
+  let originalFetch: typeof global.fetch;
+  let client: NexusClient;
+
+  beforeEach(() => {
+    originalFetch = global.fetch;
+    client = new NexusClient({
+      apiKey: "test-key",
+      baseUrl: "https://api.test.com",
+    });
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  function mockFetchResponse(data: unknown, status = 200): void {
+    global.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(data), {
+        status,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+  }
+
+  function mockFetchError(errorBody: unknown, status: number): void {
+    global.fetch = vi.fn().mockResolvedValue(new Response(JSON.stringify(errorBody), { status }));
+  }
+
+  // =========================================================================
+  // create()
+  // =========================================================================
+
+  describe("create", () => {
+    const mockResponse: CreateSandboxResponse = {
+      sandbox_id: "sbx-abc123",
+      name: "code-mode-session",
+      status: "running",
+      provider: "monty",
+      created_at: "2024-06-01T12:00:00Z",
+    };
+
+    it("should create a sandbox with minimal params", async () => {
+      mockFetchResponse(mockResponse);
+
+      const result = await client.sandbox.create({
+        name: "code-mode-session",
+      });
+
+      expect(result).toEqual(mockResponse);
+      expect(global.fetch).toHaveBeenCalledWith(
+        "https://api.test.com/api/v2/sandbox",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({ name: "code-mode-session" }),
+        }),
+      );
+    });
+
+    it("should create a sandbox with provider", async () => {
+      mockFetchResponse(mockResponse);
+
+      await client.sandbox.create({
+        name: "code-mode-session",
+        provider: "monty",
+      });
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        "https://api.test.com/api/v2/sandbox",
+        expect.objectContaining({
+          body: JSON.stringify({
+            name: "code-mode-session",
+            provider: "monty",
+          }),
+        }),
+      );
+    });
+
+    it("should create a sandbox with all optional params", async () => {
+      mockFetchResponse(mockResponse);
+
+      await client.sandbox.create({
+        name: "code-mode-session",
+        provider: "monty",
+        timeoutMinutes: 30,
+        securityProfile: "strict",
+        metadata: { session_id: "sess-123" },
+      });
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        "https://api.test.com/api/v2/sandbox",
+        expect.objectContaining({
+          body: JSON.stringify({
+            name: "code-mode-session",
+            provider: "monty",
+            timeoutMinutes: 30,
+            securityProfile: "strict",
+            metadata: { session_id: "sess-123" },
+          }),
+        }),
+      );
+    });
+
+    it("should return sandbox_id for future operations", async () => {
+      mockFetchResponse(mockResponse);
+
+      const result = await client.sandbox.create({
+        name: "code-mode-session",
+      });
+
+      expect(result.sandbox_id).toBe("sbx-abc123");
+      expect(result.status).toBe("running");
+      expect(result.provider).toBe("monty");
+    });
+
+    it("should propagate API errors on create", async () => {
+      mockFetchError({ code: "VALIDATION_ERROR", message: "Invalid provider" }, 400);
+
+      await expect(
+        client.sandbox.create({
+          name: "code-mode-session",
+        }),
+      ).rejects.toThrow("Invalid provider");
+    });
+  });
+
+  // =========================================================================
+  // runCode()
+  // =========================================================================
+
+  describe("runCode", () => {
+    const mockResponse: RunCodeResponse = {
+      stdout: '{"result": 42}',
+      stderr: "",
+      exit_code: 0,
+      execution_time: 0.015,
+    };
+
+    it("should run code with minimal params", async () => {
+      mockFetchResponse(mockResponse);
+
+      const result = await client.sandbox.runCode("sbx-abc123", {
+        language: "python",
+        code: 'print("hello")',
+      });
+
+      expect(result).toEqual(mockResponse);
+      expect(global.fetch).toHaveBeenCalledWith(
+        "https://api.test.com/api/v2/sandbox/sbx-abc123/run",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({
+            language: "python",
+            code: 'print("hello")',
+          }),
+        }),
+      );
+    });
+
+    it("should run code with timeout", async () => {
+      mockFetchResponse(mockResponse);
+
+      await client.sandbox.runCode("sbx-abc123", {
+        language: "python",
+        code: 'print("hello")',
+        timeout: 30,
+      });
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        "https://api.test.com/api/v2/sandbox/sbx-abc123/run",
+        expect.objectContaining({
+          body: JSON.stringify({
+            language: "python",
+            code: 'print("hello")',
+            timeout: 30,
+          }),
+        }),
+      );
+    });
+
+    it("should run code with host functions", async () => {
+      mockFetchResponse(mockResponse);
+
+      await client.sandbox.runCode("sbx-abc123", {
+        language: "python",
+        code: 'result = read_file("src/main.ts")',
+        host_functions: ["read_file", "search", "memory_query"],
+      });
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        "https://api.test.com/api/v2/sandbox/sbx-abc123/run",
+        expect.objectContaining({
+          body: JSON.stringify({
+            language: "python",
+            code: 'result = read_file("src/main.ts")',
+            host_functions: ["read_file", "search", "memory_query"],
+          }),
+        }),
+      );
+    });
+
+    it("should return execution results", async () => {
+      mockFetchResponse(mockResponse);
+
+      const result = await client.sandbox.runCode("sbx-abc123", {
+        language: "python",
+        code: 'print("hello")',
+      });
+
+      expect(result.stdout).toBe('{"result": 42}');
+      expect(result.stderr).toBe("");
+      expect(result.exit_code).toBe(0);
+      expect(result.execution_time).toBe(0.015);
+    });
+
+    it("should handle non-zero exit codes", async () => {
+      mockFetchResponse({
+        stdout: "",
+        stderr: "NameError: name 'x' is not defined",
+        exit_code: 1,
+        execution_time: 0.002,
+      });
+
+      const result = await client.sandbox.runCode("sbx-abc123", {
+        language: "python",
+        code: "print(x)",
+      });
+
+      expect(result.exit_code).toBe(1);
+      expect(result.stderr).toContain("NameError");
+    });
+
+    it("should handle sandbox not found error", async () => {
+      mockFetchError({ code: "NOT_FOUND", message: "Sandbox not found: sbx-invalid" }, 404);
+
+      await expect(
+        client.sandbox.runCode("sbx-invalid", {
+          language: "python",
+          code: 'print("hello")',
+        }),
+      ).rejects.toThrow("Sandbox not found");
+    });
+
+    it("should handle timeout errors", async () => {
+      mockFetchError({ code: "TIMEOUT", message: "Code execution timed out" }, 408);
+
+      await expect(
+        client.sandbox.runCode("sbx-abc123", {
+          language: "python",
+          code: "while True: pass",
+          timeout: 5,
+        }),
+      ).rejects.toThrow();
+    });
+  });
+
+  // =========================================================================
+  // destroy()
+  // =========================================================================
+
+  describe("destroy", () => {
+    const mockResponse: SandboxInfoResponse = {
+      sandbox_id: "sbx-abc123",
+      status: "destroyed",
+      provider: "monty",
+      created_at: "2024-06-01T12:00:00Z",
+    };
+
+    it("should destroy a sandbox", async () => {
+      mockFetchResponse(mockResponse);
+
+      const result = await client.sandbox.destroy("sbx-abc123");
+
+      expect(result).toEqual(mockResponse);
+      expect(global.fetch).toHaveBeenCalledWith(
+        "https://api.test.com/api/v2/sandbox/sbx-abc123",
+        expect.objectContaining({ method: "DELETE" }),
+      );
+    });
+
+    it("should return sandbox info at time of destruction", async () => {
+      mockFetchResponse(mockResponse);
+
+      const result = await client.sandbox.destroy("sbx-abc123");
+
+      expect(result.sandbox_id).toBe("sbx-abc123");
+      expect(result.status).toBe("destroyed");
+    });
+
+    it("should handle sandbox not found on destroy", async () => {
+      mockFetchError({ code: "NOT_FOUND", message: "Sandbox not found: sbx-expired" }, 404);
+
+      await expect(client.sandbox.destroy("sbx-expired")).rejects.toThrow("Sandbox not found");
+    });
+  });
+
+  // =========================================================================
+  // Error handling (cross-cutting)
+  // =========================================================================
+
+  describe("error handling", () => {
+    it("should handle network errors", async () => {
+      global.fetch = vi.fn().mockRejectedValue(new TypeError("Failed to fetch"));
+
+      await expect(client.sandbox.create({ name: "test" })).rejects.toThrow("Network error");
+    });
+
+    it("should handle 401 unauthorized", async () => {
+      mockFetchError({ code: "UNAUTHORIZED", message: "Invalid API key" }, 401);
+
+      await expect(client.sandbox.create({ name: "test" })).rejects.toThrow("Invalid API key");
+    });
+
+    it("should handle 500 server errors", async () => {
+      mockFetchError({ code: "INTERNAL_ERROR", message: "Server error" }, 500);
+
+      const singleRetryClient = new NexusClient({
+        apiKey: "test-key",
+        baseUrl: "https://api.test.com",
+        retry: { maxAttempts: 1 },
+      });
+
+      await expect(singleRetryClient.sandbox.create({ name: "test" })).rejects.toThrow(
+        "Server error",
+      );
+    });
+  });
+
+  // =========================================================================
+  // Integration scenarios
+  // =========================================================================
+
+  describe("integration scenarios", () => {
+    it("should handle full create-run-destroy lifecycle", async () => {
+      // Step 1: Create sandbox
+      const createResponse: CreateSandboxResponse = {
+        sandbox_id: "sbx-lifecycle",
+        name: "code-mode-session",
+        status: "running",
+        provider: "monty",
+        created_at: "2024-06-01T12:00:00Z",
+      };
+      mockFetchResponse(createResponse);
+
+      const sandbox = await client.sandbox.create({
+        name: "code-mode-session",
+        provider: "monty",
+      });
+
+      expect(sandbox.sandbox_id).toBe("sbx-lifecycle");
+
+      // Step 2: Run code
+      const runResponse: RunCodeResponse = {
+        stdout: '{"files": ["main.ts", "utils.ts"]}',
+        stderr: "",
+        exit_code: 0,
+        execution_time: 0.05,
+      };
+      mockFetchResponse(runResponse);
+
+      const result = await client.sandbox.runCode(sandbox.sandbox_id, {
+        language: "python",
+        code: 'files = search("*.ts")\nprint(json.dumps({"files": files}))',
+        host_functions: ["search"],
+      });
+
+      expect(result.exit_code).toBe(0);
+
+      // Step 3: Destroy sandbox
+      const destroyResponse: SandboxInfoResponse = {
+        sandbox_id: "sbx-lifecycle",
+        status: "destroyed",
+        provider: "monty",
+        created_at: "2024-06-01T12:00:00Z",
+      };
+      mockFetchResponse(destroyResponse);
+
+      const destroyed = await client.sandbox.destroy(sandbox.sandbox_id);
+      expect(destroyed.status).toBe("destroyed");
+    });
+  });
+});

--- a/packages/nexus-sdk/src/resources/sandbox.ts
+++ b/packages/nexus-sdk/src/resources/sandbox.ts
@@ -1,0 +1,106 @@
+/**
+ * Sandbox resource for code execution via Monty/Docker/E2B
+ */
+
+import type {
+  CreateSandboxParams,
+  CreateSandboxResponse,
+  RunCodeParams,
+  RunCodeResponse,
+  SandboxInfoResponse,
+} from "../types/sandbox.js";
+import { BaseResource } from "./base.js";
+
+/**
+ * Resource for managing sandboxed code execution via the Nexus Sandbox API (v2)
+ *
+ * Supports:
+ * - Creating sandbox sessions (Monty, Docker, E2B providers)
+ * - Running code within a sandbox
+ * - Destroying sandbox sessions
+ *
+ * @example
+ * ```typescript
+ * // Create a sandbox
+ * const sandbox = await client.sandbox.create({
+ *   name: 'code-mode-session',
+ *   provider: 'monty',
+ * });
+ *
+ * // Run code
+ * const result = await client.sandbox.runCode(sandbox.sandbox_id, {
+ *   language: 'python',
+ *   code: 'print("hello")',
+ * });
+ *
+ * // Destroy when done
+ * await client.sandbox.destroy(sandbox.sandbox_id);
+ * ```
+ */
+export class SandboxResource extends BaseResource {
+  /**
+   * Create a new sandbox session
+   *
+   * @param params - Sandbox creation parameters
+   * @returns Created sandbox details including sandbox_id
+   *
+   * @example
+   * ```typescript
+   * const sandbox = await client.sandbox.create({
+   *   name: 'my-sandbox',
+   *   provider: 'monty',
+   *   securityProfile: 'strict',
+   * });
+   * console.log(`Created sandbox: ${sandbox.sandbox_id}`);
+   * ```
+   */
+  async create(params: CreateSandboxParams): Promise<CreateSandboxResponse> {
+    return this.http.request<CreateSandboxResponse>("/api/v2/sandbox", {
+      method: "POST",
+      body: params,
+    });
+  }
+
+  /**
+   * Run code in an existing sandbox
+   *
+   * @param sandboxId - The sandbox session ID
+   * @param params - Code execution parameters
+   * @returns Execution results including stdout, stderr, and exit code
+   *
+   * @example
+   * ```typescript
+   * const result = await client.sandbox.runCode('sbx-123', {
+   *   language: 'python',
+   *   code: 'result = read_file("src/main.ts")\nprint(result)',
+   *   timeout: 30,
+   *   host_functions: ['read_file', 'search'],
+   * });
+   * console.log(`stdout: ${result.stdout}`);
+   * console.log(`exit code: ${result.exit_code}`);
+   * ```
+   */
+  async runCode(sandboxId: string, params: RunCodeParams): Promise<RunCodeResponse> {
+    return this.http.request<RunCodeResponse>(`/api/v2/sandbox/${sandboxId}/run`, {
+      method: "POST",
+      body: params,
+    });
+  }
+
+  /**
+   * Destroy a sandbox session
+   *
+   * @param sandboxId - The sandbox session ID to destroy
+   * @returns Sandbox info at time of destruction
+   *
+   * @example
+   * ```typescript
+   * await client.sandbox.destroy('sbx-123');
+   * ```
+   */
+  async destroy(sandboxId: string): Promise<SandboxInfoResponse> {
+    return this.http.request<SandboxInfoResponse>(`/api/v2/sandbox/${sandboxId}`, {
+      method: "DELETE",
+    });
+  }
+}

--- a/packages/nexus-sdk/src/types/index.ts
+++ b/packages/nexus-sdk/src/types/index.ts
@@ -200,3 +200,11 @@ export type {
   TransferResponse,
   TransferStatus,
 } from "./pay.js";
+// Re-export sandbox types
+export type {
+  CreateSandboxParams,
+  CreateSandboxResponse,
+  RunCodeParams,
+  RunCodeResponse,
+  SandboxInfoResponse,
+} from "./sandbox.js";

--- a/packages/nexus-sdk/src/types/sandbox.ts
+++ b/packages/nexus-sdk/src/types/sandbox.ts
@@ -1,0 +1,41 @@
+/**
+ * Sandbox types — mirrors Nexus sandbox API contract
+ */
+
+export interface CreateSandboxParams {
+  readonly name: string;
+  readonly provider?: "monty" | "docker" | "e2b";
+  readonly timeoutMinutes?: number;
+  readonly securityProfile?: "strict" | "standard" | "permissive";
+  readonly metadata?: Readonly<Record<string, string>>;
+}
+
+export interface CreateSandboxResponse {
+  readonly sandbox_id: string;
+  readonly name: string;
+  readonly status: string;
+  readonly provider: string;
+  readonly created_at: string;
+}
+
+export interface RunCodeParams {
+  readonly language: string;
+  readonly code: string;
+  readonly timeout?: number;
+  readonly host_functions?: readonly string[];
+}
+
+export interface RunCodeResponse {
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly exit_code: number;
+  readonly execution_time: number;
+}
+
+export interface SandboxInfoResponse {
+  readonly sandbox_id: string;
+  readonly status: string;
+  readonly provider: string;
+  readonly created_at: string;
+  readonly metadata?: Readonly<Record<string, string>>;
+}

--- a/packages/nexus-sdk/tsup.config.ts
+++ b/packages/nexus-sdk/tsup.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
     "resources/memory": "src/resources/memory.ts",
     "resources/eventlog": "src/resources/eventlog.ts",
     "resources/permissions": "src/resources/permissions.ts",
+    "resources/sandbox": "src/resources/sandbox.ts",
     "http/index": "src/http/index.ts",
   },
   format: ["esm"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -250,6 +250,25 @@ importers:
         specifier: ^22.0.0
         version: 22.19.11
 
+  packages/code-mode:
+    dependencies:
+      '@nexus/sdk':
+        specifier: workspace:*
+        version: link:../nexus-sdk
+      '@templar/core':
+        specifier: workspace:*
+        version: link:../core
+      '@templar/errors':
+        specifier: workspace:*
+        version: link:../errors
+    devDependencies:
+      '@templar/test-utils':
+        specifier: workspace:*
+        version: link:../test-utils
+      '@types/node':
+        specifier: ^25.2.2
+        version: 25.2.2
+
   packages/core:
     devDependencies:
       '@nexus/sdk':


### PR DESCRIPTION
## Summary

- **@nexus/sdk**: Add `SandboxResource` with `create()`, `runCode()`, `destroy()` methods targeting the Nexus Sandbox API (Monty/Docker/E2B providers)
- **@templar/errors**: Add 6 CodeMode error codes to the catalog and 5 concrete error classes (`CodeSyntaxError`, `CodeRuntimeError`, `CodeExecutionTimeoutError`, `CodeResourceExceededError`, `CodeSandboxNotFoundError`)
- **@templar/code-mode**: New L2 package — `CodeModeMiddleware` implementing `TemplarMiddleware` that intercepts LLM model calls, injects code-mode system prompts, extracts Python code blocks, executes them in a Monty sandbox, and maps errors to the code-mode error hierarchy

Instead of sequential LLM tool calls (each requiring a full round trip), the LLM writes Python code that programmatically calls tools as functions. Pydantic's Monty interpreter (Rust, sub-microsecond startup, deny-by-default) executes this safely via the Nexus Sandbox API.

### Architecture

- **Sandbox lifecycle**: Session-scoped — created on `onSessionStart`, reused across turns, destroyed on `onSessionEnd`
- **Prompt injection**: `wrapModelCall` augments the system prompt with available Python function signatures and output format rules
- **Code extraction**: Regex-based extraction of `` ```python-code-mode `` blocks from LLM responses
- **Validation sandwich**: Pre-validate code length → sandbox execution → post-validate JSON output
- **Error classification**: Non-zero exit codes mapped to specific error types based on stderr content (syntax, timeout, memory, recursion)

### Packages modified

| Package | Changes |
|---------|---------|
| `@nexus/sdk` | +`SandboxResource`, +types, client wiring, tsup entry |
| `@templar/errors` | +6 catalog entries, +`CodeModeError` hierarchy |
| `@templar/code-mode` | New package: middleware, prompt, validation, types |

## Test plan

- [x] `@templar/errors` — 32 code-mode error tests (catalog, tags, toJSON, isExpected)
- [x] `@nexus/sdk` — 19 sandbox resource tests (create, runCode, destroy, error handling)
- [x] `@templar/code-mode` — 62 tests across 4 test files:
  - `middleware.test.ts` — lifecycle, wrapModelCall, code execution, error mapping
  - `prompt.test.ts` — function signatures, prompt generation
  - `validation.test.ts` — config validation, output parsing, code extraction
  - `edge-cases.test.ts` — empty code, oversized, non-JSON, sandbox unavailable
- [x] All 3 packages build successfully (ESM + DTS)
- [ ] Phase 4: Nexus FastAPI sandbox router (separate PR against nexus repo)
- [ ] Phase 5: E2E validation with real Monty sandbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)