### PR TITLE
feat(human-delay): add @templar/human-delay typing simulation (#88)

### DIFF
--- a/packages/errors/src/__tests__/unit/catalog.test.ts
+++ b/packages/errors/src/__tests__/unit/catalog.test.ts
@@ -84,6 +84,7 @@ describe("ERROR_CATALOG", () => {
       "SELF_TEST_VERIFICATION_FAILED", // selftest domain, SELF prefix (compound)
       "SELF_TEST_TIMEOUT", // selftest domain, SELF prefix (compound)
       "SELF_TEST_CONFIGURATION_INVALID", // selftest domain, SELF prefix (compound)
+      "HUMAN_DELAY_CONFIGURATION_INVALID", // channel domain, HUMAN prefix (compound)
     ]);
 
     for (const [code, entry] of Object.entries(ERROR_CATALOG)) {

--- a/packages/errors/src/catalog.ts
+++ b/packages/errors/src/catalog.ts
@@ -2060,6 +2060,19 @@ export const ERROR_CATALOG = {
     description:
       "Code execution failed and the operation should fall back to sequential tool calls",
   },
+
+  // ============================================================================
+  // HUMAN DELAY ERRORS — Human-like typing delay simulation (#88)
+  // ============================================================================
+  HUMAN_DELAY_CONFIGURATION_INVALID: {
+    domain: "channel",
+    httpStatus: 400,
+    grpcCode: "INVALID_ARGUMENT" as const,
+    baseType: "ValidationError" as const,
+    isExpected: true,
+    title: "Invalid human delay configuration",
+    description: "The human delay configuration is invalid",
+  },
 } as const;
 
 // ============================================================================

--- a/packages/errors/src/human-delay.ts
+++ b/packages/errors/src/human-delay.ts
@@ -1,0 +1,43 @@
+/**
+ * Human delay errors — Typing simulation configuration (#88)
+ *
+ * Abstract base: HumanDelayError
+ * Concrete:
+ *   - HumanDelayConfigurationError (HUMAN_DELAY_CONFIGURATION_INVALID)
+ */
+
+import { TemplarError } from "./base.js";
+import {
+  ERROR_CATALOG,
+  type ErrorDomain,
+  type GrpcStatusCode,
+  type HttpStatusCode,
+} from "./catalog.js";
+
+// ---------------------------------------------------------------------------
+// Abstract Base
+// ---------------------------------------------------------------------------
+
+export abstract class HumanDelayError extends TemplarError {}
+
+// ---------------------------------------------------------------------------
+// Concrete Errors
+// ---------------------------------------------------------------------------
+
+export class HumanDelayConfigurationError extends HumanDelayError {
+  readonly _tag = "ValidationError" as const;
+  readonly code = "HUMAN_DELAY_CONFIGURATION_INVALID" as const;
+  readonly httpStatus: HttpStatusCode;
+  readonly grpcCode: GrpcStatusCode;
+  readonly domain: ErrorDomain;
+  readonly isExpected: boolean;
+
+  constructor(message: string) {
+    super(`Human delay configuration invalid: ${message}`);
+    const entry = ERROR_CATALOG.HUMAN_DELAY_CONFIGURATION_INVALID;
+    this.httpStatus = entry.httpStatus as HttpStatusCode;
+    this.grpcCode = entry.grpcCode as GrpcStatusCode;
+    this.domain = entry.domain as ErrorDomain;
+    this.isExpected = entry.isExpected;
+  }
+}

--- a/packages/errors/src/index.ts
+++ b/packages/errors/src/index.ts
@@ -223,6 +223,12 @@ export {
 } from "./code-mode.js";
 
 // ============================================================================
+// HUMAN DELAY ERRORS — Human-like typing delay simulation (#88)
+// ============================================================================
+
+export { HumanDelayConfigurationError, HumanDelayError } from "./human-delay.js";
+
+// ============================================================================
 // WEB SEARCH ERRORS — Pluggable search providers (#119)
 // ============================================================================
 

--- a/packages/human-delay/package.json
+++ b/packages/human-delay/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@templar/human-delay",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check .",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@templar/errors": "workspace:*"
+  },
+  "devDependencies": {
+    "@templar/core": "workspace:*",
+    "@types/node": "^22.0.0",
+    "vitest": "^4.0.0"
+  }
+}

--- a/packages/human-delay/src/__tests__/adapter.test.ts
+++ b/packages/human-delay/src/__tests__/adapter.test.ts
@@ -1,0 +1,349 @@
+import type {
+  ChannelAdapter,
+  ChannelCapabilities,
+  MessageHandler,
+  OutboundMessage,
+} from "@templar/core";
+import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from "vitest";
+import { HumanDelayAdapter } from "../adapter.js";
+import type { HumanDelayConfig } from "../types.js";
+
+// ---------------------------------------------------------------------------
+// Test Helpers
+// ---------------------------------------------------------------------------
+
+function createMockAdapter(capabilities: ChannelCapabilities = {}): ChannelAdapter & {
+  send: MockInstance<(message: OutboundMessage) => Promise<void>>;
+  connect: MockInstance<() => Promise<void>>;
+  disconnect: MockInstance<() => Promise<void>>;
+  onMessage: MockInstance<(handler: MessageHandler) => void>;
+} {
+  return {
+    name: "mock-channel",
+    capabilities,
+    connect: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+    disconnect: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+    send: vi.fn<(message: OutboundMessage) => Promise<void>>().mockResolvedValue(undefined),
+    onMessage: vi.fn<(handler: MessageHandler) => void>(),
+  };
+}
+
+function textMessage(text: string, metadata?: Record<string, unknown>): OutboundMessage {
+  return {
+    channelId: "ch-1",
+    blocks: [{ type: "text" as const, content: text }],
+    ...(metadata ? { metadata } : {}),
+  };
+}
+
+function imageMessage(): OutboundMessage {
+  return {
+    channelId: "ch-1",
+    blocks: [{ type: "image" as const, url: "https://example.com/img.png" }],
+  };
+}
+
+function fileMessage(): OutboundMessage {
+  return {
+    channelId: "ch-1",
+    blocks: [
+      {
+        type: "file" as const,
+        url: "https://example.com/doc.pdf",
+        filename: "doc.pdf",
+        mimeType: "application/pdf",
+      },
+    ],
+  };
+}
+
+function mixedMessage(): OutboundMessage {
+  return {
+    channelId: "ch-1",
+    blocks: [
+      { type: "text" as const, content: "hello" },
+      { type: "image" as const, url: "https://example.com/img.png" },
+    ],
+  };
+}
+
+const FAST_CONFIG: HumanDelayConfig = {
+  wpm: 40,
+  jitterFactor: 0,
+  minDelay: 100,
+  maxDelay: 200,
+  punctuationPause: false,
+  random: () => 0.5,
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("HumanDelayAdapter", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("delegation", () => {
+    it("connect() delegates to inner adapter", async () => {
+      const inner = createMockAdapter();
+      const adapter = new HumanDelayAdapter(inner);
+      await adapter.connect();
+      expect(inner.connect).toHaveBeenCalledOnce();
+    });
+
+    it("disconnect() delegates to inner adapter", async () => {
+      const inner = createMockAdapter();
+      const adapter = new HumanDelayAdapter(inner);
+      await adapter.disconnect();
+      expect(inner.disconnect).toHaveBeenCalledOnce();
+    });
+
+    it("onMessage() delegates to inner adapter", () => {
+      const inner = createMockAdapter();
+      const adapter = new HumanDelayAdapter(inner);
+      const handler = vi.fn();
+      adapter.onMessage(handler);
+      expect(inner.onMessage).toHaveBeenCalledWith(handler);
+    });
+
+    it("name mirrors inner adapter", () => {
+      const inner = createMockAdapter();
+      const adapter = new HumanDelayAdapter(inner);
+      expect(adapter.name).toBe("mock-channel");
+    });
+
+    it("capabilities mirrors inner adapter", () => {
+      const caps: ChannelCapabilities = {
+        text: { supported: true, maxLength: 4096 },
+        typingIndicator: { supported: true },
+      };
+      const inner = createMockAdapter(caps);
+      const adapter = new HumanDelayAdapter(inner);
+      expect(adapter.capabilities).toBe(caps);
+    });
+  });
+
+  describe("delay behavior", () => {
+    it("delays before sending text message", async () => {
+      const inner = createMockAdapter();
+      const adapter = new HumanDelayAdapter(inner, FAST_CONFIG);
+      const msg = textMessage("hello world");
+
+      const sendPromise = adapter.send(msg);
+
+      // Before timer fires, inner.send should not have been called with the actual message
+      expect(inner.send).not.toHaveBeenCalledWith(msg);
+
+      await vi.advanceTimersByTimeAsync(200);
+      await sendPromise;
+
+      expect(inner.send).toHaveBeenCalledWith(msg);
+    });
+
+    it("bypasses delay for image message", async () => {
+      const inner = createMockAdapter();
+      const adapter = new HumanDelayAdapter(inner, FAST_CONFIG);
+      const msg = imageMessage();
+
+      await adapter.send(msg);
+      expect(inner.send).toHaveBeenCalledWith(msg);
+    });
+
+    it("bypasses delay for file message", async () => {
+      const inner = createMockAdapter();
+      const adapter = new HumanDelayAdapter(inner, FAST_CONFIG);
+      const msg = fileMessage();
+
+      await adapter.send(msg);
+      expect(inner.send).toHaveBeenCalledWith(msg);
+    });
+
+    it("bypasses delay for mixed block types (not all text)", async () => {
+      const inner = createMockAdapter();
+      const adapter = new HumanDelayAdapter(inner, FAST_CONFIG);
+      const msg = mixedMessage();
+
+      await adapter.send(msg);
+      expect(inner.send).toHaveBeenCalledWith(msg);
+    });
+
+    it("bypasses delay with skipDelay: true metadata", async () => {
+      const inner = createMockAdapter();
+      const adapter = new HumanDelayAdapter(inner, FAST_CONFIG);
+      const msg = textMessage("hello world", { skipDelay: true });
+
+      await adapter.send(msg);
+      expect(inner.send).toHaveBeenCalledWith(msg);
+    });
+
+    it("bypasses delay for empty blocks", async () => {
+      const inner = createMockAdapter();
+      const adapter = new HumanDelayAdapter(inner, FAST_CONFIG);
+      const msg: OutboundMessage = { channelId: "ch-1", blocks: [] };
+
+      await adapter.send(msg);
+      expect(inner.send).toHaveBeenCalledWith(msg);
+    });
+  });
+
+  describe("typing indicator", () => {
+    it("sends typing indicator before delay when channel supports it", async () => {
+      const inner = createMockAdapter({ typingIndicator: { supported: true } });
+      const adapter = new HumanDelayAdapter(inner, FAST_CONFIG);
+      const msg = textMessage("hello world");
+
+      const sendPromise = adapter.send(msg);
+
+      // Typing indicator should be sent immediately
+      expect(inner.send).toHaveBeenCalledWith({
+        channelId: "ch-1",
+        blocks: [],
+        metadata: { typingIndicator: true },
+      });
+
+      await vi.advanceTimersByTimeAsync(200);
+      await sendPromise;
+    });
+
+    it("does NOT send typing indicator when channel lacks support", async () => {
+      const inner = createMockAdapter({});
+      const adapter = new HumanDelayAdapter(inner, FAST_CONFIG);
+      const msg = textMessage("hello world");
+
+      const sendPromise = adapter.send(msg);
+      await vi.advanceTimersByTimeAsync(200);
+      await sendPromise;
+
+      // Only the actual message should have been sent (no typing indicator)
+      expect(inner.send).toHaveBeenCalledTimes(1);
+      expect(inner.send).toHaveBeenCalledWith(msg);
+    });
+
+    it("repeats typing indicator during long delay", async () => {
+      const inner = createMockAdapter({ typingIndicator: { supported: true } });
+      const adapter = new HumanDelayAdapter(inner, {
+        ...FAST_CONFIG,
+        minDelay: 5000,
+        maxDelay: 5000,
+        typingRepeatMs: 2000,
+      });
+      const msg = textMessage("hello");
+
+      const sendPromise = adapter.send(msg);
+
+      // Initial typing indicator sent immediately
+      expect(inner.send).toHaveBeenCalledTimes(1);
+
+      // Advance 2s — first repeat
+      await vi.advanceTimersByTimeAsync(2000);
+      expect(inner.send).toHaveBeenCalledTimes(2);
+
+      // Advance another 2s — second repeat
+      await vi.advanceTimersByTimeAsync(2000);
+      expect(inner.send).toHaveBeenCalledTimes(3);
+
+      // Advance remaining 1s — message sent, total = 4
+      await vi.advanceTimersByTimeAsync(1000);
+      await sendPromise;
+
+      expect(inner.send).toHaveBeenCalledTimes(4);
+    });
+
+    it("clears typing interval after send completes", async () => {
+      const inner = createMockAdapter({ typingIndicator: { supported: true } });
+      const adapter = new HumanDelayAdapter(inner, {
+        ...FAST_CONFIG,
+        minDelay: 1000,
+        maxDelay: 1000,
+        typingRepeatMs: 500,
+      });
+      const msg = textMessage("hello");
+
+      const sendPromise = adapter.send(msg);
+
+      // 1 (initial typing) + 1 (repeat at 500ms) = 2 before timer fires
+      await vi.advanceTimersByTimeAsync(1000);
+      await sendPromise;
+
+      const callCountAfterSend = inner.send.mock.calls.length;
+
+      // Advance more time — should NOT produce additional typing sends
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(inner.send.mock.calls.length).toBe(callCountAfterSend);
+    });
+
+    it("clears typing interval if inner.send() throws (try/finally)", async () => {
+      const inner = createMockAdapter({ typingIndicator: { supported: true } });
+      inner.send.mockImplementation(async (msg: OutboundMessage) => {
+        // Only throw for the actual message, not typing indicators
+        if (msg.blocks.length > 0) {
+          throw new Error("send failed");
+        }
+      });
+
+      const adapter = new HumanDelayAdapter(inner, {
+        ...FAST_CONFIG,
+        minDelay: 1000,
+        maxDelay: 1000,
+        typingRepeatMs: 500,
+      });
+      const msg = textMessage("hello");
+
+      const sendPromise = adapter.send(msg);
+      // Attach rejection handler before advancing timers to avoid unhandled rejection warning
+      const assertionPromise = expect(sendPromise).rejects.toThrow("send failed");
+      await vi.advanceTimersByTimeAsync(1000);
+      await assertionPromise;
+
+      const callCountAfterError = inner.send.mock.calls.length;
+
+      // Advance more time — interval should be cleared
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(inner.send.mock.calls.length).toBe(callCountAfterError);
+    });
+
+    it("typing indicator failure doesn't break send", async () => {
+      const inner = createMockAdapter({ typingIndicator: { supported: true } });
+      inner.send.mockImplementation(async (msg: OutboundMessage) => {
+        if (msg.blocks.length === 0 && msg.metadata?.typingIndicator) {
+          throw new Error("typing failed");
+        }
+      });
+
+      const adapter = new HumanDelayAdapter(inner, FAST_CONFIG);
+      const msg = textMessage("hello world");
+
+      const sendPromise = adapter.send(msg);
+      await vi.advanceTimersByTimeAsync(200);
+
+      // Should complete without error despite typing indicator failure
+      await expect(sendPromise).resolves.toBeUndefined();
+    });
+  });
+
+  describe("performance", () => {
+    it("bypassed messages have negligible overhead", async () => {
+      vi.useRealTimers();
+
+      const inner = createMockAdapter();
+      const adapter = new HumanDelayAdapter(inner, FAST_CONFIG);
+      const msg = imageMessage();
+
+      const iterations = 1000;
+      const start = performance.now();
+      for (let i = 0; i < iterations; i++) {
+        await adapter.send(msg);
+      }
+      const elapsed = performance.now() - start;
+
+      // Average < 1ms per call
+      expect(elapsed / iterations).toBeLessThan(1);
+    });
+  });
+});

--- a/packages/human-delay/src/__tests__/calculator.test.ts
+++ b/packages/human-delay/src/__tests__/calculator.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from "vitest";
+import {
+  calculateDelay,
+  countPunctuationPauses,
+  countWords,
+  gaussianRandom,
+} from "../calculator.js";
+import type { ResolvedConfig } from "../types.js";
+
+// Seeded RNG for deterministic tests
+function seededRng(seed: number): () => number {
+  let s = seed;
+  return () => {
+    s = (s * 1664525 + 1013904223) % 2 ** 32;
+    return (s >>> 0) / 2 ** 32;
+  };
+}
+
+function makeConfig(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
+  return {
+    wpm: 40,
+    jitterFactor: 0.2,
+    minDelay: 500,
+    maxDelay: 8000,
+    punctuationPause: true,
+    typingRepeatMs: 4000,
+    random: seededRng(42),
+    clock: globalThis,
+    ...overrides,
+  };
+}
+
+describe("countWords", () => {
+  it("returns 0 for empty string", () => {
+    expect(countWords("")).toBe(0);
+  });
+
+  it("returns 0 for whitespace-only string", () => {
+    expect(countWords("   \t\n  ")).toBe(0);
+  });
+
+  it("returns 1 for single word", () => {
+    expect(countWords("hello")).toBe(1);
+  });
+
+  it("returns correct count for multiple words", () => {
+    expect(countWords("hello world foo bar")).toBe(4);
+  });
+
+  it("handles extra whitespace correctly", () => {
+    expect(countWords("  hello   world  ")).toBe(2);
+  });
+
+  it("handles newlines and tabs", () => {
+    expect(countWords("hello\nworld\tfoo")).toBe(3);
+  });
+});
+
+describe("gaussianRandom", () => {
+  it("returns a finite number", () => {
+    const rng = seededRng(1);
+    const result = gaussianRandom(rng);
+    expect(Number.isFinite(result)).toBe(true);
+  });
+
+  it("produces deterministic output with seeded RNG", () => {
+    const rng1 = seededRng(42);
+    const rng2 = seededRng(42);
+    expect(gaussianRandom(rng1)).toBe(gaussianRandom(rng2));
+  });
+
+  it("distribution roughly centered at 0 (100 samples)", () => {
+    const rng = seededRng(123);
+    let sum = 0;
+    const n = 100;
+    for (let i = 0; i < n; i++) {
+      sum += gaussianRandom(rng);
+    }
+    const mean = sum / n;
+    // Mean should be close to 0 (within ±0.5 for 100 samples)
+    expect(Math.abs(mean)).toBeLessThan(0.5);
+  });
+
+  it("produces varied results with different seeds", () => {
+    const a = gaussianRandom(seededRng(1));
+    const b = gaussianRandom(seededRng(999));
+    expect(a).not.toBe(b);
+  });
+});
+
+describe("countPunctuationPauses", () => {
+  it("counts sentence ends", () => {
+    const result = countPunctuationPauses("Hello. World! Really?");
+    expect(result.sentenceEnds).toBe(3);
+  });
+
+  it("counts clause pauses", () => {
+    const result = countPunctuationPauses("one, two; three: four");
+    expect(result.clausePauses).toBe(3);
+  });
+
+  it("returns 0/0 for no punctuation", () => {
+    const result = countPunctuationPauses("hello world");
+    expect(result.sentenceEnds).toBe(0);
+    expect(result.clausePauses).toBe(0);
+  });
+
+  it("handles consecutive punctuation as single group", () => {
+    const result = countPunctuationPauses("Wait... Really?!");
+    expect(result.sentenceEnds).toBe(2); // "..." and "?!"
+  });
+
+  it("handles mixed punctuation", () => {
+    const result = countPunctuationPauses("Hello, world. How are you?");
+    expect(result.sentenceEnds).toBe(2); // "." and "?"
+    expect(result.clausePauses).toBe(1); // ","
+  });
+});
+
+describe("calculateDelay", () => {
+  it("returns minDelay for empty text", () => {
+    const config = makeConfig();
+    expect(calculateDelay("", config)).toBe(500);
+  });
+
+  it("returns minDelay for whitespace-only text", () => {
+    const config = makeConfig();
+    expect(calculateDelay("   ", config)).toBe(500);
+  });
+
+  it("calculates delay based on WPM for 10 words", () => {
+    // 10 words at 40 WPM = 15000ms base, with jitter ≈ 15000 ± 20%
+    const config = makeConfig({ jitterFactor: 0, punctuationPause: false, maxDelay: 60000 });
+    const delay = calculateDelay("one two three four five six seven eight nine ten", config);
+    // With jitterFactor=0, gaussianRandom still runs but is multiplied by 0
+    expect(delay).toBe(15000);
+  });
+
+  it("clamps result to minDelay", () => {
+    const config = makeConfig({ minDelay: 1000, wpm: 1000 });
+    // 2 words at 1000 WPM = 120ms base, should clamp to 1000
+    const delay = calculateDelay("hello world", config);
+    expect(delay).toBeGreaterThanOrEqual(1000);
+  });
+
+  it("clamps result to maxDelay", () => {
+    const config = makeConfig({ maxDelay: 2000, wpm: 1 });
+    // 10 words at 1 WPM = 600000ms base, should clamp to 2000
+    const delay = calculateDelay("one two three four five six seven eight nine ten", config);
+    expect(delay).toBe(2000);
+  });
+
+  it("adds extra time for punctuation", () => {
+    const config = makeConfig({ jitterFactor: 0 });
+    const withPunctuation = calculateDelay("Hello, world.", config);
+    const without = makeConfig({ jitterFactor: 0, punctuationPause: false });
+    const withoutPunctuation = calculateDelay("Hello, world.", without);
+    // Should add 300ms (1 sentence end) + 100ms (1 clause pause)
+    expect(withPunctuation).toBe(withoutPunctuation + 400);
+  });
+
+  it("skips punctuation pause when disabled", () => {
+    const configWith = makeConfig({ jitterFactor: 0, punctuationPause: true });
+    const configWithout = makeConfig({ jitterFactor: 0, punctuationPause: false });
+    const with_ = calculateDelay("Hello. World!", configWith);
+    const without = calculateDelay("Hello. World!", configWithout);
+    expect(with_).toBeGreaterThan(without);
+  });
+
+  it("jitter produces variation with seeded RNG", () => {
+    const config1 = makeConfig({ random: seededRng(1), maxDelay: 60000 });
+    const config2 = makeConfig({ random: seededRng(999), maxDelay: 60000 });
+    const text = "The quick brown fox jumps over the lazy dog";
+    const delay1 = calculateDelay(text, config1);
+    const delay2 = calculateDelay(text, config2);
+    expect(delay1).not.toBe(delay2);
+  });
+
+  it("respects custom WPM", () => {
+    const slow = makeConfig({ wpm: 20, jitterFactor: 0, punctuationPause: false, maxDelay: 60000 });
+    const fast = makeConfig({ wpm: 80, jitterFactor: 0, punctuationPause: false, maxDelay: 60000 });
+    const text = "one two three four";
+    // 4 words: slow = 12000ms, fast = 3000ms
+    expect(calculateDelay(text, slow)).toBe(12000);
+    expect(calculateDelay(text, fast)).toBe(3000);
+  });
+});

--- a/packages/human-delay/src/__tests__/config.test.ts
+++ b/packages/human-delay/src/__tests__/config.test.ts
@@ -1,0 +1,86 @@
+import { HumanDelayConfigurationError } from "@templar/errors";
+import { describe, expect, it } from "vitest";
+import { validateHumanDelayConfig } from "../adapter.js";
+
+describe("validateHumanDelayConfig", () => {
+  it("accepts undefined config (all defaults)", () => {
+    expect(() => validateHumanDelayConfig(undefined)).not.toThrow();
+  });
+
+  it("accepts valid config", () => {
+    expect(() =>
+      validateHumanDelayConfig({
+        wpm: 60,
+        jitterFactor: 0.3,
+        minDelay: 200,
+        maxDelay: 5000,
+        typingRepeatMs: 3000,
+      }),
+    ).not.toThrow();
+  });
+
+  it("accepts empty object (all defaults)", () => {
+    expect(() => validateHumanDelayConfig({})).not.toThrow();
+  });
+
+  it("throws for wpm=0", () => {
+    expect(() => validateHumanDelayConfig({ wpm: 0 })).toThrow(HumanDelayConfigurationError);
+  });
+
+  it("throws for wpm=-1", () => {
+    expect(() => validateHumanDelayConfig({ wpm: -1 })).toThrow(HumanDelayConfigurationError);
+  });
+
+  it("throws for wpm=NaN", () => {
+    expect(() => validateHumanDelayConfig({ wpm: Number.NaN })).toThrow(
+      HumanDelayConfigurationError,
+    );
+  });
+
+  it("throws for wpm=Infinity", () => {
+    expect(() => validateHumanDelayConfig({ wpm: Number.POSITIVE_INFINITY })).toThrow(
+      HumanDelayConfigurationError,
+    );
+  });
+
+  it("throws for jitterFactor=-0.1", () => {
+    expect(() => validateHumanDelayConfig({ jitterFactor: -0.1 })).toThrow(
+      HumanDelayConfigurationError,
+    );
+  });
+
+  it("throws for jitterFactor=1.1", () => {
+    expect(() => validateHumanDelayConfig({ jitterFactor: 1.1 })).toThrow(
+      HumanDelayConfigurationError,
+    );
+  });
+
+  it("accepts jitterFactor boundary values (0 and 1)", () => {
+    expect(() => validateHumanDelayConfig({ jitterFactor: 0 })).not.toThrow();
+    expect(() => validateHumanDelayConfig({ jitterFactor: 1 })).not.toThrow();
+  });
+
+  it("throws for minDelay=-1", () => {
+    expect(() => validateHumanDelayConfig({ minDelay: -1 })).toThrow(HumanDelayConfigurationError);
+  });
+
+  it("throws for maxDelay=-1", () => {
+    expect(() => validateHumanDelayConfig({ maxDelay: -1 })).toThrow(HumanDelayConfigurationError);
+  });
+
+  it("throws when minDelay > maxDelay", () => {
+    expect(() => validateHumanDelayConfig({ minDelay: 5000, maxDelay: 1000 })).toThrow(
+      HumanDelayConfigurationError,
+    );
+  });
+
+  it("throws for typingRepeatMs=50 (below 100ms minimum)", () => {
+    expect(() => validateHumanDelayConfig({ typingRepeatMs: 50 })).toThrow(
+      HumanDelayConfigurationError,
+    );
+  });
+
+  it("accepts typingRepeatMs=100 (boundary)", () => {
+    expect(() => validateHumanDelayConfig({ typingRepeatMs: 100 })).not.toThrow();
+  });
+});

--- a/packages/human-delay/src/__tests__/integration.test.ts
+++ b/packages/human-delay/src/__tests__/integration.test.ts
@@ -1,0 +1,217 @@
+import type {
+  ChannelAdapter,
+  ChannelCapabilities,
+  MessageHandler,
+  OutboundMessage,
+} from "@templar/core";
+import { HumanDelayConfigurationError } from "@templar/errors";
+import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from "vitest";
+import { HumanDelayAdapter } from "../adapter.js";
+import { withHumanDelay } from "../index.js";
+import type { HumanDelayConfig } from "../types.js";
+
+// ---------------------------------------------------------------------------
+// Test Helpers
+// ---------------------------------------------------------------------------
+
+function createMockAdapter(
+  capabilities: ChannelCapabilities = { typingIndicator: { supported: true } },
+): ChannelAdapter & {
+  send: MockInstance<(message: OutboundMessage) => Promise<void>>;
+  connect: MockInstance<() => Promise<void>>;
+  disconnect: MockInstance<() => Promise<void>>;
+  onMessage: MockInstance<(handler: MessageHandler) => void>;
+} {
+  return {
+    name: "test-channel",
+    capabilities,
+    connect: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+    disconnect: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+    send: vi.fn<(message: OutboundMessage) => Promise<void>>().mockResolvedValue(undefined),
+    onMessage: vi.fn<(handler: MessageHandler) => void>(),
+  };
+}
+
+function textMessage(text: string): OutboundMessage {
+  return {
+    channelId: "ch-1",
+    blocks: [{ type: "text" as const, content: text }],
+  };
+}
+
+const DETERMINISTIC_CONFIG: HumanDelayConfig = {
+  wpm: 40,
+  jitterFactor: 0,
+  minDelay: 500,
+  maxDelay: 8000,
+  punctuationPause: false,
+  random: () => 0.5,
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("integration", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("full flow: typing → delay → send (correct order)", async () => {
+    const inner = createMockAdapter();
+    const adapter = new HumanDelayAdapter(inner, {
+      ...DETERMINISTIC_CONFIG,
+      minDelay: 1000,
+      maxDelay: 1000,
+    });
+    const msg = textMessage("hello world");
+    const callOrder: string[] = [];
+
+    inner.send.mockImplementation(async (m: OutboundMessage) => {
+      if (m.metadata?.typingIndicator) {
+        callOrder.push("typing");
+      } else {
+        callOrder.push("send");
+      }
+    });
+
+    const sendPromise = adapter.send(msg);
+    await vi.advanceTimersByTimeAsync(1000);
+    await sendPromise;
+
+    expect(callOrder).toEqual(["typing", "send"]);
+  });
+
+  it("multiple sequential sends get independent delays", async () => {
+    const inner = createMockAdapter();
+    const adapter = new HumanDelayAdapter(inner, {
+      ...DETERMINISTIC_CONFIG,
+      minDelay: 500,
+      maxDelay: 500,
+    });
+
+    const msg1 = textMessage("first message");
+    const msg2 = textMessage("second message");
+
+    const p1 = adapter.send(msg1);
+    await vi.advanceTimersByTimeAsync(500);
+    await p1;
+
+    const p2 = adapter.send(msg2);
+    await vi.advanceTimersByTimeAsync(500);
+    await p2;
+
+    // Filter out typing indicator calls
+    const actualSends = inner.send.mock.calls.filter((call) => !call[0]?.metadata?.typingIndicator);
+    expect(actualSends).toHaveLength(2);
+    expect(actualSends[0]?.[0]).toEqual(msg1);
+    expect(actualSends[1]?.[0]).toEqual(msg2);
+  });
+
+  it("config defaults applied correctly when no config provided", () => {
+    const inner = createMockAdapter();
+    const adapter = new HumanDelayAdapter(inner);
+    // Should not throw — defaults are valid
+    expect(adapter.name).toBe("test-channel");
+  });
+
+  it("custom WPM changes delay proportionally", async () => {
+    const inner1 = createMockAdapter({ typingIndicator: { supported: true } });
+    const inner2 = createMockAdapter({ typingIndicator: { supported: true } });
+
+    const slowAdapter = new HumanDelayAdapter(inner1, {
+      ...DETERMINISTIC_CONFIG,
+      wpm: 20,
+    });
+    const fastAdapter = new HumanDelayAdapter(inner2, {
+      ...DETERMINISTIC_CONFIG,
+      wpm: 80,
+    });
+
+    const msg = textMessage("one two three four");
+
+    // Slow: 4 words / 20 WPM * 60000 = 12000ms (clamped to maxDelay=8000)
+    const slowPromise = slowAdapter.send(msg);
+    await vi.advanceTimersByTimeAsync(8000);
+    await slowPromise;
+
+    const slowSends = inner1.send.mock.calls.filter((call) => !call[0]?.metadata?.typingIndicator);
+    expect(slowSends).toHaveLength(1);
+
+    // Fast: 4 words / 80 WPM * 60000 = 3000ms
+    const fastPromise = fastAdapter.send(msg);
+    await vi.advanceTimersByTimeAsync(3000);
+    await fastPromise;
+
+    const fastSends = inner2.send.mock.calls.filter((call) => !call[0]?.metadata?.typingIndicator);
+    expect(fastSends).toHaveLength(1);
+  });
+
+  it("long message (100 words) delay capped at maxDelay", async () => {
+    const inner = createMockAdapter();
+    const adapter = new HumanDelayAdapter(inner, {
+      ...DETERMINISTIC_CONFIG,
+      maxDelay: 5000,
+    });
+
+    const words = Array.from({ length: 100 }, (_, i) => `word${i}`).join(" ");
+    const msg = textMessage(words);
+
+    const sendPromise = adapter.send(msg);
+    await vi.advanceTimersByTimeAsync(5000);
+    await sendPromise;
+
+    const actualSends = inner.send.mock.calls.filter((call) => !call[0]?.metadata?.typingIndicator);
+    expect(actualSends).toHaveLength(1);
+  });
+
+  it("short message (1 word) delay at minDelay", async () => {
+    const inner = createMockAdapter();
+    const adapter = new HumanDelayAdapter(inner, {
+      ...DETERMINISTIC_CONFIG,
+      minDelay: 500,
+    });
+
+    const msg = textMessage("hi");
+    const sendPromise = adapter.send(msg);
+
+    // 1 word / 40 WPM * 60000 = 1500ms but minDelay=500 (1500 > 500 so not clamped)
+    // Actually 1 word at 40 WPM = 1500ms which is > 500, so delay = 1500ms
+    await vi.advanceTimersByTimeAsync(1500);
+    await sendPromise;
+
+    const actualSends = inner.send.mock.calls.filter((call) => !call[0]?.metadata?.typingIndicator);
+    expect(actualSends).toHaveLength(1);
+  });
+
+  it("withHumanDelay() factory validates and returns adapter", () => {
+    const inner = createMockAdapter();
+    const wrapped = withHumanDelay(inner, { wpm: 60 });
+    expect(wrapped).toBeInstanceOf(HumanDelayAdapter);
+    expect(wrapped.name).toBe("test-channel");
+  });
+
+  it("withHumanDelay() factory with invalid config throws before wrapping", () => {
+    const inner = createMockAdapter();
+    expect(() => withHumanDelay(inner, { wpm: -1 })).toThrow(HumanDelayConfigurationError);
+  });
+
+  it("decorator is transparent — inner adapter behavior preserved", async () => {
+    const inner = createMockAdapter();
+    const handler = vi.fn();
+    const adapter = new HumanDelayAdapter(inner);
+
+    adapter.onMessage(handler);
+    expect(inner.onMessage).toHaveBeenCalledWith(handler);
+
+    await adapter.connect();
+    expect(inner.connect).toHaveBeenCalledOnce();
+
+    await adapter.disconnect();
+    expect(inner.disconnect).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/human-delay/src/adapter.ts
+++ b/packages/human-delay/src/adapter.ts
@@ -1,0 +1,162 @@
+import type {
+  ChannelAdapter,
+  ChannelCapabilities,
+  MessageHandler,
+  OutboundMessage,
+} from "@templar/core";
+import { HumanDelayConfigurationError } from "@templar/errors";
+import { calculateDelay } from "./calculator.js";
+import { type Clock, DEFAULT_CONFIG, type HumanDelayConfig, type ResolvedConfig } from "./types.js";
+
+const DEFAULT_CLOCK: Clock = globalThis;
+
+/** Resolve user config with defaults */
+function resolveConfig(config?: HumanDelayConfig): ResolvedConfig {
+  return {
+    wpm: config?.wpm ?? DEFAULT_CONFIG.wpm,
+    jitterFactor: config?.jitterFactor ?? DEFAULT_CONFIG.jitterFactor,
+    minDelay: config?.minDelay ?? DEFAULT_CONFIG.minDelay,
+    maxDelay: config?.maxDelay ?? DEFAULT_CONFIG.maxDelay,
+    punctuationPause: config?.punctuationPause ?? DEFAULT_CONFIG.punctuationPause,
+    typingRepeatMs: config?.typingRepeatMs ?? DEFAULT_CONFIG.typingRepeatMs,
+    random: config?.random ?? Math.random,
+    clock: config?.clock ?? DEFAULT_CLOCK,
+  };
+}
+
+/** Validate configuration, throw HumanDelayConfigurationError on invalid input */
+export function validateHumanDelayConfig(config?: HumanDelayConfig): void {
+  if (config === undefined) return;
+
+  if (config.wpm !== undefined && (config.wpm <= 0 || !Number.isFinite(config.wpm))) {
+    throw new HumanDelayConfigurationError(`wpm must be > 0, got ${config.wpm}`);
+  }
+  if (config.jitterFactor !== undefined && (config.jitterFactor < 0 || config.jitterFactor > 1)) {
+    throw new HumanDelayConfigurationError(`jitterFactor must be 0-1, got ${config.jitterFactor}`);
+  }
+  if (config.minDelay !== undefined && config.minDelay < 0) {
+    throw new HumanDelayConfigurationError(`minDelay must be >= 0, got ${config.minDelay}`);
+  }
+  if (config.maxDelay !== undefined && config.maxDelay < 0) {
+    throw new HumanDelayConfigurationError(`maxDelay must be >= 0, got ${config.maxDelay}`);
+  }
+  if (
+    config.minDelay !== undefined &&
+    config.maxDelay !== undefined &&
+    config.minDelay > config.maxDelay
+  ) {
+    throw new HumanDelayConfigurationError(
+      `minDelay (${config.minDelay}) > maxDelay (${config.maxDelay})`,
+    );
+  }
+  if (config.typingRepeatMs !== undefined && config.typingRepeatMs < 100) {
+    throw new HumanDelayConfigurationError(
+      `typingRepeatMs must be >= 100, got ${config.typingRepeatMs}`,
+    );
+  }
+}
+
+/** Check if a message should be delayed */
+function shouldDelay(message: OutboundMessage): boolean {
+  if (message.metadata?.skipDelay === true) return false;
+  return message.blocks.length > 0 && message.blocks.every((b) => b.type === "text");
+}
+
+/** Extract combined text from text blocks */
+function extractText(message: OutboundMessage): string {
+  return message.blocks
+    .filter((b): b is { readonly type: "text"; readonly content: string } => b.type === "text")
+    .map((b) => b.content)
+    .join("\n");
+}
+
+/** Promise-based sleep using provided clock */
+function sleep(ms: number, clock: Clock): Promise<void> {
+  return new Promise((resolve) => {
+    clock.setTimeout(resolve, ms);
+  });
+}
+
+/** Whether inner adapter supports typing indicators */
+function supportsTyping(adapter: ChannelAdapter): boolean {
+  return adapter.capabilities.typingIndicator?.supported === true;
+}
+
+/**
+ * Channel adapter decorator that adds human-like typing delays.
+ *
+ * - Sends typing indicator during delay (if channel supports it)
+ * - Auto-repeats typing indicator to prevent expiry
+ * - Bypasses delay for non-text messages and skipDelay metadata
+ * - try/finally ensures timer cleanup on error
+ */
+export class HumanDelayAdapter implements ChannelAdapter {
+  readonly name: string;
+  readonly capabilities: ChannelCapabilities;
+
+  private readonly inner: ChannelAdapter;
+  private readonly config: ResolvedConfig;
+
+  constructor(inner: ChannelAdapter, config?: HumanDelayConfig) {
+    this.inner = inner;
+    this.name = inner.name;
+    this.capabilities = inner.capabilities;
+    this.config = resolveConfig(config);
+  }
+
+  async connect(): Promise<void> {
+    await this.inner.connect();
+  }
+
+  async disconnect(): Promise<void> {
+    await this.inner.disconnect();
+  }
+
+  onMessage(handler: MessageHandler): void {
+    this.inner.onMessage(handler);
+  }
+
+  async send(message: OutboundMessage): Promise<void> {
+    if (!shouldDelay(message)) {
+      return this.inner.send(message);
+    }
+
+    const text = extractText(message);
+    const delayMs = calculateDelay(text, this.config);
+    const hasTyping = supportsTyping(this.inner);
+
+    // Send initial typing indicator
+    if (hasTyping) {
+      await this.sendTypingIndicator(message.channelId);
+    }
+
+    // Start typing indicator repeat interval
+    const intervalId = hasTyping
+      ? this.config.clock.setInterval(() => {
+          void this.sendTypingIndicator(message.channelId);
+        }, this.config.typingRepeatMs)
+      : undefined;
+
+    try {
+      await sleep(delayMs, this.config.clock);
+      await this.inner.send(message);
+    } finally {
+      if (intervalId !== undefined) {
+        this.config.clock.clearInterval(intervalId);
+      }
+    }
+  }
+
+  /** Send a typing indicator to the channel (best-effort, errors swallowed) */
+  private async sendTypingIndicator(channelId: string): Promise<void> {
+    try {
+      await this.inner.send({
+        channelId,
+        blocks: [],
+        metadata: { typingIndicator: true },
+      });
+    } catch {
+      // Best-effort — don't break the send flow for typing indicator failures
+    }
+  }
+}

--- a/packages/human-delay/src/calculator.ts
+++ b/packages/human-delay/src/calculator.ts
@@ -1,0 +1,50 @@
+import type { ResolvedConfig } from "./types.js";
+
+/** Count words in text (split on whitespace) */
+export function countWords(text: string): number {
+  const trimmed = text.trim();
+  if (trimmed.length === 0) return 0;
+  return trimmed.split(/\s+/).length;
+}
+
+/** Box-Muller transform: uniform [0,1) → Gaussian (mean=0, stddev=1) */
+export function gaussianRandom(random: () => number): number {
+  const u1 = random();
+  const u2 = random();
+  // Clamp u1 away from 0 to avoid log(0)
+  const safeU1 = Math.max(u1, 1e-10);
+  return Math.sqrt(-2 * Math.log(safeU1)) * Math.cos(2 * Math.PI * u2);
+}
+
+/** Count punctuation-based pause triggers */
+export function countPunctuationPauses(text: string): {
+  sentenceEnds: number;
+  clausePauses: number;
+} {
+  const sentenceEnds = (text.match(/[.!?]+/g) ?? []).length;
+  const clausePauses = (text.match(/[,;:]+/g) ?? []).length;
+  return { sentenceEnds, clausePauses };
+}
+
+/** Calculate delay for a text message */
+export function calculateDelay(text: string, config: ResolvedConfig): number {
+  const words = countWords(text);
+  if (words === 0) return config.minDelay;
+
+  // Base delay: time to type at target WPM
+  const baseMs = (words / config.wpm) * 60_000;
+
+  // Gaussian jitter: ±jitterFactor variation
+  const jitter = 1 + gaussianRandom(config.random) * config.jitterFactor;
+  let delayMs = baseMs * jitter;
+
+  // Punctuation pauses
+  if (config.punctuationPause) {
+    const { sentenceEnds, clausePauses } = countPunctuationPauses(text);
+    delayMs += sentenceEnds * 300; // 300ms per sentence end
+    delayMs += clausePauses * 100; // 100ms per clause pause
+  }
+
+  // Clamp to [minDelay, maxDelay]
+  return Math.max(config.minDelay, Math.min(config.maxDelay, Math.round(delayMs)));
+}

--- a/packages/human-delay/src/index.ts
+++ b/packages/human-delay/src/index.ts
@@ -1,0 +1,22 @@
+export { HumanDelayAdapter, validateHumanDelayConfig } from "./adapter.js";
+export { calculateDelay, countWords, gaussianRandom } from "./calculator.js";
+export type { Clock, HumanDelayConfig, ResolvedConfig } from "./types.js";
+export { DEFAULT_CONFIG } from "./types.js";
+
+import type { ChannelAdapter } from "@templar/core";
+import { HumanDelayAdapter, validateHumanDelayConfig } from "./adapter.js";
+import type { HumanDelayConfig } from "./types.js";
+
+/**
+ * Wrap a channel adapter with human-like typing delays.
+ *
+ * @param adapter - Any ChannelAdapter to wrap
+ * @param config - Optional delay configuration (defaults: 40 WPM, ±20% jitter)
+ * @returns A new ChannelAdapter with delay behavior on send()
+ */
+export function withHumanDelay(adapter: ChannelAdapter, config?: HumanDelayConfig): ChannelAdapter {
+  validateHumanDelayConfig(config);
+  return new HumanDelayAdapter(adapter, config);
+}
+
+export const PACKAGE_NAME = "@templar/human-delay";

--- a/packages/human-delay/src/types.ts
+++ b/packages/human-delay/src/types.ts
@@ -1,0 +1,47 @@
+/** Clock abstraction for testable timers */
+export interface Clock {
+  setTimeout(fn: () => void, ms: number): ReturnType<typeof setTimeout>;
+  setInterval(fn: () => void, ms: number): ReturnType<typeof setInterval>;
+  clearInterval(id: ReturnType<typeof setInterval>): void;
+}
+
+/** Human delay configuration */
+export interface HumanDelayConfig {
+  /** Target words per minute (default: 40 — average human typing speed) */
+  readonly wpm?: number;
+  /** Gaussian jitter factor 0-1 (default: 0.2 = ±20% variation) */
+  readonly jitterFactor?: number;
+  /** Minimum delay in ms (default: 500) */
+  readonly minDelay?: number;
+  /** Maximum delay in ms (default: 8000) */
+  readonly maxDelay?: number;
+  /** Add extra pauses at sentence boundaries (default: true) */
+  readonly punctuationPause?: boolean;
+  /** Typing indicator repeat interval in ms (default: 4000) */
+  readonly typingRepeatMs?: number;
+  /** RNG function for deterministic tests (default: Math.random) */
+  readonly random?: () => number;
+  /** Clock abstraction for testable timers (default: globalThis) */
+  readonly clock?: Clock;
+}
+
+export const DEFAULT_CONFIG = {
+  wpm: 40,
+  jitterFactor: 0.2,
+  minDelay: 500,
+  maxDelay: 8000,
+  punctuationPause: true,
+  typingRepeatMs: 4000,
+} as const;
+
+/** Fully resolved config (no optionals) */
+export interface ResolvedConfig {
+  readonly wpm: number;
+  readonly jitterFactor: number;
+  readonly minDelay: number;
+  readonly maxDelay: number;
+  readonly punctuationPause: boolean;
+  readonly typingRepeatMs: number;
+  readonly random: () => number;
+  readonly clock: Clock;
+}

--- a/packages/human-delay/tsconfig.json
+++ b/packages/human-delay/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": ["node"]
+  },
+  "include": ["src"],
+  "references": [{ "path": "../errors" }, { "path": "../core" }]
+}

--- a/packages/human-delay/tsup.config.ts
+++ b/packages/human-delay/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: { compilerOptions: { composite: false } },
+  clean: true,
+  treeshake: true,
+  target: "node22",
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -375,6 +375,22 @@ importers:
         specifier: ^4.0.0
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(yaml@2.8.2)
 
+  packages/human-delay:
+    dependencies:
+      '@templar/errors':
+        specifier: workspace:*
+        version: link:../errors
+    devDependencies:
+      '@templar/core':
+        specifier: workspace:*
+        version: link:../core
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.11
+      vitest:
+        specifier: ^4.0.0
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(yaml@2.8.2)
+
   packages/long-running:
     dependencies:
       '@templar/core':
@@ -5660,6 +5676,14 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
+  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@22.19.11)(yaml@2.8.2))':
+    dependencies:
+      '@vitest/spy': 4.0.18
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.1(@types/node@22.19.11)(yaml@2.8.2)
+
   '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@25.2.2)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 4.0.18
@@ -7632,7 +7656,7 @@ snapshots:
   vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(yaml@2.8.2):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.2.2)(yaml@2.8.2))
+      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@22.19.11)(yaml@2.8.2))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18


### PR DESCRIPTION
## Summary

- Adds `@templar/human-delay` package (Layer 2) that wraps any `ChannelAdapter` with human-like typing delays
- `withHumanDelay(adapter, config?)` factory function provides the main public API
- WPM-based delay algorithm with Gaussian jitter (Box-Muller transform), punctuation pauses, and configurable min/max clamping
- Auto-repeating typing indicator every 4s with `try/finally` cleanup guarantees
- Bypasses delay for non-text messages and `metadata.skipDelay` flag
- Injectable `Clock` and `random` function for deterministic testing with `vi.useFakeTimers()`
- Adds `HUMAN_DELAY_CONFIGURATION_INVALID` error code to `@templar/errors` catalog

### Files

| Package | New | Modified |
|---------|-----|----------|
| `@templar/human-delay` | `package.json`, `tsconfig.json`, `tsup.config.ts`, `src/types.ts` (~47 LOC), `src/calculator.ts` (~50 LOC), `src/adapter.ts` (~162 LOC), `src/index.ts` (~22 LOC) | — |
| `@templar/human-delay` (tests) | `calculator.test.ts`, `config.test.ts`, `adapter.test.ts`, `integration.test.ts` (~839 LOC) | — |
| `@templar/errors` | `src/human-delay.ts` (~43 LOC) | `catalog.ts`, `index.ts`, `catalog.test.ts` |

## Test plan

- [x] 66 tests pass across 4 test files (calculator, config, adapter, integration)
- [x] `@templar/errors` tests pass (253 tests, no regressions)
- [x] Build succeeds with `tsup` (ESM + DTS)
- [x] Typecheck passes (`tsc --noEmit`)
- [x] Lint passes (`biome check .`)
- [ ] CI pipeline validates cross-package build
- [ ] Manual validation with Nexus typing indicators

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)