### PR TITLE
feat(doctor): add security scanner and multi-tenant audit package (#27)

### DIFF
--- a/packages/doctor/package.json
+++ b/packages/doctor/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@templar/doctor",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "bin": {
+    "templar-doctor": "./dist/cli.js"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check .",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
+  },
+  "dependencies": {
+    "@templar/core": "workspace:*",
+    "@templar/errors": "workspace:*",
+    "yaml": "^2.8.0"
+  },
+  "devDependencies": {
+    "@nexus/sdk": "workspace:*",
+    "@templar/test-utils": "workspace:*",
+    "@types/node": "^25.0.0",
+    "vitest": "^4.0.0"
+  }
+}

--- a/packages/doctor/src/__tests__/integration/engine-pipeline.test.ts
+++ b/packages/doctor/src/__tests__/integration/engine-pipeline.test.ts
@@ -1,0 +1,113 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { getBuiltinChecks } from "../../checks/index.js";
+import { runAudit } from "../../engine.js";
+import type { DoctorConfig } from "../../types.js";
+
+describe("Engine Pipeline (Integration)", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "doctor-int-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("runs all built-in checks on a clean workspace", async () => {
+    const checks = getBuiltinChecks();
+    const config: DoctorConfig = { workspace: tmpDir };
+    const report = await runAudit(checks, config);
+
+    // Should complete without errors
+    expect(report.checkResults.length).toBeGreaterThan(0);
+    expect(report.exitCode).toBeGreaterThanOrEqual(0);
+    expect(report.durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("completes local scan in under 3 seconds", async () => {
+    const checks = getBuiltinChecks();
+    const config: DoctorConfig = { workspace: tmpDir };
+    const report = await runAudit(checks, config);
+
+    expect(report.durationMs).toBeLessThan(3000);
+  });
+
+  it("detects findings in a workspace with known issues", async () => {
+    // Create a world-writable .env
+    const envFile = path.join(tmpDir, ".env");
+    await fs.writeFile(envFile, 'API_KEY="sk-test1234567890abcdefghij"');
+    await fs.chmod(envFile, 0o666);
+
+    // Create gateway.yaml with issues
+    await fs.writeFile(path.join(tmpDir, "gateway.yaml"), `authMode: legacy\nbind: 0.0.0.0:8080\n`);
+
+    const checks = getBuiltinChecks();
+    const config: DoctorConfig = { workspace: tmpDir };
+    const report = await runAudit(checks, config);
+
+    expect(report.summary.total).toBeGreaterThan(0);
+    expect(report.summary.critical).toBeGreaterThan(0);
+    expect(report.exitCode).toBe(2);
+  });
+
+  it("disables specific checks", async () => {
+    const checks = getBuiltinChecks();
+    const config: DoctorConfig = {
+      workspace: tmpDir,
+      disabledChecks: ["filesystem-permissions", "secrets-scanning"],
+    };
+
+    const report = await runAudit(checks, config);
+    const disabled = report.checkResults.filter((r) => r.status === "skipped");
+    expect(disabled.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("skips Nexus checks when no client provided", async () => {
+    const checks = getBuiltinChecks();
+    const config: DoctorConfig = { workspace: tmpDir };
+    const report = await runAudit(checks, config);
+
+    const nexusChecks = report.checkResults.filter(
+      (r) => r.checkName === "multi-tenant-isolation" || r.checkName === "budget-leak-detection",
+    );
+
+    for (const result of nexusChecks) {
+      expect(result.status).toBe("skipped");
+    }
+  });
+
+  it("handles verbose mode", async () => {
+    const checks = getBuiltinChecks();
+    const config: DoctorConfig = { workspace: tmpDir, verbose: true };
+    const report = await runAudit(checks, config);
+
+    // Verbose mode shouldn't change results, just verify it runs
+    expect(report.checkResults.length).toBeGreaterThan(0);
+  });
+
+  it("handles concurrent execution correctly", async () => {
+    const checks = getBuiltinChecks();
+    const config: DoctorConfig = { workspace: tmpDir, concurrency: 1 };
+    const report = await runAudit(checks, config);
+
+    expect(report.checkResults.length).toBeGreaterThan(0);
+  });
+
+  it("includes correct timestamps", async () => {
+    const before = Date.now();
+    const checks = getBuiltinChecks();
+    const report = await runAudit(checks, { workspace: tmpDir });
+    const after = Date.now();
+
+    const startTime = new Date(report.startedAt).getTime();
+    const endTime = new Date(report.completedAt).getTime();
+
+    expect(startTime).toBeGreaterThanOrEqual(before);
+    expect(endTime).toBeLessThanOrEqual(after);
+    expect(startTime).toBeLessThanOrEqual(endTime);
+  });
+});

--- a/packages/doctor/src/__tests__/integration/middleware.test.ts
+++ b/packages/doctor/src/__tests__/integration/middleware.test.ts
@@ -1,0 +1,92 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { DoctorCheckFailedError, DoctorConfigurationError } from "@templar/errors";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createCheckResult } from "../../finding-factory.js";
+import { DoctorMiddleware } from "../../middleware.js";
+import type { DoctorCheck, DoctorCheckResult } from "../../types.js";
+
+describe("DoctorMiddleware (Integration)", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "doctor-mw-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("throws DoctorConfigurationError for missing workspace", () => {
+    expect(() => new DoctorMiddleware({ workspace: "" })).toThrow(DoctorConfigurationError);
+  });
+
+  it("runs audit on session start", async () => {
+    const mw = new DoctorMiddleware({ workspace: tmpDir });
+    expect(mw.getReport()).toBeNull();
+
+    await mw.onSessionStart();
+    const report = mw.getReport();
+    expect(report).not.toBeNull();
+    expect(report?.checkResults.length).toBeGreaterThan(0);
+  });
+
+  it("throws DoctorCheckFailedError on CRITICAL findings", async () => {
+    // Create a workspace with CRITICAL issues
+    const envFile = path.join(tmpDir, ".env");
+    await fs.writeFile(envFile, "SECRET=value");
+    await fs.chmod(envFile, 0o666); // World-writable
+
+    const mw = new DoctorMiddleware({ workspace: tmpDir });
+
+    await expect(mw.onSessionStart()).rejects.toThrow(DoctorCheckFailedError);
+  });
+
+  it("passes on a clean workspace", async () => {
+    const mw = new DoctorMiddleware({ workspace: tmpDir });
+
+    // Should not throw
+    await mw.onSessionStart();
+    const report = mw.getReport();
+    expect(report?.summary.critical).toBe(0);
+  });
+
+  it("caches report after first run", async () => {
+    const mw = new DoctorMiddleware({ workspace: tmpDir });
+    await mw.onSessionStart();
+    const report1 = mw.getReport();
+    expect(report1).not.toBeNull();
+
+    // Second call returns same report (report is set once)
+    const report2 = mw.getReport();
+    expect(report2).toBe(report1);
+  });
+
+  it("includes custom checks alongside built-in checks", async () => {
+    const customCheck: DoctorCheck = {
+      name: "custom-check",
+      requiresNexus: false,
+      async run(): Promise<DoctorCheckResult> {
+        return createCheckResult("custom-check", [], 1);
+      },
+    };
+
+    const mw = new DoctorMiddleware({
+      workspace: tmpDir,
+      checks: [customCheck],
+    });
+
+    await mw.onSessionStart();
+    const report = mw.getReport();
+    const custom = report?.checkResults.find((r) => r.checkName === "custom-check");
+    expect(custom).toBeDefined();
+    expect(custom?.status).toBe("passed");
+  });
+
+  it("onSessionEnd is a no-op", async () => {
+    const mw = new DoctorMiddleware({ workspace: tmpDir });
+    await mw.onSessionStart();
+    await expect(mw.onSessionEnd()).resolves.toBeUndefined();
+  });
+});

--- a/packages/doctor/src/__tests__/unit/attack-surface-summary.test.ts
+++ b/packages/doctor/src/__tests__/unit/attack-surface-summary.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { generateAttackSurfaceSummary } from "../../checks/attack-surface-summary.js";
+import { createCheckResult, createFinding, createSkippedResult } from "../../finding-factory.js";
+
+describe("generateAttackSurfaceSummary", () => {
+  it("generates AS-001 when >5 critical/high findings", () => {
+    const findings = Array.from({ length: 6 }, (_, i) =>
+      createFinding({
+        id: `TEST-${i}`,
+        checkName: "test",
+        severity: i < 3 ? "CRITICAL" : "HIGH",
+        title: `Finding ${i}`,
+        description: "Test",
+        remediation: "Fix",
+        location: "test.ts",
+        owaspRef: ["ASI01"],
+      }),
+    );
+
+    const results = [createCheckResult("test", findings, 10)];
+    const summary = generateAttackSurfaceSummary(results);
+
+    expect(summary.some((f) => f.id === "AS-001")).toBe(true);
+    expect(summary.some((f) => f.severity === "HIGH")).toBe(true);
+  });
+
+  it("generates AS-002 when checks are skipped", () => {
+    const results = [
+      createCheckResult("check-a", [], 10),
+      createSkippedResult("check-b", "No Nexus"),
+    ];
+
+    const summary = generateAttackSurfaceSummary(results);
+    expect(summary.some((f) => f.id === "AS-002")).toBe(true);
+  });
+
+  it("returns empty findings for clean results", () => {
+    const results = [createCheckResult("check-a", [], 10), createCheckResult("check-b", [], 10)];
+
+    const summary = generateAttackSurfaceSummary(results);
+    // No findings, no skips → no AS-001, no AS-002, no AS-003
+    expect(summary).toHaveLength(0);
+  });
+});

--- a/packages/doctor/src/__tests__/unit/budget-leak-detection.test.ts
+++ b/packages/doctor/src/__tests__/unit/budget-leak-detection.test.ts
@@ -1,0 +1,68 @@
+import type { NexusClient } from "@templar/core";
+import { describe, expect, it } from "vitest";
+import { BudgetLeakDetectionCheck } from "../../checks/budget-leak-detection.js";
+import type { DoctorCheckContext } from "../../types.js";
+
+function mockContext(nexus: unknown): DoctorCheckContext {
+  return {
+    workspace: "/tmp",
+    nexus: nexus as NexusClient,
+  };
+}
+
+describe("BudgetLeakDetectionCheck", () => {
+  const check = new BudgetLeakDetectionCheck();
+
+  it("auto-skips when no Nexus client", async () => {
+    const result = await check.run({ workspace: "/tmp" });
+    expect(result.status).toBe("passed");
+    expect(result.findings).toHaveLength(0);
+  });
+
+  it("detects zero balance", async () => {
+    const mockNexus = {
+      pay: {
+        getBalance: async () => ({ balance: 0, budgetLimit: 100 }),
+      },
+    };
+
+    const result = await check.run(mockContext(mockNexus));
+    expect(result.findings.some((f) => f.id === "BL-001")).toBe(true);
+  });
+
+  it("detects missing budget limit", async () => {
+    const mockNexus = {
+      pay: {
+        getBalance: async () => ({ balance: 100 }),
+      },
+    };
+
+    const result = await check.run(mockContext(mockNexus));
+    expect(result.findings.some((f) => f.id === "BL-002")).toBe(true);
+  });
+
+  it("passes with healthy budget", async () => {
+    const mockNexus = {
+      pay: {
+        getBalance: async () => ({ balance: 100, budgetLimit: 500 }),
+      },
+    };
+
+    const result = await check.run(mockContext(mockNexus));
+    expect(result.findings.filter((f) => f.id === "BL-001")).toHaveLength(0);
+  });
+
+  it("handles API errors gracefully", async () => {
+    const mockNexus = {
+      pay: {
+        getBalance: async () => {
+          throw new Error("Pay API error");
+        },
+      },
+    };
+
+    const result = await check.run(mockContext(mockNexus));
+    expect(result.status).toBe("error");
+    expect(result.error?.message).toBe("Pay API error");
+  });
+});

--- a/packages/doctor/src/__tests__/unit/channel-security.test.ts
+++ b/packages/doctor/src/__tests__/unit/channel-security.test.ts
@@ -1,0 +1,67 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ChannelSecurityCheck } from "../../checks/channel-security.js";
+
+describe("ChannelSecurityCheck", () => {
+  const check = new ChannelSecurityCheck();
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "doctor-ch-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("detects HTTP webhook URLs", async () => {
+    await fs.writeFile(
+      path.join(tmpDir, "templar.yaml"),
+      `channels:\n  - name: slack\n    webhook: http://example.com/hook\n`,
+    );
+
+    const result = await check.run({ workspace: tmpDir });
+    expect(result.findings.some((f) => f.id === "CH-003")).toBe(true);
+    expect(result.findings.some((f) => f.severity === "CRITICAL")).toBe(true);
+  });
+
+  it("detects missing allowlist", async () => {
+    await fs.writeFile(
+      path.join(tmpDir, "templar.yaml"),
+      `channels:\n  - name: discord\n    type: discord\n`,
+    );
+
+    const result = await check.run({ workspace: tmpDir });
+    expect(result.findings.some((f) => f.id === "CH-002")).toBe(true);
+  });
+
+  it("detects open DM without allowlist", async () => {
+    await fs.writeFile(
+      path.join(tmpDir, "templar.yaml"),
+      `channels:\n  - name: telegram\n    allowDM: true\n`,
+    );
+
+    const result = await check.run({ workspace: tmpDir });
+    expect(result.findings.some((f) => f.id === "CH-001")).toBe(true);
+  });
+
+  it("passes for HTTPS webhook with allowlist", async () => {
+    await fs.writeFile(
+      path.join(tmpDir, "templar.yaml"),
+      `channels:\n  - name: slack\n    webhook: https://example.com/hook\n    allowlist:\n      - user1\n`,
+    );
+
+    const result = await check.run({ workspace: tmpDir });
+    expect(result.findings.some((f) => f.id === "CH-003")).toBe(false);
+  });
+
+  it("handles malformed YAML gracefully", async () => {
+    await fs.writeFile(path.join(tmpDir, "templar.yaml"), ":::invalid yaml{{{");
+
+    const result = await check.run({ workspace: tmpDir });
+    expect(result.status).toBe("passed");
+    expect(result.findings).toHaveLength(0);
+  });
+});

--- a/packages/doctor/src/__tests__/unit/engine.test.ts
+++ b/packages/doctor/src/__tests__/unit/engine.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from "vitest";
+import { runAudit } from "../../engine.js";
+import { createCheckResult, createFinding } from "../../finding-factory.js";
+import type {
+  DoctorCheck,
+  DoctorCheckContext,
+  DoctorCheckResult,
+  DoctorConfig,
+} from "../../types.js";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function makeCheck(
+  name: string,
+  requiresNexus: boolean,
+  resultFn: (ctx: DoctorCheckContext) => Promise<DoctorCheckResult>,
+): DoctorCheck {
+  return { name, requiresNexus, run: resultFn };
+}
+
+function passingCheck(name: string): DoctorCheck {
+  return makeCheck(name, false, async () => createCheckResult(name, [], 10));
+}
+
+function findingCheck(name: string, severity: "CRITICAL" | "HIGH" | "MEDIUM" | "LOW"): DoctorCheck {
+  return makeCheck(name, false, async () => {
+    const finding = createFinding({
+      id: `${name}-001`,
+      checkName: name,
+      severity,
+      title: `${name} finding`,
+      description: "Test finding",
+      remediation: "Fix it",
+      location: "test.ts",
+      owaspRef: ["ASI01"],
+    });
+    return createCheckResult(name, [finding], 10);
+  });
+}
+
+function slowCheck(name: string, delayMs: number): DoctorCheck {
+  return makeCheck(name, false, async () => {
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
+    return createCheckResult(name, [], delayMs);
+  });
+}
+
+function throwingCheck(name: string): DoctorCheck {
+  return makeCheck(name, false, async () => {
+    throw new Error("Check exploded");
+  });
+}
+
+function nexusCheck(name: string): DoctorCheck {
+  return makeCheck(name, true, async () => createCheckResult(name, [], 10));
+}
+
+const baseConfig: DoctorConfig = {
+  workspace: "/tmp/test-workspace",
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("runAudit", () => {
+  it("returns a report with all passing checks", async () => {
+    const checks = [passingCheck("check-a"), passingCheck("check-b")];
+    const report = await runAudit(checks, baseConfig);
+
+    expect(report.checkResults).toHaveLength(2);
+    expect(report.summary.total).toBe(0);
+    expect(report.exitCode).toBe(0);
+    expect(report.durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("computes exit code 2 for CRITICAL findings", async () => {
+    const checks = [findingCheck("critical-check", "CRITICAL")];
+    const report = await runAudit(checks, baseConfig);
+
+    expect(report.summary.critical).toBe(1);
+    expect(report.exitCode).toBe(2);
+  });
+
+  it("computes exit code 1 for HIGH findings (no CRITICAL)", async () => {
+    const checks = [findingCheck("high-check", "HIGH")];
+    const report = await runAudit(checks, baseConfig);
+
+    expect(report.summary.high).toBe(1);
+    expect(report.exitCode).toBe(1);
+  });
+
+  it("computes exit code 0 for MEDIUM/LOW findings", async () => {
+    const checks = [findingCheck("med-check", "MEDIUM"), findingCheck("low-check", "LOW")];
+    const report = await runAudit(checks, baseConfig);
+
+    expect(report.summary.medium).toBe(1);
+    expect(report.summary.low).toBe(1);
+    expect(report.exitCode).toBe(0);
+  });
+
+  it("filters disabled checks", async () => {
+    const checks = [passingCheck("check-a"), passingCheck("check-b")];
+    const report = await runAudit(checks, {
+      ...baseConfig,
+      disabledChecks: ["check-a"],
+    });
+
+    const skipped = report.checkResults.find((r) => r.checkName === "check-a");
+    expect(skipped?.status).toBe("skipped");
+    expect(skipped?.skipReason).toBe("Disabled by configuration");
+  });
+
+  it("auto-skips Nexus checks when no client", async () => {
+    const checks = [nexusCheck("nexus-check")];
+    const report = await runAudit(checks, baseConfig);
+
+    expect(report.checkResults[0]?.status).toBe("skipped");
+    expect(report.checkResults[0]?.skipReason).toBe("Nexus client not available");
+  });
+
+  it("isolates check failures into error results", async () => {
+    const checks = [passingCheck("ok"), throwingCheck("broken")];
+    const report = await runAudit(checks, baseConfig);
+
+    const ok = report.checkResults.find((r) => r.checkName === "ok");
+    const broken = report.checkResults.find((r) => r.checkName === "broken");
+
+    expect(ok?.status).toBe("passed");
+    expect(broken?.status).toBe("error");
+    expect(broken?.error?.message).toBe("Check exploded");
+  });
+
+  it("runs checks with concurrency limit", async () => {
+    const checks = [
+      slowCheck("slow-1", 50),
+      slowCheck("slow-2", 50),
+      slowCheck("slow-3", 50),
+      slowCheck("slow-4", 50),
+    ];
+
+    const report = await runAudit(checks, { ...baseConfig, concurrency: 2 });
+    expect(report.checkResults).toHaveLength(4);
+    expect(report.checkResults.every((r) => r.status === "passed")).toBe(true);
+  });
+
+  it("respects the default concurrency of 4", async () => {
+    const checks = Array.from({ length: 8 }, (_, i) => passingCheck(`check-${i}`));
+    const report = await runAudit(checks, baseConfig);
+    expect(report.checkResults).toHaveLength(8);
+  });
+
+  it("includes startedAt and completedAt timestamps", async () => {
+    const report = await runAudit([passingCheck("a")], baseConfig);
+    expect(report.startedAt).toBeTruthy();
+    expect(report.completedAt).toBeTruthy();
+    expect(new Date(report.startedAt).getTime()).toBeLessThanOrEqual(
+      new Date(report.completedAt).getTime(),
+    );
+  });
+
+  it("computes summary correctly with mixed results", async () => {
+    const checks = [
+      findingCheck("c1", "CRITICAL"),
+      findingCheck("c2", "HIGH"),
+      findingCheck("c3", "MEDIUM"),
+      passingCheck("c4"),
+      throwingCheck("c5"),
+    ];
+
+    const report = await runAudit(checks, baseConfig);
+
+    expect(report.summary.total).toBe(3);
+    expect(report.summary.critical).toBe(1);
+    expect(report.summary.high).toBe(1);
+    expect(report.summary.medium).toBe(1);
+    expect(report.summary.checksRun).toBe(5);
+    expect(report.summary.checksFailed).toBe(1);
+  });
+
+  it("handles empty check list", async () => {
+    const report = await runAudit([], baseConfig);
+    expect(report.checkResults).toHaveLength(0);
+    expect(report.summary.total).toBe(0);
+    expect(report.exitCode).toBe(0);
+  });
+});

--- a/packages/doctor/src/__tests__/unit/filesystem-permissions.test.ts
+++ b/packages/doctor/src/__tests__/unit/filesystem-permissions.test.ts
@@ -1,0 +1,67 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { FilesystemPermissionsCheck } from "../../checks/filesystem-permissions.js";
+
+describe("FilesystemPermissionsCheck", () => {
+  const check = new FilesystemPermissionsCheck();
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "doctor-fs-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("detects world-writable sensitive files", async () => {
+    const envFile = path.join(tmpDir, ".env");
+    await fs.writeFile(envFile, "SECRET=value");
+    await fs.chmod(envFile, 0o666);
+
+    const result = await check.run({ workspace: tmpDir });
+    expect(result.findings.some((f) => f.id === "FS-001")).toBe(true);
+    expect(result.findings.some((f) => f.severity === "CRITICAL")).toBe(true);
+  });
+
+  it("detects group-writable sensitive files", async () => {
+    const keyFile = path.join(tmpDir, "server.key");
+    await fs.writeFile(keyFile, "key content");
+    await fs.chmod(keyFile, 0o664);
+
+    const result = await check.run({ workspace: tmpDir });
+    expect(result.findings.some((f) => f.id === "FS-002")).toBe(true);
+    expect(result.findings.some((f) => f.severity === "HIGH")).toBe(true);
+  });
+
+  it("passes when files have correct permissions", async () => {
+    const envFile = path.join(tmpDir, ".env");
+    await fs.writeFile(envFile, "SECRET=value");
+    await fs.chmod(envFile, 0o600);
+
+    const result = await check.run({ workspace: tmpDir });
+    expect(result.findings).toHaveLength(0);
+    expect(result.status).toBe("passed");
+  });
+
+  it("passes when no sensitive files exist", async () => {
+    await fs.writeFile(path.join(tmpDir, "readme.txt"), "hello");
+
+    const result = await check.run({ workspace: tmpDir });
+    expect(result.findings).toHaveLength(0);
+    expect(result.status).toBe("passed");
+  });
+
+  it("skips on Windows", async () => {
+    if (process.platform === "win32") {
+      const result = await check.run({ workspace: tmpDir });
+      expect(result.status).toBe("skipped");
+    } else {
+      // On non-Windows, just verify it doesn't skip
+      const result = await check.run({ workspace: tmpDir });
+      expect(result.status).not.toBe("skipped");
+    }
+  });
+});

--- a/packages/doctor/src/__tests__/unit/finding-factory.test.ts
+++ b/packages/doctor/src/__tests__/unit/finding-factory.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import {
+  createCheckResult,
+  createErrorResult,
+  createFinding,
+  createSkippedResult,
+} from "../../finding-factory.js";
+
+describe("createFinding", () => {
+  it("creates an immutable finding with all required fields", () => {
+    const finding = createFinding({
+      id: "TEST-001",
+      checkName: "test-check",
+      severity: "HIGH",
+      title: "Test finding",
+      description: "A test finding",
+      remediation: "Fix it",
+      location: "test.ts",
+      owaspRef: ["ASI01"],
+    });
+
+    expect(finding.id).toBe("TEST-001");
+    expect(finding.checkName).toBe("test-check");
+    expect(finding.severity).toBe("HIGH");
+    expect(finding.title).toBe("Test finding");
+    expect(finding.description).toBe("A test finding");
+    expect(finding.remediation).toBe("Fix it");
+    expect(finding.location).toBe("test.ts");
+    expect(finding.owaspRef).toEqual(["ASI01"]);
+    expect(finding.metadata).toBeUndefined();
+  });
+
+  it("includes metadata when provided via spread pattern", () => {
+    const finding = createFinding({
+      id: "TEST-002",
+      checkName: "test-check",
+      severity: "LOW",
+      title: "Test",
+      description: "Test",
+      remediation: "Test",
+      location: "test.ts",
+      owaspRef: [],
+      metadata: { key: "value" },
+    });
+
+    expect(finding.metadata).toEqual({ key: "value" });
+  });
+
+  it("omits metadata key when not provided", () => {
+    const finding = createFinding({
+      id: "TEST-003",
+      checkName: "test-check",
+      severity: "LOW",
+      title: "Test",
+      description: "Test",
+      remediation: "Test",
+      location: "test.ts",
+      owaspRef: [],
+    });
+
+    expect("metadata" in finding).toBe(false);
+  });
+
+  it("supports multiple OWASP references", () => {
+    const finding = createFinding({
+      id: "TEST-004",
+      checkName: "test-check",
+      severity: "CRITICAL",
+      title: "Test",
+      description: "Test",
+      remediation: "Test",
+      location: "test.ts",
+      owaspRef: ["ASI01", "ASI03", "ASI07"],
+    });
+
+    expect(finding.owaspRef).toEqual(["ASI01", "ASI03", "ASI07"]);
+  });
+});
+
+describe("createCheckResult", () => {
+  it("returns 'passed' status when no findings", () => {
+    const result = createCheckResult("test-check", [], 100);
+    expect(result.status).toBe("passed");
+    expect(result.checkName).toBe("test-check");
+    expect(result.durationMs).toBe(100);
+    expect(result.findings).toEqual([]);
+  });
+
+  it("returns 'findings' status when findings exist", () => {
+    const finding = createFinding({
+      id: "TEST-001",
+      checkName: "test-check",
+      severity: "HIGH",
+      title: "Test",
+      description: "Test",
+      remediation: "Test",
+      location: "test.ts",
+      owaspRef: [],
+    });
+
+    const result = createCheckResult("test-check", [finding], 50);
+    expect(result.status).toBe("findings");
+    expect(result.findings).toHaveLength(1);
+  });
+});
+
+describe("createSkippedResult", () => {
+  it("creates a skipped result with reason", () => {
+    const result = createSkippedResult("test-check", "Not supported");
+    expect(result.status).toBe("skipped");
+    expect(result.checkName).toBe("test-check");
+    expect(result.skipReason).toBe("Not supported");
+    expect(result.durationMs).toBe(0);
+    expect(result.findings).toEqual([]);
+  });
+});
+
+describe("createErrorResult", () => {
+  it("creates an error result with the error object", () => {
+    const error = new Error("Something went wrong");
+    const result = createErrorResult("test-check", error, 200);
+    expect(result.status).toBe("error");
+    expect(result.checkName).toBe("test-check");
+    expect(result.error).toBe(error);
+    expect(result.durationMs).toBe(200);
+    expect(result.findings).toEqual([]);
+  });
+});

--- a/packages/doctor/src/__tests__/unit/gateway-exposure.test.ts
+++ b/packages/doctor/src/__tests__/unit/gateway-exposure.test.ts
@@ -1,0 +1,71 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { GatewayExposureCheck } from "../../checks/gateway-exposure.js";
+
+describe("GatewayExposureCheck", () => {
+  const check = new GatewayExposureCheck();
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "doctor-gw-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("detects legacy auth mode", async () => {
+    await fs.writeFile(
+      path.join(tmpDir, "gateway.yaml"),
+      `authMode: legacy\nbind: 127.0.0.1:8080\n`,
+    );
+
+    const result = await check.run({ workspace: tmpDir });
+    expect(result.findings.some((f) => f.id === "GW-001")).toBe(true);
+  });
+
+  it("detects wildcard bind without TLS", async () => {
+    await fs.writeFile(
+      path.join(tmpDir, "gateway.yaml"),
+      `authMode: device-key\nbind: 0.0.0.0:8080\n`,
+    );
+
+    const result = await check.run({ workspace: tmpDir });
+    expect(result.findings.some((f) => f.id === "GW-002")).toBe(true);
+    expect(result.findings.some((f) => f.severity === "CRITICAL")).toBe(true);
+  });
+
+  it("detects TOFU enabled", async () => {
+    await fs.writeFile(
+      path.join(tmpDir, "gateway.yaml"),
+      `authMode: device-key\nbind: 127.0.0.1:8080\ntofu: true\n`,
+    );
+
+    const result = await check.run({ workspace: tmpDir });
+    expect(result.findings.some((f) => f.id === "GW-003")).toBe(true);
+  });
+
+  it("detects exposed API key in config", async () => {
+    await fs.writeFile(
+      path.join(tmpDir, "gateway.yaml"),
+      `authMode: device-key\nbind: 127.0.0.1:8080\napiKey: sk-real-key-123\n`,
+    );
+
+    const result = await check.run({ workspace: tmpDir });
+    expect(result.findings.some((f) => f.id === "GW-004")).toBe(true);
+  });
+
+  it("passes with a clean configuration", async () => {
+    await fs.writeFile(
+      path.join(tmpDir, "gateway.yaml"),
+      `authMode: device-key\nbind: 127.0.0.1:8080\ntls:\n  cert: cert.pem\n  key: key.pem\nrateLimit:\n  maxPerMinute: 100\n`,
+    );
+
+    const result = await check.run({ workspace: tmpDir });
+    expect(
+      result.findings.filter((f) => f.severity === "CRITICAL" || f.severity === "HIGH"),
+    ).toHaveLength(0);
+  });
+});

--- a/packages/doctor/src/__tests__/unit/json-reporter.test.ts
+++ b/packages/doctor/src/__tests__/unit/json-reporter.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import { JsonReporter } from "../../reporters/json-reporter.js";
+import type { DoctorReport } from "../../types.js";
+
+describe("JsonReporter", () => {
+  const reporter = new JsonReporter();
+
+  it("outputs valid JSON", () => {
+    const report: DoctorReport = {
+      startedAt: "2024-01-01T00:00:00.000Z",
+      completedAt: "2024-01-01T00:00:01.000Z",
+      durationMs: 100,
+      checkResults: [{ checkName: "test-check", status: "passed", durationMs: 50, findings: [] }],
+      summary: {
+        total: 0,
+        critical: 0,
+        high: 0,
+        medium: 0,
+        low: 0,
+        checksRun: 1,
+        checksSkipped: 0,
+        checksFailed: 0,
+      },
+      exitCode: 0,
+    };
+
+    const output = reporter.report(report);
+    const parsed = JSON.parse(output);
+    expect(parsed.startedAt).toBe("2024-01-01T00:00:00.000Z");
+    expect(parsed.exitCode).toBe(0);
+  });
+
+  it("includes full structure with findings", () => {
+    const report: DoctorReport = {
+      startedAt: "2024-01-01T00:00:00.000Z",
+      completedAt: "2024-01-01T00:00:01.000Z",
+      durationMs: 100,
+      checkResults: [
+        {
+          checkName: "test-check",
+          status: "findings",
+          durationMs: 50,
+          findings: [
+            {
+              id: "T-001",
+              checkName: "test-check",
+              severity: "HIGH",
+              title: "Test finding",
+              description: "A test",
+              remediation: "Fix it",
+              location: "test.ts",
+              owaspRef: ["ASI01"],
+            },
+          ],
+        },
+      ],
+      summary: {
+        total: 1,
+        critical: 0,
+        high: 1,
+        medium: 0,
+        low: 0,
+        checksRun: 1,
+        checksSkipped: 0,
+        checksFailed: 0,
+      },
+      exitCode: 1,
+    };
+
+    const parsed = JSON.parse(reporter.report(report));
+    expect(parsed.checkResults[0].findings[0].id).toBe("T-001");
+    expect(parsed.summary.high).toBe(1);
+  });
+
+  it("serializes error objects correctly", () => {
+    const report: DoctorReport = {
+      startedAt: "2024-01-01T00:00:00.000Z",
+      completedAt: "2024-01-01T00:00:01.000Z",
+      durationMs: 100,
+      checkResults: [
+        {
+          checkName: "broken",
+          status: "error",
+          durationMs: 10,
+          findings: [],
+          error: new Error("Something broke"),
+        },
+      ],
+      summary: {
+        total: 0,
+        critical: 0,
+        high: 0,
+        medium: 0,
+        low: 0,
+        checksRun: 1,
+        checksSkipped: 0,
+        checksFailed: 1,
+      },
+      exitCode: 0,
+    };
+
+    const parsed = JSON.parse(reporter.report(report));
+    expect(parsed.checkResults[0].error.message).toBe("Something broke");
+    expect(parsed.checkResults[0].error.name).toBe("Error");
+  });
+});

--- a/packages/doctor/src/__tests__/unit/multi-tenant-isolation.test.ts
+++ b/packages/doctor/src/__tests__/unit/multi-tenant-isolation.test.ts
@@ -1,0 +1,88 @@
+import type { NexusClient } from "@templar/core";
+import { describe, expect, it } from "vitest";
+import { MultiTenantIsolationCheck } from "../../checks/multi-tenant-isolation.js";
+import type { DoctorCheckContext } from "../../types.js";
+
+function mockContext(nexus: unknown): DoctorCheckContext {
+  return {
+    workspace: "/tmp",
+    nexus: nexus as NexusClient,
+  };
+}
+
+describe("MultiTenantIsolationCheck", () => {
+  const check = new MultiTenantIsolationCheck();
+
+  it("auto-skips when no Nexus client", async () => {
+    const result = await check.run({ workspace: "/tmp" });
+    expect(result.status).toBe("passed");
+    expect(result.findings).toHaveLength(0);
+  });
+
+  it("detects cross-zone grants", async () => {
+    const mockNexus = {
+      permissions: {
+        listNamespaceTools: async () => [
+          { id: "g1", sourceZone: "zone-a", targetZone: "zone-b", permission: "read" },
+        ],
+      },
+    };
+
+    const result = await check.run(mockContext(mockNexus));
+    expect(result.findings.some((f) => f.id === "MT-001")).toBe(true);
+    expect(result.findings.some((f) => f.severity === "CRITICAL")).toBe(true);
+  });
+
+  it("detects wildcard permissions", async () => {
+    const mockNexus = {
+      permissions: {
+        listNamespaceTools: async () => [
+          {
+            id: "g1",
+            sourceZone: "zone-a",
+            targetZone: "zone-a",
+            permission: "*",
+            resource: "tools",
+          },
+        ],
+      },
+    };
+
+    const result = await check.run(mockContext(mockNexus));
+    expect(result.findings.some((f) => f.id === "MT-002")).toBe(true);
+  });
+
+  it("passes with clean grants", async () => {
+    const mockNexus = {
+      permissions: {
+        listNamespaceTools: async () => [
+          {
+            id: "g1",
+            sourceZone: "zone-a",
+            targetZone: "zone-a",
+            permission: "read",
+            resource: "tools.search",
+            zone: "zone-a",
+          },
+        ],
+      },
+    };
+
+    const result = await check.run(mockContext(mockNexus));
+    expect(result.findings.filter((f) => f.id === "MT-001" || f.id === "MT-002")).toHaveLength(0);
+  });
+
+  it("handles API errors gracefully", async () => {
+    const mockNexus = {
+      permissions: {
+        listNamespaceTools: async () => {
+          throw new Error("Nexus API error");
+        },
+      },
+    };
+
+    const result = await check.run(mockContext(mockNexus));
+    expect(result.status).toBe("error");
+    expect(result.error?.message).toBe("Nexus API error");
+  });
+});

--- a/packages/doctor/src/__tests__/unit/secrets-scanning.test.ts
+++ b/packages/doctor/src/__tests__/unit/secrets-scanning.test.ts
@@ -1,0 +1,68 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { SecretsScanningCheck } from "../../checks/secrets-scanning.js";
+
+describe("SecretsScanningCheck", () => {
+  const check = new SecretsScanningCheck();
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "doctor-sec-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("detects OpenAI API keys", async () => {
+    await fs.writeFile(
+      path.join(tmpDir, "config.ts"),
+      `const key = "sk-abcdefghij1234567890abcdefghij";`,
+    );
+
+    const result = await check.run({ workspace: tmpDir });
+    expect(result.findings.some((f) => f.id === "SEC-001")).toBe(true);
+    expect(result.findings.some((f) => f.severity === "CRITICAL")).toBe(true);
+  });
+
+  it("detects AWS access keys", async () => {
+    await fs.writeFile(path.join(tmpDir, "config.ts"), `const aws = "AKIAIOSFODNN7EXAMPLE";`);
+
+    const result = await check.run({ workspace: tmpDir });
+    expect(result.findings.some((f) => f.id === "SEC-001")).toBe(true);
+  });
+
+  it("detects generic password patterns", async () => {
+    await fs.writeFile(path.join(tmpDir, "config.json"), `{"password": "mysecretpassword123"}`);
+
+    const result = await check.run({ workspace: tmpDir });
+    expect(result.findings.some((f) => f.id === "SEC-003")).toBe(true);
+  });
+
+  it("reports .env not in .gitignore", async () => {
+    await fs.writeFile(path.join(tmpDir, ".env"), "SECRET=value");
+    await fs.writeFile(path.join(tmpDir, ".gitignore"), "dist/\n");
+
+    const result = await check.run({ workspace: tmpDir });
+    expect(result.findings.some((f) => f.id === "SEC-002")).toBe(true);
+  });
+
+  it("passes when .env is properly gitignored", async () => {
+    await fs.writeFile(path.join(tmpDir, ".env"), "SECRET=value");
+    await fs.writeFile(path.join(tmpDir, ".gitignore"), ".env\ndist/\n");
+
+    const result = await check.run({ workspace: tmpDir });
+    expect(result.findings.some((f) => f.id === "SEC-002")).toBe(false);
+  });
+
+  it("skips files over 1MB", async () => {
+    const largeContent = "x".repeat(2_000_000);
+    await fs.writeFile(path.join(tmpDir, "large.ts"), largeContent);
+
+    const result = await check.run({ workspace: tmpDir });
+    // Should not find anything in the large file
+    expect(result.findings.filter((f) => f.location === "large.ts")).toHaveLength(0);
+  });
+});

--- a/packages/doctor/src/__tests__/unit/skill-code-safety.test.ts
+++ b/packages/doctor/src/__tests__/unit/skill-code-safety.test.ts
@@ -1,0 +1,78 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { SkillCodeSafetyCheck } from "../../checks/skill-code-safety.js";
+
+describe("SkillCodeSafetyCheck", () => {
+  const check = new SkillCodeSafetyCheck();
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "doctor-skill-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("detects eval() in skill code", async () => {
+    const skillsDir = path.join(tmpDir, "skills");
+    await fs.mkdir(skillsDir, { recursive: true });
+    await fs.writeFile(path.join(skillsDir, "dangerous.ts"), `const result = eval("1 + 1");`);
+
+    const result = await check.run({ workspace: tmpDir });
+    expect(result.findings.some((f) => f.id === "SK-001")).toBe(true);
+    expect(result.findings.some((f) => f.severity === "CRITICAL")).toBe(true);
+  });
+
+  it("detects child_process in skill code", async () => {
+    const skillsDir = path.join(tmpDir, "skills");
+    await fs.mkdir(skillsDir, { recursive: true });
+    await fs.writeFile(path.join(skillsDir, "runner.ts"), `import { exec } from "child_process";`);
+
+    const result = await check.run({ workspace: tmpDir });
+    expect(result.findings.some((f) => f.id === "SK-002")).toBe(true);
+  });
+
+  it("detects dynamic import in skill code", async () => {
+    const skillsDir = path.join(tmpDir, "skills");
+    await fs.mkdir(skillsDir, { recursive: true });
+    await fs.writeFile(
+      path.join(skillsDir, "loader.ts"),
+      `const mod = await import("./dangerous");`,
+    );
+
+    const result = await check.run({ workspace: tmpDir });
+    expect(result.findings.some((f) => f.id === "SK-005")).toBe(true);
+  });
+
+  it("extracts and scans code from SKILL.md", async () => {
+    await fs.writeFile(
+      path.join(tmpDir, "SKILL.md"),
+      "# Skill\n\n```typescript\nconst x = eval('test');\n```\n",
+    );
+
+    const result = await check.run({ workspace: tmpDir });
+    expect(result.findings.some((f) => f.id === "SK-001")).toBe(true);
+  });
+
+  it("passes with clean skill code", async () => {
+    const skillsDir = path.join(tmpDir, "skills");
+    await fs.mkdir(skillsDir, { recursive: true });
+    await fs.writeFile(
+      path.join(skillsDir, "safe.ts"),
+      `export function greet(name: string) { return "Hello, " + name; }`,
+    );
+
+    const result = await check.run({ workspace: tmpDir });
+    expect(result.findings).toHaveLength(0);
+    expect(result.status).toBe("passed");
+  });
+
+  it("handles missing skills directory", async () => {
+    const result = await check.run({ workspace: tmpDir });
+    expect(result.status).toBe("passed");
+    expect(result.findings).toHaveLength(0);
+  });
+});

--- a/packages/doctor/src/__tests__/unit/terminal-reporter.test.ts
+++ b/packages/doctor/src/__tests__/unit/terminal-reporter.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+import { TerminalReporter } from "../../reporters/terminal-reporter.js";
+import type { DoctorReport } from "../../types.js";
+
+// Strip ANSI escape codes for assertions
+function stripAnsi(str: string): string {
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: needed for ANSI stripping
+  return str.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+describe("TerminalReporter", () => {
+  const reporter = new TerminalReporter();
+
+  it("renders check results with ANSI colors", () => {
+    const report: DoctorReport = {
+      startedAt: "2024-01-01T00:00:00.000Z",
+      completedAt: "2024-01-01T00:00:01.000Z",
+      durationMs: 100,
+      checkResults: [
+        {
+          checkName: "test-check",
+          status: "findings",
+          durationMs: 50,
+          findings: [
+            {
+              id: "T-001",
+              checkName: "test-check",
+              severity: "CRITICAL",
+              title: "Critical issue",
+              description: "Something is critical",
+              remediation: "Fix it now",
+              location: "test.ts",
+              owaspRef: ["ASI01"],
+            },
+          ],
+        },
+      ],
+      summary: {
+        total: 1,
+        critical: 1,
+        high: 0,
+        medium: 0,
+        low: 0,
+        checksRun: 1,
+        checksSkipped: 0,
+        checksFailed: 0,
+      },
+      exitCode: 2,
+    };
+
+    const output = reporter.report(report);
+    expect(output).toContain("\x1b["); // Has ANSI codes
+    const plain = stripAnsi(output);
+    expect(plain).toContain("test-check");
+    expect(plain).toContain("[CRITICAL]");
+    expect(plain).toContain("1 CRITICAL");
+  });
+
+  it("groups findings by severity in summary", () => {
+    const report: DoctorReport = {
+      startedAt: "2024-01-01T00:00:00.000Z",
+      completedAt: "2024-01-01T00:00:01.000Z",
+      durationMs: 100,
+      checkResults: [],
+      summary: {
+        total: 4,
+        critical: 1,
+        high: 1,
+        medium: 1,
+        low: 1,
+        checksRun: 4,
+        checksSkipped: 0,
+        checksFailed: 0,
+      },
+      exitCode: 2,
+    };
+
+    const plain = stripAnsi(reporter.report(report));
+    expect(plain).toContain("1 CRITICAL");
+    expect(plain).toContain("1 HIGH");
+    expect(plain).toContain("1 MEDIUM");
+    expect(plain).toContain("1 LOW");
+  });
+
+  it("shows timing info", () => {
+    const report: DoctorReport = {
+      startedAt: "2024-01-01T00:00:00.000Z",
+      completedAt: "2024-01-01T00:00:01.000Z",
+      durationMs: 250,
+      checkResults: [{ checkName: "fast-check", status: "passed", durationMs: 25, findings: [] }],
+      summary: {
+        total: 0,
+        critical: 0,
+        high: 0,
+        medium: 0,
+        low: 0,
+        checksRun: 1,
+        checksSkipped: 0,
+        checksFailed: 0,
+      },
+      exitCode: 0,
+    };
+
+    const plain = stripAnsi(reporter.report(report));
+    expect(plain).toContain("250ms");
+    expect(plain).toContain("25ms");
+  });
+
+  it("shows success message when no findings", () => {
+    const report: DoctorReport = {
+      startedAt: "2024-01-01T00:00:00.000Z",
+      completedAt: "2024-01-01T00:00:01.000Z",
+      durationMs: 100,
+      checkResults: [],
+      summary: {
+        total: 0,
+        critical: 0,
+        high: 0,
+        medium: 0,
+        low: 0,
+        checksRun: 0,
+        checksSkipped: 0,
+        checksFailed: 0,
+      },
+      exitCode: 0,
+    };
+
+    const plain = stripAnsi(reporter.report(report));
+    expect(plain).toContain("No findings");
+  });
+});

--- a/packages/doctor/src/checks/attack-surface-summary.ts
+++ b/packages/doctor/src/checks/attack-surface-summary.ts
@@ -1,0 +1,123 @@
+import { createFinding } from "../finding-factory.js";
+import type { DoctorCheckResult, DoctorFinding } from "../types.js";
+
+// ---------------------------------------------------------------------------
+// Attack surface summary — post-processing aggregator
+// ---------------------------------------------------------------------------
+
+/**
+ * Aggregates findings from all checks to produce summary-level findings.
+ * This is NOT a `DoctorCheck` — it runs as a post-processing step on results.
+ */
+export function generateAttackSurfaceSummary(
+  results: readonly DoctorCheckResult[],
+): readonly DoctorFinding[] {
+  const findings: DoctorFinding[] = [];
+
+  // Collect all findings from all checks
+  const allFindings = results.flatMap((r) => r.findings);
+  const criticalAndHigh = allFindings.filter(
+    (f) => f.severity === "CRITICAL" || f.severity === "HIGH",
+  );
+
+  // AS-001: High attack surface (>5 critical/high findings)
+  if (criticalAndHigh.length > 5) {
+    findings.push(
+      createFinding({
+        id: "AS-001",
+        checkName: "attack-surface-summary",
+        severity: "HIGH",
+        title: "High attack surface detected",
+        description: `Found ${criticalAndHigh.length} critical/high findings across ${results.length} checks`,
+        remediation: "Prioritize fixing CRITICAL findings, then HIGH findings",
+        location: "aggregate",
+        owaspRef: collectOwaspRefs(criticalAndHigh),
+      }),
+    );
+  }
+
+  // AS-002: Missing security controls (checks with no findings that should have some)
+  const _checksWithNoFindings = results.filter(
+    (r) => r.status === "passed" && r.findings.length === 0,
+  );
+  const skippedChecks = results.filter((r) => r.status === "skipped");
+
+  if (skippedChecks.length > 0) {
+    findings.push(
+      createFinding({
+        id: "AS-002",
+        checkName: "attack-surface-summary",
+        severity: "MEDIUM",
+        title: "Security checks skipped",
+        description: `${skippedChecks.length} security check(s) were skipped: ${skippedChecks.map((r) => r.checkName).join(", ")}`,
+        remediation:
+          "Enable skipped checks by providing required configuration (e.g., Nexus client)",
+        location: "aggregate",
+        owaspRef: ["ASI07"],
+      }),
+    );
+  }
+
+  // AS-003: Remediation priority list
+  if (allFindings.length > 0) {
+    const severityOrder: Record<string, number> = {
+      CRITICAL: 0,
+      HIGH: 1,
+      MEDIUM: 2,
+      LOW: 3,
+    };
+    const sorted = [...allFindings].sort(
+      (a, b) => (severityOrder[a.severity] ?? 4) - (severityOrder[b.severity] ?? 4),
+    );
+    const top5 = sorted.slice(0, 5);
+
+    findings.push(
+      createFinding({
+        id: "AS-003",
+        checkName: "attack-surface-summary",
+        severity: "LOW",
+        title: "Remediation priority list",
+        description: `Top ${top5.length} findings to address: ${top5.map((f) => `[${f.severity}] ${f.title}`).join("; ")}`,
+        remediation: "Address findings in priority order: CRITICAL → HIGH → MEDIUM → LOW",
+        location: "aggregate",
+        owaspRef: collectOwaspRefs(top5),
+      }),
+    );
+  }
+
+  return findings;
+}
+
+function collectOwaspRefs(
+  findings: readonly DoctorFinding[],
+): readonly (
+  | "ASI01"
+  | "ASI02"
+  | "ASI03"
+  | "ASI04"
+  | "ASI05"
+  | "ASI06"
+  | "ASI07"
+  | "ASI08"
+  | "ASI09"
+  | "ASI10"
+)[] {
+  const refs = new Set<
+    | "ASI01"
+    | "ASI02"
+    | "ASI03"
+    | "ASI04"
+    | "ASI05"
+    | "ASI06"
+    | "ASI07"
+    | "ASI08"
+    | "ASI09"
+    | "ASI10"
+  >();
+  for (const f of findings) {
+    for (const ref of f.owaspRef) {
+      refs.add(ref);
+    }
+  }
+  return [...refs];
+}

--- a/packages/doctor/src/checks/budget-leak-detection.ts
+++ b/packages/doctor/src/checks/budget-leak-detection.ts
@@ -1,0 +1,104 @@
+import { createCheckResult, createErrorResult, createFinding } from "../finding-factory.js";
+import type {
+  DoctorCheck,
+  DoctorCheckContext,
+  DoctorCheckResult,
+  DoctorFinding,
+} from "../types.js";
+
+// ---------------------------------------------------------------------------
+// Budget leak detection check
+// ---------------------------------------------------------------------------
+
+/**
+ * Scans Nexus budget state for potential cost leaks:
+ * zero balance, missing budget limits, and zone budget exceedance.
+ */
+export class BudgetLeakDetectionCheck implements DoctorCheck {
+  readonly name = "budget-leak-detection";
+  readonly requiresNexus = true;
+
+  async run(context: DoctorCheckContext): Promise<DoctorCheckResult> {
+    const start = performance.now();
+
+    if (!context.nexus) {
+      return createCheckResult(this.name, [], Math.round(performance.now() - start));
+    }
+
+    const findings: DoctorFinding[] = [];
+
+    try {
+      const nexus = context.nexus as unknown as Record<string, unknown>;
+      const pay = nexus.pay as { getBalance?: () => Promise<unknown> } | undefined;
+
+      if (!pay?.getBalance) {
+        const durationMs = Math.round(performance.now() - start);
+        return createCheckResult(this.name, findings, durationMs);
+      }
+
+      const balance = await pay.getBalance();
+
+      if (balance && typeof balance === "object") {
+        const b = balance as Record<string, unknown>;
+
+        // BL-001: Zero balance
+        const amount = b.balance ?? b.amount ?? b.credits;
+        if (typeof amount === "number" && amount <= 0) {
+          findings.push(
+            createFinding({
+              id: "BL-001",
+              checkName: this.name,
+              severity: "HIGH",
+              title: "Zero or negative balance",
+              description: `Agent wallet balance is ${amount}`,
+              remediation: "Top up the agent wallet to prevent service disruption",
+              location: "nexus:pay:balance",
+              owaspRef: ["ASI08"],
+            }),
+          );
+        }
+
+        // BL-002: No budget limit
+        const limit = b.budgetLimit ?? b.budget_limit ?? b.limit;
+        if (limit === undefined || limit === null) {
+          findings.push(
+            createFinding({
+              id: "BL-002",
+              checkName: this.name,
+              severity: "MEDIUM",
+              title: "No budget limit configured",
+              description: "Agent has no budget limit — spending is unbounded",
+              remediation: "Set a budget limit in the agent manifest or Nexus dashboard",
+              location: "nexus:pay:config",
+              owaspRef: ["ASI08"],
+            }),
+          );
+        }
+
+        // BL-003: Exceeds zone budget
+        const zoneBudget = b.zoneBudget ?? b.zone_budget;
+        if (typeof amount === "number" && typeof zoneBudget === "number" && amount > zoneBudget) {
+          findings.push(
+            createFinding({
+              id: "BL-003",
+              checkName: this.name,
+              severity: "CRITICAL",
+              title: "Budget exceeds zone allocation",
+              description: `Agent balance (${amount}) exceeds zone budget (${zoneBudget})`,
+              remediation: "Reconcile agent budgets with zone allocations",
+              location: "nexus:pay:zone",
+              owaspRef: ["ASI08"],
+            }),
+          );
+        }
+      }
+    } catch (err) {
+      const durationMs = Math.round(performance.now() - start);
+      const error = err instanceof Error ? err : new Error(String(err));
+      return createErrorResult(this.name, error, durationMs);
+    }
+
+    const durationMs = Math.round(performance.now() - start);
+    return createCheckResult(this.name, findings, durationMs);
+  }
+}

--- a/packages/doctor/src/checks/channel-security.ts
+++ b/packages/doctor/src/checks/channel-security.ts
@@ -1,0 +1,135 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { parse as parseYaml } from "yaml";
+import { createCheckResult, createFinding } from "../finding-factory.js";
+import type {
+  DoctorCheck,
+  DoctorCheckContext,
+  DoctorCheckResult,
+  DoctorFinding,
+} from "../types.js";
+
+// ---------------------------------------------------------------------------
+// Channel security check
+// ---------------------------------------------------------------------------
+
+/**
+ * Scans templar.yaml for insecure channel configurations:
+ * HTTP webhooks, missing allowlists, open DM, and main scoping.
+ */
+export class ChannelSecurityCheck implements DoctorCheck {
+  readonly name = "channel-security";
+  readonly requiresNexus = false;
+
+  async run(context: DoctorCheckContext): Promise<DoctorCheckResult> {
+    const start = performance.now();
+    const findings: DoctorFinding[] = [];
+
+    const configPath = path.join(context.workspace, "templar.yaml");
+    let content: string;
+    try {
+      content = await fs.readFile(configPath, "utf-8");
+    } catch {
+      const durationMs = Math.round(performance.now() - start);
+      return createCheckResult(this.name, findings, durationMs);
+    }
+
+    let config: unknown;
+    try {
+      config = parseYaml(content);
+    } catch {
+      const durationMs = Math.round(performance.now() - start);
+      return createCheckResult(this.name, findings, durationMs);
+    }
+
+    if (!config || typeof config !== "object") {
+      const durationMs = Math.round(performance.now() - start);
+      return createCheckResult(this.name, findings, durationMs);
+    }
+
+    const channels = (config as Record<string, unknown>).channels;
+    if (!channels || typeof channels !== "object" || !Array.isArray(channels)) {
+      // Also check if channels is an object (map form)
+      if (channels && typeof channels === "object") {
+        this.scanChannels(Object.values(channels as Record<string, unknown>), findings);
+      }
+    } else {
+      this.scanChannels(channels as unknown[], findings);
+    }
+
+    const durationMs = Math.round(performance.now() - start);
+    return createCheckResult(this.name, findings, durationMs);
+  }
+
+  private scanChannels(channels: unknown[], findings: DoctorFinding[]): void {
+    for (const channel of channels) {
+      if (!channel || typeof channel !== "object") continue;
+      const ch = channel as Record<string, unknown>;
+
+      // CH-003: HTTP webhook (not HTTPS)
+      const webhook = ch.webhook ?? ch.webhookUrl ?? ch.url;
+      if (typeof webhook === "string" && webhook.startsWith("http://")) {
+        findings.push(
+          createFinding({
+            id: "CH-003",
+            checkName: this.name,
+            severity: "CRITICAL",
+            title: "HTTP webhook URL",
+            description: `Channel uses insecure HTTP webhook: ${webhook}`,
+            remediation: "Use HTTPS for all webhook URLs",
+            location: "templar.yaml:channels",
+            owaspRef: ["ASI09"],
+          }),
+        );
+      }
+
+      // CH-001: Open DM (no restrictions on direct messages)
+      if (ch.allowDM === true && !ch.allowlist && !ch.allowList) {
+        findings.push(
+          createFinding({
+            id: "CH-001",
+            checkName: this.name,
+            severity: "HIGH",
+            title: "Open DM channel",
+            description: "Channel allows direct messages without an allowlist",
+            remediation: "Add an allowlist to restrict who can DM the agent",
+            location: "templar.yaml:channels",
+            owaspRef: ["ASI01", "ASI09"],
+          }),
+        );
+      }
+
+      // CH-002: Missing allowlist
+      if (!ch.allowlist && !ch.allowList && !ch.allowedUsers && !ch.allowedChannels) {
+        findings.push(
+          createFinding({
+            id: "CH-002",
+            checkName: this.name,
+            severity: "MEDIUM",
+            title: "Missing channel allowlist",
+            description: "Channel has no allowlist for users or channels",
+            remediation: "Add an allowlist to restrict channel access",
+            location: "templar.yaml:channels",
+            owaspRef: ["ASI01"],
+          }),
+        );
+      }
+
+      // CH-004: Session scoping set to "main"
+      if (ch.sessionScoping === "main" || ch.scoping === "main") {
+        findings.push(
+          createFinding({
+            id: "CH-004",
+            checkName: this.name,
+            severity: "MEDIUM",
+            title: "Main session scoping",
+            description: "Channel uses 'main' session scoping — all users share context",
+            remediation: "Use 'user' or 'channel' session scoping for tenant isolation",
+            location: "templar.yaml:channels",
+            owaspRef: ["ASI01"],
+          }),
+        );
+      }
+    }
+  }
+}

--- a/packages/doctor/src/checks/filesystem-permissions.ts
+++ b/packages/doctor/src/checks/filesystem-permissions.ts
@@ -1,0 +1,149 @@
+import type { Dirent } from "node:fs";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { createCheckResult, createFinding, createSkippedResult } from "../finding-factory.js";
+import type {
+  DoctorCheck,
+  DoctorCheckContext,
+  DoctorCheckResult,
+  DoctorFinding,
+} from "../types.js";
+
+// ---------------------------------------------------------------------------
+// Glob patterns for sensitive files
+// ---------------------------------------------------------------------------
+
+const SENSITIVE_PATTERNS = [
+  "templar.yaml",
+  ".env",
+  ".env.local",
+  ".env.production",
+  ".env.staging",
+];
+
+const SENSITIVE_EXTENSIONS = [".key", ".pem"];
+
+const IGNORE_DIRS = new Set(["node_modules", "dist", ".git", "coverage"]);
+
+// ---------------------------------------------------------------------------
+// Filesystem permission check
+// ---------------------------------------------------------------------------
+
+/**
+ * Checks filesystem permissions on sensitive configuration files.
+ * Detects world-writable and group-writable files.
+ */
+export class FilesystemPermissionsCheck implements DoctorCheck {
+  readonly name = "filesystem-permissions";
+  readonly requiresNexus = false;
+
+  async run(context: DoctorCheckContext): Promise<DoctorCheckResult> {
+    if (process.platform === "win32") {
+      return createSkippedResult(this.name, "Not supported on Windows");
+    }
+
+    const start = performance.now();
+    const findings: DoctorFinding[] = [];
+
+    const files = await this.findSensitiveFiles(context.workspace);
+
+    for (const filePath of files) {
+      try {
+        const stat = await fs.stat(filePath);
+        const mode = stat.mode;
+        const relative = path.relative(context.workspace, filePath);
+
+        // World-writable check (0o002)
+        if (mode & 0o002) {
+          findings.push(
+            createFinding({
+              id: "FS-001",
+              checkName: this.name,
+              severity: "CRITICAL",
+              title: "World-writable sensitive file",
+              description: `File "${relative}" is world-writable (mode: ${mode.toString(8)})`,
+              remediation: `Run: chmod o-w "${relative}"`,
+              location: relative,
+              owaspRef: ["ASI05"],
+            }),
+          );
+        }
+        // Group-writable check (0o020)
+        else if (mode & 0o020) {
+          findings.push(
+            createFinding({
+              id: "FS-002",
+              checkName: this.name,
+              severity: "HIGH",
+              title: "Group-writable sensitive file",
+              description: `File "${relative}" is group-writable (mode: ${mode.toString(8)})`,
+              remediation: `Run: chmod g-w "${relative}"`,
+              location: relative,
+              owaspRef: ["ASI05"],
+            }),
+          );
+        }
+
+        // Directory permission check
+        if (stat.isDirectory() && mode & 0o002) {
+          findings.push(
+            createFinding({
+              id: "FS-003",
+              checkName: this.name,
+              severity: "MEDIUM",
+              title: "World-writable directory",
+              description: `Directory "${relative}" is world-writable`,
+              remediation: `Run: chmod o-w "${relative}"`,
+              location: relative,
+              owaspRef: ["ASI05"],
+            }),
+          );
+        }
+      } catch {
+        // File may have been removed between scan and stat
+      }
+    }
+
+    const durationMs = Math.round(performance.now() - start);
+    return createCheckResult(this.name, findings, durationMs);
+  }
+
+  private async findSensitiveFiles(dir: string): Promise<string[]> {
+    const results: string[] = [];
+    await this.walkDir(dir, results, 0);
+    return results;
+  }
+
+  private async walkDir(dir: string, results: string[], depth: number): Promise<void> {
+    if (depth > 5) return;
+
+    let entries: Dirent[];
+    try {
+      entries = (await fs.readdir(dir, { withFileTypes: true })) as Dirent[];
+    } catch {
+      return;
+    }
+
+    for (const entry of entries) {
+      if (IGNORE_DIRS.has(entry.name)) continue;
+
+      const fullPath = path.join(dir, entry.name);
+
+      if (entry.isDirectory()) {
+        await this.walkDir(fullPath, results, depth + 1);
+        continue;
+      }
+
+      if (entry.isFile()) {
+        const isSensitiveName = SENSITIVE_PATTERNS.some(
+          (p) => entry.name === p || entry.name.startsWith(".env"),
+        );
+        const isSensitiveExt = SENSITIVE_EXTENSIONS.some((ext) => entry.name.endsWith(ext));
+
+        if (isSensitiveName || isSensitiveExt) {
+          results.push(fullPath);
+        }
+      }
+    }
+  }
+}

--- a/packages/doctor/src/checks/gateway-exposure.ts
+++ b/packages/doctor/src/checks/gateway-exposure.ts
@@ -1,0 +1,141 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { parse as parseYaml } from "yaml";
+import { createCheckResult, createFinding } from "../finding-factory.js";
+import type {
+  DoctorCheck,
+  DoctorCheckContext,
+  DoctorCheckResult,
+  DoctorFinding,
+} from "../types.js";
+
+// ---------------------------------------------------------------------------
+// Gateway exposure check
+// ---------------------------------------------------------------------------
+
+/**
+ * Scans gateway.yaml for insecure configurations:
+ * legacy auth, wildcard bind, TOFU, exposed API keys, missing rate limiting.
+ */
+export class GatewayExposureCheck implements DoctorCheck {
+  readonly name = "gateway-exposure";
+  readonly requiresNexus = false;
+
+  async run(context: DoctorCheckContext): Promise<DoctorCheckResult> {
+    const start = performance.now();
+    const findings: DoctorFinding[] = [];
+
+    const configPath = path.join(context.workspace, "gateway.yaml");
+    let content: string;
+    try {
+      content = await fs.readFile(configPath, "utf-8");
+    } catch {
+      const durationMs = Math.round(performance.now() - start);
+      return createCheckResult(this.name, findings, durationMs);
+    }
+
+    let config: unknown;
+    try {
+      config = parseYaml(content);
+    } catch {
+      const durationMs = Math.round(performance.now() - start);
+      return createCheckResult(this.name, findings, durationMs);
+    }
+
+    if (!config || typeof config !== "object") {
+      const durationMs = Math.round(performance.now() - start);
+      return createCheckResult(this.name, findings, durationMs);
+    }
+
+    const gw = config as Record<string, unknown>;
+
+    // GW-001: Legacy auth mode
+    const authMode = gw.authMode ?? gw.auth;
+    if (authMode === "legacy" || authMode === "none") {
+      findings.push(
+        createFinding({
+          id: "GW-001",
+          checkName: this.name,
+          severity: "HIGH",
+          title: "Legacy or no authentication",
+          description: `Gateway uses "${String(authMode)}" authentication mode`,
+          remediation: "Configure device-key or mTLS authentication",
+          location: "gateway.yaml:authMode",
+          owaspRef: ["ASI07"],
+        }),
+      );
+    }
+
+    // GW-002: Wildcard bind without TLS
+    const bind = gw.bind ?? gw.host ?? gw.listen;
+    const tls = gw.tls ?? gw.ssl;
+    if (typeof bind === "string" && bind.includes("0.0.0.0") && !tls) {
+      findings.push(
+        createFinding({
+          id: "GW-002",
+          checkName: this.name,
+          severity: "CRITICAL",
+          title: "Wildcard bind without TLS",
+          description: "Gateway binds to 0.0.0.0 without TLS enabled",
+          remediation: "Enable TLS or bind to a specific interface (127.0.0.1)",
+          location: "gateway.yaml:bind",
+          owaspRef: ["ASI05", "ASI07"],
+        }),
+      );
+    }
+
+    // GW-003: TOFU enabled
+    const tofu = gw.tofu ?? gw.trustOnFirstUse;
+    if (tofu === true) {
+      findings.push(
+        createFinding({
+          id: "GW-003",
+          checkName: this.name,
+          severity: "HIGH",
+          title: "Trust-On-First-Use enabled",
+          description: "Gateway allows TOFU device key registration",
+          remediation: "Pre-register device keys and disable TOFU in production",
+          location: "gateway.yaml:tofu",
+          owaspRef: ["ASI07"],
+        }),
+      );
+    }
+
+    // GW-004: Exposed API key in config
+    const apiKey = gw.apiKey ?? gw.api_key;
+    if (typeof apiKey === "string" && apiKey.length > 0 && !apiKey.startsWith("${")) {
+      findings.push(
+        createFinding({
+          id: "GW-004",
+          checkName: this.name,
+          severity: "CRITICAL",
+          title: "API key exposed in gateway config",
+          description: "Gateway config contains a hardcoded API key",
+          remediation: `Use environment variable interpolation: \${API_KEY}`,
+          location: "gateway.yaml:apiKey",
+          owaspRef: ["ASI05"],
+        }),
+      );
+    }
+
+    // GW-005: No rate limiting
+    const rateLimit = gw.rateLimit ?? gw.rateLimiting ?? gw.throttle;
+    if (!rateLimit) {
+      findings.push(
+        createFinding({
+          id: "GW-005",
+          checkName: this.name,
+          severity: "MEDIUM",
+          title: "No rate limiting configured",
+          description: "Gateway has no rate limiting configuration",
+          remediation: "Add rate limiting to prevent abuse",
+          location: "gateway.yaml",
+          owaspRef: ["ASI07"],
+        }),
+      );
+    }
+
+    const durationMs = Math.round(performance.now() - start);
+    return createCheckResult(this.name, findings, durationMs);
+  }
+}

--- a/packages/doctor/src/checks/index.ts
+++ b/packages/doctor/src/checks/index.ts
@@ -1,0 +1,32 @@
+import type { DoctorCheck } from "../types.js";
+import { BudgetLeakDetectionCheck } from "./budget-leak-detection.js";
+import { ChannelSecurityCheck } from "./channel-security.js";
+import { FilesystemPermissionsCheck } from "./filesystem-permissions.js";
+import { GatewayExposureCheck } from "./gateway-exposure.js";
+import { MultiTenantIsolationCheck } from "./multi-tenant-isolation.js";
+import { SecretsScanningCheck } from "./secrets-scanning.js";
+import { SkillCodeSafetyCheck } from "./skill-code-safety.js";
+
+export { generateAttackSurfaceSummary } from "./attack-surface-summary.js";
+export { BudgetLeakDetectionCheck } from "./budget-leak-detection.js";
+export { ChannelSecurityCheck } from "./channel-security.js";
+export { FilesystemPermissionsCheck } from "./filesystem-permissions.js";
+export { GatewayExposureCheck } from "./gateway-exposure.js";
+export { MultiTenantIsolationCheck } from "./multi-tenant-isolation.js";
+export { SecretsScanningCheck } from "./secrets-scanning.js";
+export { SkillCodeSafetyCheck } from "./skill-code-safety.js";
+
+/**
+ * Returns all built-in security check instances.
+ */
+export function getBuiltinChecks(): readonly DoctorCheck[] {
+  return [
+    new FilesystemPermissionsCheck(),
+    new ChannelSecurityCheck(),
+    new SecretsScanningCheck(),
+    new GatewayExposureCheck(),
+    new MultiTenantIsolationCheck(),
+    new BudgetLeakDetectionCheck(),
+    new SkillCodeSafetyCheck(),
+  ];
+}

--- a/packages/doctor/src/checks/multi-tenant-isolation.ts
+++ b/packages/doctor/src/checks/multi-tenant-isolation.ts
@@ -1,0 +1,118 @@
+import { createCheckResult, createErrorResult, createFinding } from "../finding-factory.js";
+import type {
+  DoctorCheck,
+  DoctorCheckContext,
+  DoctorCheckResult,
+  DoctorFinding,
+} from "../types.js";
+
+// ---------------------------------------------------------------------------
+// Multi-tenant isolation check
+// ---------------------------------------------------------------------------
+
+/**
+ * Scans Nexus ReBAC grants for multi-tenant isolation issues:
+ * cross-zone grants, wildcard permissions, and zone boundary violations.
+ */
+export class MultiTenantIsolationCheck implements DoctorCheck {
+  readonly name = "multi-tenant-isolation";
+  readonly requiresNexus = true;
+
+  async run(context: DoctorCheckContext): Promise<DoctorCheckResult> {
+    const start = performance.now();
+
+    if (!context.nexus) {
+      return createCheckResult(this.name, [], Math.round(performance.now() - start));
+    }
+
+    const findings: DoctorFinding[] = [];
+
+    try {
+      // Access the permissions resource via the Nexus client
+      const nexus = context.nexus as unknown as Record<string, unknown>;
+      const permissions = nexus.permissions as
+        | { listNamespaceTools?: (ns: string) => Promise<unknown[]> }
+        | undefined;
+
+      if (!permissions?.listNamespaceTools) {
+        const durationMs = Math.round(performance.now() - start);
+        return createCheckResult(this.name, findings, durationMs);
+      }
+
+      const grants = await permissions.listNamespaceTools("*");
+
+      if (Array.isArray(grants)) {
+        for (const grant of grants) {
+          if (!grant || typeof grant !== "object") continue;
+          const g = grant as Record<string, unknown>;
+
+          // MT-001: Cross-zone grant
+          const sourceZone = g.sourceZone ?? g.source_zone;
+          const targetZone = g.targetZone ?? g.target_zone;
+          if (
+            typeof sourceZone === "string" &&
+            typeof targetZone === "string" &&
+            sourceZone !== targetZone
+          ) {
+            findings.push(
+              createFinding({
+                id: "MT-001",
+                checkName: this.name,
+                severity: "CRITICAL",
+                title: "Cross-zone permission grant",
+                description: `Grant spans zones: ${sourceZone} → ${targetZone}`,
+                remediation: "Remove cross-zone grants or add explicit zone bridging policies",
+                location: `nexus:permissions:${String(g.id ?? "unknown")}`,
+                owaspRef: ["ASI03", "ASI07"],
+              }),
+            );
+          }
+
+          // MT-002: Wildcard permission
+          const permission = g.permission ?? g.action;
+          const resource = g.resource ?? g.tool;
+          if (
+            (typeof permission === "string" && permission === "*") ||
+            (typeof resource === "string" && resource === "*")
+          ) {
+            findings.push(
+              createFinding({
+                id: "MT-002",
+                checkName: this.name,
+                severity: "HIGH",
+                title: "Wildcard permission grant",
+                description: `Wildcard grant detected: permission=${String(permission)}, resource=${String(resource)}`,
+                remediation: "Replace wildcard grants with specific permissions",
+                location: `nexus:permissions:${String(g.id ?? "unknown")}`,
+                owaspRef: ["ASI03", "ASI07"],
+              }),
+            );
+          }
+
+          // MT-003: Zone boundary (no zone specified)
+          if (!sourceZone && !targetZone && !g.zone && !g.namespace) {
+            findings.push(
+              createFinding({
+                id: "MT-003",
+                checkName: this.name,
+                severity: "MEDIUM",
+                title: "Missing zone boundary",
+                description: "Permission grant has no zone or namespace boundary",
+                remediation: "Add explicit zone boundaries to all permission grants",
+                location: `nexus:permissions:${String(g.id ?? "unknown")}`,
+                owaspRef: ["ASI07"],
+              }),
+            );
+          }
+        }
+      }
+    } catch (err) {
+      const durationMs = Math.round(performance.now() - start);
+      const error = err instanceof Error ? err : new Error(String(err));
+      return createErrorResult(this.name, error, durationMs);
+    }
+
+    const durationMs = Math.round(performance.now() - start);
+    return createCheckResult(this.name, findings, durationMs);
+  }
+}

--- a/packages/doctor/src/checks/secrets-scanning.ts
+++ b/packages/doctor/src/checks/secrets-scanning.ts
@@ -1,0 +1,229 @@
+import type { Dirent } from "node:fs";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { createCheckResult, createFinding } from "../finding-factory.js";
+import type {
+  DoctorCheck,
+  DoctorCheckContext,
+  DoctorCheckResult,
+  DoctorFinding,
+} from "../types.js";
+
+// ---------------------------------------------------------------------------
+// Secret patterns
+// ---------------------------------------------------------------------------
+
+const SECRET_PATTERNS: readonly {
+  readonly id: string;
+  readonly pattern: RegExp;
+  readonly severity: "CRITICAL" | "HIGH";
+  readonly title: string;
+  readonly description: string;
+}[] = [
+  {
+    id: "SEC-001",
+    pattern: /sk-[A-Za-z0-9]{20,}/,
+    severity: "CRITICAL",
+    title: "OpenAI API key detected",
+    description: "Found what appears to be an OpenAI API key",
+  },
+  {
+    id: "SEC-001",
+    pattern: /AKIA[0-9A-Z]{16}/,
+    severity: "CRITICAL",
+    title: "AWS access key detected",
+    description: "Found what appears to be an AWS access key ID",
+  },
+  {
+    id: "SEC-001",
+    pattern: /ghp_[A-Za-z0-9]{36}/,
+    severity: "CRITICAL",
+    title: "GitHub personal access token detected",
+    description: "Found what appears to be a GitHub personal access token",
+  },
+  {
+    id: "SEC-003",
+    pattern: /(?:password|passwd|pwd)["']?\s*[:=]\s*["'][^"']{4,}["']/i,
+    severity: "CRITICAL",
+    title: "Hardcoded password detected",
+    description: "Found what appears to be a hardcoded password",
+  },
+  {
+    id: "SEC-004",
+    pattern: /-----BEGIN (?:RSA |EC |DSA )?PRIVATE KEY-----/,
+    severity: "CRITICAL",
+    title: "Private key detected",
+    description: "Found what appears to be a private key",
+  },
+  {
+    id: "SEC-001",
+    pattern: /(?:api[_-]?key|apikey|secret[_-]?key)\s*[:=]\s*["'][A-Za-z0-9+/=]{16,}["']/i,
+    severity: "CRITICAL",
+    title: "Generic API key detected",
+    description: "Found what appears to be a hardcoded API key or secret",
+  },
+];
+
+const SCAN_EXTENSIONS = new Set([".ts", ".js", ".yaml", ".yml", ".json", ".env"]);
+const IGNORE_DIRS = new Set(["node_modules", "dist", ".git", "coverage", "__tests__", "test"]);
+const MAX_FILE_SIZE = 1_048_576; // 1MB
+
+// ---------------------------------------------------------------------------
+// Secrets scanning check
+// ---------------------------------------------------------------------------
+
+/**
+ * Scans workspace files for hardcoded secrets, API keys, and credentials.
+ */
+export class SecretsScanningCheck implements DoctorCheck {
+  readonly name = "secrets-scanning";
+  readonly requiresNexus = false;
+
+  async run(context: DoctorCheckContext): Promise<DoctorCheckResult> {
+    const start = performance.now();
+    const findings: DoctorFinding[] = [];
+
+    // Check .env in .gitignore
+    await this.checkGitignore(context.workspace, findings);
+
+    // Scan files for secrets
+    const files = await this.findFiles(context.workspace);
+    for (const filePath of files) {
+      await this.scanFile(filePath, context.workspace, findings);
+    }
+
+    const durationMs = Math.round(performance.now() - start);
+    return createCheckResult(this.name, findings, durationMs);
+  }
+
+  private async checkGitignore(workspace: string, findings: DoctorFinding[]): Promise<void> {
+    const gitignorePath = path.join(workspace, ".gitignore");
+    const envPath = path.join(workspace, ".env");
+
+    let envExists: boolean;
+    try {
+      await fs.access(envPath);
+      envExists = true;
+    } catch {
+      envExists = false;
+    }
+
+    if (!envExists) return;
+
+    let gitignoreContent: string;
+    try {
+      gitignoreContent = await fs.readFile(gitignorePath, "utf-8");
+    } catch {
+      findings.push(
+        createFinding({
+          id: "SEC-002",
+          checkName: this.name,
+          severity: "HIGH",
+          title: ".env file not in .gitignore",
+          description: ".env file exists but .gitignore is missing or unreadable",
+          remediation: "Add .env to .gitignore to prevent accidental commits",
+          location: ".gitignore",
+          owaspRef: ["ASI03"],
+        }),
+      );
+      return;
+    }
+
+    const lines = gitignoreContent.split("\n").map((l) => l.trim());
+    const hasEnvPattern = lines.some(
+      (l) => l === ".env" || l === ".env*" || l === "*.env" || l === ".env.*",
+    );
+
+    if (!hasEnvPattern) {
+      findings.push(
+        createFinding({
+          id: "SEC-002",
+          checkName: this.name,
+          severity: "HIGH",
+          title: ".env file not in .gitignore",
+          description: ".env file exists but is not excluded by .gitignore",
+          remediation: "Add .env to .gitignore to prevent accidental commits",
+          location: ".gitignore",
+          owaspRef: ["ASI03"],
+        }),
+      );
+    }
+  }
+
+  private async scanFile(
+    filePath: string,
+    workspace: string,
+    findings: DoctorFinding[],
+  ): Promise<void> {
+    let stat: Awaited<ReturnType<typeof fs.stat>>;
+    try {
+      stat = await fs.stat(filePath);
+    } catch {
+      return;
+    }
+
+    if (stat.size > MAX_FILE_SIZE) return;
+
+    let content: string;
+    try {
+      content = await fs.readFile(filePath, "utf-8");
+    } catch {
+      return;
+    }
+
+    const relative = path.relative(workspace, filePath);
+
+    for (const pattern of SECRET_PATTERNS) {
+      if (pattern.pattern.test(content)) {
+        findings.push(
+          createFinding({
+            id: pattern.id,
+            checkName: this.name,
+            severity: pattern.severity,
+            title: pattern.title,
+            description: `${pattern.description} in ${relative}`,
+            remediation: "Move secrets to environment variables or a secret manager",
+            location: relative,
+            owaspRef: ["ASI03"],
+          }),
+        );
+      }
+    }
+  }
+
+  private async findFiles(dir: string): Promise<string[]> {
+    const results: string[] = [];
+    await this.walkDir(dir, results, 0);
+    return results;
+  }
+
+  private async walkDir(dir: string, results: string[], depth: number): Promise<void> {
+    if (depth > 5) return;
+
+    let entries: Dirent[];
+    try {
+      entries = (await fs.readdir(dir, { withFileTypes: true })) as Dirent[];
+    } catch {
+      return;
+    }
+
+    for (const entry of entries) {
+      if (IGNORE_DIRS.has(entry.name)) continue;
+
+      const fullPath = path.join(dir, entry.name);
+
+      if (entry.isDirectory()) {
+        await this.walkDir(fullPath, results, depth + 1);
+        continue;
+      }
+
+      if (entry.isFile()) {
+        const ext = path.extname(entry.name);
+        const isEnvFile = entry.name.startsWith(".env");
+        if (SCAN_EXTENSIONS.has(ext) || isEnvFile) {
+          results.push(fullPath);
+        }
+      }
+    }
+  }
+}

--- a/packages/doctor/src/checks/skill-code-safety.ts
+++ b/packages/doctor/src/checks/skill-code-safety.ts
@@ -1,0 +1,232 @@
+import type { Dirent } from "node:fs";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { createCheckResult, createFinding } from "../finding-factory.js";
+import type {
+  DoctorCheck,
+  DoctorCheckContext,
+  DoctorCheckResult,
+  DoctorFinding,
+} from "../types.js";
+
+// ---------------------------------------------------------------------------
+// Dangerous code patterns
+// ---------------------------------------------------------------------------
+
+const DANGEROUS_PATTERNS: readonly {
+  readonly id: string;
+  readonly pattern: RegExp;
+  readonly severity: "CRITICAL" | "HIGH" | "MEDIUM";
+  readonly title: string;
+  readonly owaspRef: readonly ("ASI02" | "ASI04")[];
+}[] = [
+  {
+    id: "SK-001",
+    pattern: /\beval\s*\(/,
+    severity: "CRITICAL",
+    title: "eval() usage detected",
+    owaspRef: ["ASI02"],
+  },
+  {
+    id: "SK-001",
+    pattern: /\bnew\s+Function\s*\(/,
+    severity: "CRITICAL",
+    title: "new Function() usage detected",
+    owaspRef: ["ASI02"],
+  },
+  {
+    id: "SK-002",
+    pattern: /\bchild_process\b/,
+    severity: "CRITICAL",
+    title: "child_process usage detected",
+    owaspRef: ["ASI02", "ASI04"],
+  },
+  {
+    id: "SK-002",
+    pattern: /\bexec\s*\(/,
+    severity: "CRITICAL",
+    title: "exec() usage detected",
+    owaspRef: ["ASI02"],
+  },
+  {
+    id: "SK-002",
+    pattern: /\bspawn\s*\(/,
+    severity: "CRITICAL",
+    title: "spawn() usage detected",
+    owaspRef: ["ASI02"],
+  },
+  {
+    id: "SK-003",
+    pattern: /\bfs\.(?:rm|rmdir|unlink|writeFile)\s*\(/,
+    severity: "HIGH",
+    title: "Destructive filesystem operation",
+    owaspRef: ["ASI02"],
+  },
+  {
+    id: "SK-004",
+    pattern: /\bprocess\.env\b/,
+    severity: "MEDIUM",
+    title: "process.env access detected",
+    owaspRef: ["ASI04"],
+  },
+  {
+    id: "SK-005",
+    pattern: /\bimport\s*\(/,
+    severity: "HIGH",
+    title: "Dynamic import() detected",
+    owaspRef: ["ASI04"],
+  },
+];
+
+const SKILL_GLOBS = ["SKILL.md"];
+const CODE_EXTENSIONS = new Set([".ts", ".js"]);
+const IGNORE_DIRS = new Set(["node_modules", "dist", ".git", "coverage"]);
+
+// ---------------------------------------------------------------------------
+// Skill code safety check
+// ---------------------------------------------------------------------------
+
+/**
+ * Scans skill definitions and code for dangerous patterns:
+ * eval, child_process, exec, spawn, dynamic import, env access.
+ */
+export class SkillCodeSafetyCheck implements DoctorCheck {
+  readonly name = "skill-code-safety";
+  readonly requiresNexus = false;
+
+  async run(context: DoctorCheckContext): Promise<DoctorCheckResult> {
+    const start = performance.now();
+    const findings: DoctorFinding[] = [];
+
+    // Scan SKILL.md files for code fences
+    const skillFiles = await this.findFiles(context.workspace, SKILL_GLOBS, true);
+    for (const filePath of skillFiles) {
+      const codeBlocks = await this.extractCodeFromMarkdown(filePath);
+      const relative = path.relative(context.workspace, filePath);
+      for (const code of codeBlocks) {
+        this.scanCode(code, relative, findings);
+      }
+    }
+
+    // Scan skills/**/*.{ts,js} files
+    const skillsDir = path.join(context.workspace, "skills");
+    const codeFiles = await this.findCodeFiles(skillsDir);
+    for (const filePath of codeFiles) {
+      let content: string;
+      try {
+        content = await fs.readFile(filePath, "utf-8");
+      } catch {
+        continue;
+      }
+      const relative = path.relative(context.workspace, filePath);
+      this.scanCode(content, relative, findings);
+    }
+
+    const durationMs = Math.round(performance.now() - start);
+    return createCheckResult(this.name, findings, durationMs);
+  }
+
+  private scanCode(content: string, location: string, findings: DoctorFinding[]): void {
+    for (const pattern of DANGEROUS_PATTERNS) {
+      if (pattern.pattern.test(content)) {
+        findings.push(
+          createFinding({
+            id: pattern.id,
+            checkName: this.name,
+            severity: pattern.severity,
+            title: pattern.title,
+            description: `${pattern.title} in ${location}`,
+            remediation: "Remove or sandbox dangerous code patterns in skills",
+            location,
+            owaspRef: pattern.owaspRef,
+          }),
+        );
+      }
+    }
+  }
+
+  private async extractCodeFromMarkdown(filePath: string): Promise<string[]> {
+    let content: string;
+    try {
+      content = await fs.readFile(filePath, "utf-8");
+    } catch {
+      return [];
+    }
+
+    const codeBlocks: string[] = [];
+    const fenceRegex = /```(?:typescript|javascript|ts|js)?\n([\s\S]*?)```/g;
+    for (const match of content.matchAll(fenceRegex)) {
+      const block = match[1];
+      if (block) {
+        codeBlocks.push(block);
+      }
+    }
+    return codeBlocks;
+  }
+
+  private async findFiles(
+    dir: string,
+    names: readonly string[],
+    recurse: boolean,
+  ): Promise<string[]> {
+    const results: string[] = [];
+    await this.walkForNames(dir, new Set(names), results, recurse ? 5 : 0, 0);
+    return results;
+  }
+
+  private async walkForNames(
+    dir: string,
+    names: ReadonlySet<string>,
+    results: string[],
+    maxDepth: number,
+    depth: number,
+  ): Promise<void> {
+    if (depth > maxDepth) return;
+
+    let entries: Dirent[];
+    try {
+      entries = (await fs.readdir(dir, { withFileTypes: true })) as Dirent[];
+    } catch {
+      return;
+    }
+
+    for (const entry of entries) {
+      if (IGNORE_DIRS.has(entry.name)) continue;
+      const fullPath = path.join(dir, entry.name);
+
+      if (entry.isDirectory()) {
+        await this.walkForNames(fullPath, names, results, maxDepth, depth + 1);
+      } else if (entry.isFile() && names.has(entry.name)) {
+        results.push(fullPath);
+      }
+    }
+  }
+
+  private async findCodeFiles(dir: string): Promise<string[]> {
+    const results: string[] = [];
+    await this.walkForExtensions(dir, results, 0);
+    return results;
+  }
+
+  private async walkForExtensions(dir: string, results: string[], depth: number): Promise<void> {
+    if (depth > 5) return;
+
+    let entries: Dirent[];
+    try {
+      entries = (await fs.readdir(dir, { withFileTypes: true })) as Dirent[];
+    } catch {
+      return;
+    }
+
+    for (const entry of entries) {
+      if (IGNORE_DIRS.has(entry.name)) continue;
+      const fullPath = path.join(dir, entry.name);
+
+      if (entry.isDirectory()) {
+        await this.walkForExtensions(fullPath, results, depth + 1);
+      } else if (entry.isFile() && CODE_EXTENSIONS.has(path.extname(entry.name))) {
+        results.push(fullPath);
+      }
+    }
+  }
+}

--- a/packages/doctor/src/cli.ts
+++ b/packages/doctor/src/cli.ts
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+
+import { generateAttackSurfaceSummary } from "./checks/attack-surface-summary.js";
+import { getBuiltinChecks } from "./checks/index.js";
+import { runAudit } from "./engine.js";
+import { JsonReporter } from "./reporters/json-reporter.js";
+import { TerminalReporter } from "./reporters/terminal-reporter.js";
+import type { DoctorConfig, DoctorReport } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Argument parsing (minimal, no external CLI lib)
+// ---------------------------------------------------------------------------
+
+interface CliArgs {
+  readonly workspace: string;
+  readonly format: "terminal" | "json";
+  readonly verbose: boolean;
+  readonly disable: readonly string[];
+  readonly nexusUrl?: string;
+  readonly nexusApiKey?: string;
+}
+
+function parseArgs(argv: readonly string[]): CliArgs {
+  let workspace = ".";
+  let format: "terminal" | "json" = "terminal";
+  let verbose = false;
+  const disable: string[] = [];
+  let nexusUrl: string | undefined;
+  let nexusApiKey: string | undefined;
+
+  for (let i = 2; i < argv.length; i++) {
+    const arg = argv[i];
+    const next = argv[i + 1];
+
+    switch (arg) {
+      case "--workspace":
+        if (next) {
+          workspace = next;
+          i++;
+        }
+        break;
+      case "--format":
+        if (next === "json" || next === "terminal") {
+          format = next;
+          i++;
+        }
+        break;
+      case "--verbose":
+        verbose = true;
+        break;
+      case "--disable":
+        if (next) {
+          disable.push(...next.split(","));
+          i++;
+        }
+        break;
+      case "--nexus-url":
+        if (next) {
+          nexusUrl = next;
+          i++;
+        }
+        break;
+      case "--nexus-api-key":
+        if (next) {
+          nexusApiKey = next;
+          i++;
+        }
+        break;
+      case "--help":
+        printHelp();
+        process.exit(0);
+        break;
+    }
+  }
+
+  return {
+    workspace,
+    format,
+    verbose,
+    disable,
+    ...(nexusUrl ? { nexusUrl } : {}),
+    ...(nexusApiKey ? { nexusApiKey } : {}),
+  };
+}
+
+function printHelp(): void {
+  const help = `
+templar-doctor — Security scanner for Templar deployments
+
+Usage: templar-doctor [options]
+
+Options:
+  --workspace <path>       Workspace to scan (default: .)
+  --format terminal|json   Output format (default: terminal)
+  --verbose                Show detailed timing and check info
+  --disable <check1,check2>  Disable specific checks
+  --nexus-url <url>        Nexus API URL (enables multi-tenant checks)
+  --nexus-api-key <key>    Nexus API key
+  --help                   Show this help message
+`;
+  console.log(help);
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv);
+
+  // Build Nexus client if URL provided
+  let nexus: DoctorConfig["nexus"];
+  if (args.nexusUrl) {
+    try {
+      const { NexusClient } = await import("@nexus/sdk");
+      nexus = new NexusClient({
+        baseUrl: args.nexusUrl,
+        ...(args.nexusApiKey ? { apiKey: args.nexusApiKey } : {}),
+      });
+    } catch {
+      if (args.verbose) {
+        console.error("Warning: @nexus/sdk not available, skipping Nexus checks");
+      }
+    }
+  }
+
+  const checks = getBuiltinChecks();
+
+  const config: DoctorConfig = {
+    workspace: args.workspace,
+    ...(nexus ? { nexus } : {}),
+    ...(args.disable.length > 0 ? { disabledChecks: args.disable } : {}),
+    ...(args.verbose ? { verbose: true } : {}),
+  };
+
+  const report: DoctorReport = await runAudit(checks, config);
+
+  // Generate attack surface summary and merge
+  const summaryFindings = generateAttackSurfaceSummary(report.checkResults);
+  const finalReport: DoctorReport =
+    summaryFindings.length > 0
+      ? {
+          ...report,
+          checkResults: [
+            ...report.checkResults,
+            {
+              checkName: "attack-surface-summary",
+              status: "findings",
+              durationMs: 0,
+              findings: summaryFindings,
+            },
+          ],
+        }
+      : report;
+
+  // Output
+  const reporter = args.format === "json" ? new JsonReporter() : new TerminalReporter();
+  console.log(reporter.report(finalReport));
+
+  process.exit(report.exitCode);
+}
+
+main().catch((err) => {
+  console.error("Fatal:", err instanceof Error ? err.message : String(err));
+  process.exit(1);
+});

--- a/packages/doctor/src/engine.ts
+++ b/packages/doctor/src/engine.ts
@@ -1,0 +1,207 @@
+import { DoctorScanTimeoutError } from "@templar/errors";
+import { createErrorResult, createSkippedResult } from "./finding-factory.js";
+import type {
+  DoctorCheck,
+  DoctorCheckContext,
+  DoctorCheckResult,
+  DoctorConfig,
+  DoctorReport,
+  DoctorSummary,
+} from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const DEFAULT_CONCURRENCY = 4;
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+// ---------------------------------------------------------------------------
+// Semaphore-based concurrency limiter
+// ---------------------------------------------------------------------------
+
+async function runWithConcurrency<T>(
+  tasks: readonly (() => Promise<T>)[],
+  concurrency: number,
+): Promise<T[]> {
+  const results: T[] = [];
+  let index = 0;
+
+  async function worker(): Promise<void> {
+    while (index < tasks.length) {
+      const current = index;
+      index++;
+      const task = tasks[current];
+      if (task) {
+        results[current] = await task();
+      }
+    }
+  }
+
+  const workers: Promise<void>[] = [];
+  for (let i = 0; i < Math.min(concurrency, tasks.length); i++) {
+    workers.push(worker());
+  }
+  await Promise.allSettled(workers);
+
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// Summary computation
+// ---------------------------------------------------------------------------
+
+function computeSummary(results: readonly DoctorCheckResult[]): DoctorSummary {
+  let critical = 0;
+  let high = 0;
+  let medium = 0;
+  let low = 0;
+  let checksRun = 0;
+  let checksSkipped = 0;
+  let checksFailed = 0;
+
+  for (const result of results) {
+    if (result.status === "skipped") {
+      checksSkipped++;
+    } else if (result.status === "error") {
+      checksFailed++;
+      checksRun++;
+    } else {
+      checksRun++;
+    }
+
+    for (const finding of result.findings) {
+      switch (finding.severity) {
+        case "CRITICAL":
+          critical++;
+          break;
+        case "HIGH":
+          high++;
+          break;
+        case "MEDIUM":
+          medium++;
+          break;
+        case "LOW":
+          low++;
+          break;
+      }
+    }
+  }
+
+  return {
+    total: critical + high + medium + low,
+    critical,
+    high,
+    medium,
+    low,
+    checksRun,
+    checksSkipped,
+    checksFailed,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Exit code computation
+// ---------------------------------------------------------------------------
+
+function computeExitCode(summary: DoctorSummary): number {
+  if (summary.critical > 0) return 2;
+  if (summary.high > 0) return 1;
+  return 0;
+}
+
+// ---------------------------------------------------------------------------
+// Single check executor with isolation
+// ---------------------------------------------------------------------------
+
+async function executeCheck(
+  check: DoctorCheck,
+  context: DoctorCheckContext,
+): Promise<DoctorCheckResult> {
+  // Auto-skip Nexus checks when no client available
+  if (check.requiresNexus && !context.nexus) {
+    return createSkippedResult(check.name, "Nexus client not available");
+  }
+
+  const start = performance.now();
+  try {
+    return await check.run(context);
+  } catch (err) {
+    const durationMs = Math.round(performance.now() - start);
+    const error = err instanceof Error ? err : new Error(String(err));
+    return createErrorResult(check.name, error, durationMs);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Audit engine
+// ---------------------------------------------------------------------------
+
+/**
+ * Runs all security checks and produces an immutable `DoctorReport`.
+ *
+ * Checks run in parallel with a configurable concurrency limit (default: 4).
+ * Each check is isolated — failures produce error results, not exceptions.
+ * Nexus-dependent checks auto-skip when no `NexusClient` is provided.
+ */
+export async function runAudit(
+  checks: readonly DoctorCheck[],
+  config: DoctorConfig,
+): Promise<DoctorReport> {
+  const startedAt = new Date().toISOString();
+  const startTime = performance.now();
+
+  const concurrency = config.concurrency ?? DEFAULT_CONCURRENCY;
+  const timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  // Filter disabled checks
+  const disabledSet = new Set(config.disabledChecks ?? []);
+  const activeChecks = checks.filter((c) => !disabledSet.has(c.name));
+
+  // Build context
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+
+  const context: DoctorCheckContext = {
+    workspace: config.workspace,
+    ...(config.nexus ? { nexus: config.nexus } : {}),
+    abortSignal: controller.signal,
+    ...(config.verbose ? { verbose: config.verbose } : {}),
+  };
+
+  try {
+    // Build task list
+    const tasks = activeChecks.map((check) => () => executeCheck(check, context));
+
+    // Include skipped results for disabled checks
+    const disabledResults: DoctorCheckResult[] = checks
+      .filter((c) => disabledSet.has(c.name))
+      .map((c) => createSkippedResult(c.name, "Disabled by configuration"));
+
+    // Run with concurrency
+    let activeResults: DoctorCheckResult[];
+    try {
+      activeResults = await runWithConcurrency(tasks, concurrency);
+    } catch {
+      throw new DoctorScanTimeoutError(timeoutMs);
+    }
+
+    const checkResults = [...activeResults, ...disabledResults];
+    const summary = computeSummary(checkResults);
+    const exitCode = computeExitCode(summary);
+
+    const completedAt = new Date().toISOString();
+    const durationMs = Math.round(performance.now() - startTime);
+
+    return {
+      startedAt,
+      completedAt,
+      durationMs,
+      checkResults,
+      summary,
+      exitCode,
+    };
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}

--- a/packages/doctor/src/finding-factory.ts
+++ b/packages/doctor/src/finding-factory.ts
@@ -1,0 +1,85 @@
+import type { DoctorCheckResult, DoctorFinding, OwaspAgenticRef, Severity } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Finding factory
+// ---------------------------------------------------------------------------
+
+interface CreateFindingParams {
+  readonly id: string;
+  readonly checkName: string;
+  readonly severity: Severity;
+  readonly title: string;
+  readonly description: string;
+  readonly remediation: string;
+  readonly location: string;
+  readonly owaspRef: readonly OwaspAgenticRef[];
+  readonly metadata?: Readonly<Record<string, string>>;
+}
+
+/**
+ * Creates an immutable `DoctorFinding` from the given parameters.
+ * Uses spread for optional `metadata` to comply with `exactOptionalPropertyTypes`.
+ */
+export function createFinding(params: CreateFindingParams): DoctorFinding {
+  return {
+    id: params.id,
+    checkName: params.checkName,
+    severity: params.severity,
+    title: params.title,
+    description: params.description,
+    remediation: params.remediation,
+    location: params.location,
+    owaspRef: params.owaspRef,
+    ...(params.metadata ? { metadata: params.metadata } : {}),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Check result factories
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates a check result with findings (or passed if no findings).
+ */
+export function createCheckResult(
+  checkName: string,
+  findings: readonly DoctorFinding[],
+  durationMs: number,
+): DoctorCheckResult {
+  return {
+    checkName,
+    status: findings.length > 0 ? "findings" : "passed",
+    durationMs,
+    findings,
+  };
+}
+
+/**
+ * Creates a skipped check result.
+ */
+export function createSkippedResult(checkName: string, reason: string): DoctorCheckResult {
+  return {
+    checkName,
+    status: "skipped",
+    durationMs: 0,
+    findings: [],
+    skipReason: reason,
+  };
+}
+
+/**
+ * Creates an error check result from a failed check execution.
+ */
+export function createErrorResult(
+  checkName: string,
+  error: Error,
+  durationMs: number,
+): DoctorCheckResult {
+  return {
+    checkName,
+    status: "error",
+    durationMs,
+    findings: [],
+    error,
+  };
+}

--- a/packages/doctor/src/index.ts
+++ b/packages/doctor/src/index.ts
@@ -1,0 +1,49 @@
+// ============================================================================
+// @templar/doctor — Security Scanner + Multi-Tenant Audits
+// ============================================================================
+
+// Built-in checks
+export {
+  BudgetLeakDetectionCheck,
+  ChannelSecurityCheck,
+  FilesystemPermissionsCheck,
+  GatewayExposureCheck,
+  generateAttackSurfaceSummary,
+  getBuiltinChecks,
+  MultiTenantIsolationCheck,
+  SecretsScanningCheck,
+  SkillCodeSafetyCheck,
+} from "./checks/index.js";
+
+// Engine
+export { runAudit } from "./engine.js";
+
+// Finding factory
+export {
+  createCheckResult,
+  createErrorResult,
+  createFinding,
+  createSkippedResult,
+} from "./finding-factory.js";
+// Middleware
+export { DoctorMiddleware } from "./middleware.js";
+export { JsonReporter } from "./reporters/json-reporter.js";
+export { TerminalReporter } from "./reporters/terminal-reporter.js";
+// Reporters
+export type { DoctorReporter } from "./reporters/types.js";
+// Types
+export type {
+  DoctorCheck,
+  DoctorCheckContext,
+  DoctorCheckResult,
+  DoctorConfig,
+  DoctorFinding,
+  DoctorReport,
+  DoctorSummary,
+  OwaspAgenticRef,
+  Severity,
+} from "./types.js";
+
+// Package metadata
+export const PACKAGE_NAME = "@templar/doctor";
+export const PACKAGE_VERSION = "0.1.0";

--- a/packages/doctor/src/middleware.ts
+++ b/packages/doctor/src/middleware.ts
@@ -1,0 +1,52 @@
+import type { TemplarMiddleware } from "@templar/core";
+import { DoctorCheckFailedError, DoctorConfigurationError } from "@templar/errors";
+import { getBuiltinChecks } from "./checks/index.js";
+import { runAudit } from "./engine.js";
+import type { DoctorCheck, DoctorConfig, DoctorReport } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Doctor middleware
+// ---------------------------------------------------------------------------
+
+/**
+ * Templar middleware that runs a security audit on session start.
+ * Throws `DoctorCheckFailedError` if CRITICAL findings are present.
+ */
+export class DoctorMiddleware implements TemplarMiddleware {
+  readonly name = "templar:doctor";
+  private readonly config: DoctorConfig;
+  private readonly checks: readonly DoctorCheck[];
+  private report: DoctorReport | null = null;
+
+  constructor(config: DoctorConfig) {
+    if (!config.workspace) {
+      throw new DoctorConfigurationError("workspace is required");
+    }
+
+    const builtinChecks = getBuiltinChecks();
+    this.checks = config.checks ? [...builtinChecks, ...config.checks] : builtinChecks;
+    this.config = config;
+  }
+
+  async onSessionStart(): Promise<void> {
+    this.report = await runAudit(this.checks, this.config);
+
+    if (this.report.summary.critical > 0) {
+      throw new DoctorCheckFailedError(
+        "templar:doctor",
+        `Security audit found ${this.report.summary.critical} CRITICAL finding(s)`,
+      );
+    }
+  }
+
+  async onSessionEnd(): Promise<void> {
+    // no-op
+  }
+
+  /**
+   * Returns the cached audit report, or null if not yet run.
+   */
+  getReport(): DoctorReport | null {
+    return this.report;
+  }
+}

--- a/packages/doctor/src/reporters/json-reporter.ts
+++ b/packages/doctor/src/reporters/json-reporter.ts
@@ -1,0 +1,25 @@
+import type { DoctorReport } from "../types.js";
+import type { DoctorReporter } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// JSON reporter
+// ---------------------------------------------------------------------------
+
+/**
+ * Renders the full report as formatted JSON.
+ */
+export class JsonReporter implements DoctorReporter {
+  readonly name = "json";
+
+  report(result: DoctorReport): string {
+    // Serialize with error objects converted to plain objects
+    const serializable = {
+      ...result,
+      checkResults: result.checkResults.map((cr) => ({
+        ...cr,
+        ...(cr.error ? { error: { message: cr.error.message, name: cr.error.name } } : {}),
+      })),
+    };
+    return JSON.stringify(serializable, null, 2);
+  }
+}

--- a/packages/doctor/src/reporters/terminal-reporter.ts
+++ b/packages/doctor/src/reporters/terminal-reporter.ts
@@ -1,0 +1,99 @@
+import type { DoctorReport, Severity } from "../types.js";
+import type { DoctorReporter } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// ANSI helpers (no chalk dependency)
+// ---------------------------------------------------------------------------
+
+const RESET = "\x1b[0m";
+const BOLD = "\x1b[1m";
+const DIM = "\x1b[2m";
+const RED = "\x1b[31m";
+const YELLOW = "\x1b[33m";
+const GREEN = "\x1b[32m";
+const CYAN = "\x1b[36m";
+const MAGENTA = "\x1b[35m";
+
+const SEVERITY_COLORS: Record<Severity, string> = {
+  CRITICAL: RED,
+  HIGH: MAGENTA,
+  MEDIUM: YELLOW,
+  LOW: CYAN,
+};
+
+const STATUS_ICONS: Record<string, string> = {
+  passed: `${GREEN}✓${RESET}`,
+  findings: `${RED}✗${RESET}`,
+  skipped: `${DIM}⊘${RESET}`,
+  error: `${RED}!${RESET}`,
+};
+
+// ---------------------------------------------------------------------------
+// Terminal reporter
+// ---------------------------------------------------------------------------
+
+/**
+ * Renders a human-readable ANSI-colored terminal report.
+ */
+export class TerminalReporter implements DoctorReporter {
+  readonly name = "terminal";
+
+  report(result: DoctorReport): string {
+    const lines: string[] = [];
+
+    lines.push("");
+    lines.push(`${BOLD}Templar Doctor — Security Audit Report${RESET}`);
+    lines.push(`${"─".repeat(50)}`);
+    lines.push("");
+
+    // Check results
+    for (const check of result.checkResults) {
+      const icon = STATUS_ICONS[check.status] ?? "?";
+      const timing = check.durationMs > 0 ? `${DIM}(${check.durationMs}ms)${RESET}` : "";
+      lines.push(`  ${icon} ${check.checkName} ${timing}`);
+
+      if (check.status === "skipped" && check.skipReason) {
+        lines.push(`    ${DIM}Skipped: ${check.skipReason}${RESET}`);
+      }
+
+      if (check.status === "error" && check.error) {
+        lines.push(`    ${RED}Error: ${check.error.message}${RESET}`);
+      }
+
+      if (check.findings.length > 0) {
+        for (const finding of check.findings) {
+          const color = SEVERITY_COLORS[finding.severity];
+          lines.push(`    ${color}[${finding.severity}]${RESET} ${finding.title}`);
+          lines.push(`      ${DIM}${finding.description}${RESET}`);
+          lines.push(`      ${DIM}Location: ${finding.location}${RESET}`);
+          lines.push(`      ${DIM}Remediation: ${finding.remediation}${RESET}`);
+        }
+      }
+    }
+
+    lines.push("");
+    lines.push(`${"─".repeat(50)}`);
+
+    // Summary
+    const s = result.summary;
+    const summaryParts: string[] = [];
+    if (s.critical > 0) summaryParts.push(`${RED}${s.critical} CRITICAL${RESET}`);
+    if (s.high > 0) summaryParts.push(`${MAGENTA}${s.high} HIGH${RESET}`);
+    if (s.medium > 0) summaryParts.push(`${YELLOW}${s.medium} MEDIUM${RESET}`);
+    if (s.low > 0) summaryParts.push(`${CYAN}${s.low} LOW${RESET}`);
+
+    if (summaryParts.length === 0) {
+      lines.push(`  ${GREEN}${BOLD}No findings — all checks passed!${RESET}`);
+    } else {
+      lines.push(`  ${BOLD}Findings:${RESET} ${summaryParts.join(", ")}`);
+    }
+
+    lines.push(
+      `  ${DIM}Checks: ${s.checksRun} run, ${s.checksSkipped} skipped, ${s.checksFailed} failed${RESET}`,
+    );
+    lines.push(`  ${DIM}Duration: ${result.durationMs}ms${RESET}`);
+    lines.push("");
+
+    return lines.join("\n");
+  }
+}

--- a/packages/doctor/src/reporters/types.ts
+++ b/packages/doctor/src/reporters/types.ts
@@ -1,0 +1,9 @@
+import type { DoctorReport } from "../types.js";
+
+/**
+ * Reporter interface for formatting doctor audit reports.
+ */
+export interface DoctorReporter {
+  readonly name: string;
+  report(result: DoctorReport): string;
+}

--- a/packages/doctor/src/types.ts
+++ b/packages/doctor/src/types.ts
@@ -1,0 +1,113 @@
+import type { NexusClient } from "@templar/core";
+
+// ---------------------------------------------------------------------------
+// Severity and OWASP Agentic references
+// ---------------------------------------------------------------------------
+
+export type Severity = "CRITICAL" | "HIGH" | "MEDIUM" | "LOW";
+
+/**
+ * OWASP Agentic Security Initiative Top 10 reference identifiers.
+ * @see https://owasp.org/www-project-agentic-security-initiative/
+ */
+export type OwaspAgenticRef =
+  | "ASI01"
+  | "ASI02"
+  | "ASI03"
+  | "ASI04"
+  | "ASI05"
+  | "ASI06"
+  | "ASI07"
+  | "ASI08"
+  | "ASI09"
+  | "ASI10";
+
+// ---------------------------------------------------------------------------
+// Finding — a single security issue discovered by a check
+// ---------------------------------------------------------------------------
+
+export interface DoctorFinding {
+  readonly id: string;
+  readonly checkName: string;
+  readonly severity: Severity;
+  readonly title: string;
+  readonly description: string;
+  readonly remediation: string;
+  readonly location: string;
+  readonly owaspRef: readonly OwaspAgenticRef[];
+  readonly metadata?: Readonly<Record<string, string>>;
+}
+
+// ---------------------------------------------------------------------------
+// Check result — outcome of running a single check
+// ---------------------------------------------------------------------------
+
+export interface DoctorCheckResult {
+  readonly checkName: string;
+  readonly status: "passed" | "findings" | "skipped" | "error";
+  readonly durationMs: number;
+  readonly findings: readonly DoctorFinding[];
+  readonly error?: Error;
+  readonly skipReason?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Check context — runtime context passed to each check
+// ---------------------------------------------------------------------------
+
+export interface DoctorCheckContext {
+  readonly workspace: string;
+  readonly nexus?: NexusClient;
+  readonly abortSignal?: AbortSignal;
+  readonly verbose?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Check interface — pluggable security check
+// ---------------------------------------------------------------------------
+
+export interface DoctorCheck {
+  readonly name: string;
+  readonly requiresNexus: boolean;
+  run(context: DoctorCheckContext): Promise<DoctorCheckResult>;
+}
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+export interface DoctorConfig {
+  readonly workspace: string;
+  readonly nexus?: NexusClient;
+  readonly checks?: readonly DoctorCheck[];
+  readonly disabledChecks?: readonly string[];
+  readonly concurrency?: number;
+  readonly timeoutMs?: number;
+  readonly verbose?: boolean;
+  readonly includeGlobs?: readonly string[];
+  readonly ignoreGlobs?: readonly string[];
+}
+
+// ---------------------------------------------------------------------------
+// Report — final audit output
+// ---------------------------------------------------------------------------
+
+export interface DoctorReport {
+  readonly startedAt: string;
+  readonly completedAt: string;
+  readonly durationMs: number;
+  readonly checkResults: readonly DoctorCheckResult[];
+  readonly summary: DoctorSummary;
+  readonly exitCode: number;
+}
+
+export interface DoctorSummary {
+  readonly total: number;
+  readonly critical: number;
+  readonly high: number;
+  readonly medium: number;
+  readonly low: number;
+  readonly checksRun: number;
+  readonly checksSkipped: number;
+  readonly checksFailed: number;
+}

--- a/packages/doctor/tsconfig.json
+++ b/packages/doctor/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": ["node"]
+  },
+  "include": ["src"],
+  "references": [{ "path": "../core" }, { "path": "../errors" }]
+}

--- a/packages/doctor/tsup.config.ts
+++ b/packages/doctor/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts", "src/cli.ts"],
+  format: ["esm"],
+  dts: { compilerOptions: { composite: false } },
+  clean: true,
+  treeshake: true,
+  target: "node22",
+});

--- a/packages/doctor/vitest.config.ts
+++ b/packages/doctor/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: "v8",
+      include: ["src/**/*.ts"],
+      exclude: ["src/**/__tests__/**", "src/**/index.ts", "src/types.ts", "src/cli.ts"],
+      thresholds: {
+        branches: 80,
+        functions: 80,
+        lines: 80,
+        statements: 80,
+      },
+    },
+  },
+});

--- a/packages/errors/src/catalog.ts
+++ b/packages/errors/src/catalog.ts
@@ -2003,6 +2003,46 @@ export const ERROR_CATALOG = {
   },
 
   // ============================================================================
+  // DOCTOR ERRORS — Security scanner and multi-tenant audits (#27)
+  // ============================================================================
+  DOCTOR_CONFIGURATION_INVALID: {
+    domain: "doctor",
+    httpStatus: 400,
+    grpcCode: "INVALID_ARGUMENT" as const,
+    baseType: "ValidationError" as const,
+    isExpected: true,
+    title: "Invalid doctor configuration",
+    description: "The doctor scan configuration is invalid",
+  },
+  DOCTOR_CHECK_FAILED: {
+    domain: "doctor",
+    httpStatus: 500,
+    grpcCode: "INTERNAL" as const,
+    baseType: "InternalError" as const,
+    isExpected: false,
+    title: "Doctor check failed",
+    description: "A doctor security check threw an unexpected error",
+  },
+  DOCTOR_NEXUS_UNAVAILABLE: {
+    domain: "doctor",
+    httpStatus: 503,
+    grpcCode: "UNAVAILABLE" as const,
+    baseType: "ExternalError" as const,
+    isExpected: false,
+    title: "Nexus unavailable for doctor",
+    description: "The Nexus API is unavailable for multi-tenant security checks",
+  },
+  DOCTOR_SCAN_TIMEOUT: {
+    domain: "doctor",
+    httpStatus: 504,
+    grpcCode: "DEADLINE_EXCEEDED" as const,
+    baseType: "TimeoutError" as const,
+    isExpected: false,
+    title: "Doctor scan timeout",
+    description: "The doctor security scan exceeded the configured timeout",
+  },
+
+  // ============================================================================
   // CODE MODE ERRORS — LLM-generated code execution via Monty sandbox (#111)
   // ============================================================================
   CODE_SYNTAX_ERROR: {

--- a/packages/errors/src/doctor.ts
+++ b/packages/errors/src/doctor.ts
@@ -1,0 +1,123 @@
+import { TemplarError } from "./base.js";
+import {
+  ERROR_CATALOG,
+  type ErrorDomain,
+  type GrpcStatusCode,
+  type HttpStatusCode,
+} from "./catalog.js";
+
+// ---------------------------------------------------------------------------
+// Base class for all doctor errors
+// ---------------------------------------------------------------------------
+
+/**
+ * Abstract base class for doctor errors.
+ *
+ * Enables generic catch: `if (e instanceof DoctorError)`
+ * while specific subclasses allow precise handling.
+ */
+export abstract class DoctorError extends TemplarError {}
+
+// ---------------------------------------------------------------------------
+// Doctor configuration invalid
+// ---------------------------------------------------------------------------
+
+/**
+ * Thrown when the doctor scan configuration is invalid.
+ */
+export class DoctorConfigurationError extends DoctorError {
+  readonly _tag = "ValidationError" as const;
+  readonly code = "DOCTOR_CONFIGURATION_INVALID" as const;
+  readonly httpStatus: HttpStatusCode;
+  readonly grpcCode: GrpcStatusCode;
+  readonly domain: ErrorDomain;
+  readonly isExpected: boolean;
+
+  constructor(message: string) {
+    super(`Invalid doctor configuration: ${message}`);
+    const entry = ERROR_CATALOG.DOCTOR_CONFIGURATION_INVALID;
+    this.httpStatus = entry.httpStatus as HttpStatusCode;
+    this.grpcCode = entry.grpcCode as GrpcStatusCode;
+    this.domain = entry.domain as ErrorDomain;
+    this.isExpected = entry.isExpected;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Doctor check failed
+// ---------------------------------------------------------------------------
+
+/**
+ * Thrown when a doctor security check throws an unexpected error.
+ */
+export class DoctorCheckFailedError extends DoctorError {
+  readonly _tag = "InternalError" as const;
+  readonly code = "DOCTOR_CHECK_FAILED" as const;
+  readonly httpStatus: HttpStatusCode;
+  readonly grpcCode: GrpcStatusCode;
+  readonly domain: ErrorDomain;
+  readonly isExpected: boolean;
+  readonly checkName: string;
+
+  constructor(checkName: string, message: string) {
+    super(`Doctor check "${checkName}" failed: ${message}`);
+    const entry = ERROR_CATALOG.DOCTOR_CHECK_FAILED;
+    this.httpStatus = entry.httpStatus as HttpStatusCode;
+    this.grpcCode = entry.grpcCode as GrpcStatusCode;
+    this.domain = entry.domain as ErrorDomain;
+    this.isExpected = entry.isExpected;
+    this.checkName = checkName;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Doctor Nexus unavailable
+// ---------------------------------------------------------------------------
+
+/**
+ * Thrown when the Nexus API is unavailable for multi-tenant checks.
+ */
+export class DoctorNexusUnavailableError extends DoctorError {
+  readonly _tag = "ExternalError" as const;
+  readonly code = "DOCTOR_NEXUS_UNAVAILABLE" as const;
+  readonly httpStatus: HttpStatusCode;
+  readonly grpcCode: GrpcStatusCode;
+  readonly domain: ErrorDomain;
+  readonly isExpected: boolean;
+
+  constructor(message: string) {
+    super(`Nexus unavailable for doctor: ${message}`);
+    const entry = ERROR_CATALOG.DOCTOR_NEXUS_UNAVAILABLE;
+    this.httpStatus = entry.httpStatus as HttpStatusCode;
+    this.grpcCode = entry.grpcCode as GrpcStatusCode;
+    this.domain = entry.domain as ErrorDomain;
+    this.isExpected = entry.isExpected;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Doctor scan timeout
+// ---------------------------------------------------------------------------
+
+/**
+ * Thrown when the doctor security scan exceeds the configured timeout.
+ */
+export class DoctorScanTimeoutError extends DoctorError {
+  readonly _tag = "TimeoutError" as const;
+  readonly code = "DOCTOR_SCAN_TIMEOUT" as const;
+  readonly httpStatus: HttpStatusCode;
+  readonly grpcCode: GrpcStatusCode;
+  readonly domain: ErrorDomain;
+  readonly isExpected: boolean;
+  readonly timeoutMs: number;
+
+  constructor(timeoutMs: number) {
+    super(`Doctor scan timed out after ${timeoutMs}ms`);
+    const entry = ERROR_CATALOG.DOCTOR_SCAN_TIMEOUT;
+    this.httpStatus = entry.httpStatus as HttpStatusCode;
+    this.grpcCode = entry.grpcCode as GrpcStatusCode;
+    this.domain = entry.domain as ErrorDomain;
+    this.isExpected = entry.isExpected;
+    this.timeoutMs = timeoutMs;
+  }
+}

--- a/packages/errors/src/index.ts
+++ b/packages/errors/src/index.ts
@@ -210,6 +210,18 @@ export {
 } from "./a2a.js";
 
 // ============================================================================
+// DOCTOR ERRORS — Security scanner and multi-tenant audits (#27)
+// ============================================================================
+
+export {
+  DoctorCheckFailedError,
+  DoctorConfigurationError,
+  DoctorError,
+  DoctorNexusUnavailableError,
+  DoctorScanTimeoutError,
+} from "./doctor.js";
+
+// ============================================================================
 // CODE MODE ERRORS — LLM-generated code execution via Monty sandbox (#111)
 // ============================================================================
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -278,6 +278,31 @@ importers:
         specifier: ^25.2.2
         version: 25.2.2
 
+  packages/doctor:
+    dependencies:
+      '@templar/core':
+        specifier: workspace:*
+        version: link:../core
+      '@templar/errors':
+        specifier: workspace:*
+        version: link:../errors
+      yaml:
+        specifier: ^2.8.0
+        version: 2.8.2
+    devDependencies:
+      '@nexus/sdk':
+        specifier: workspace:*
+        version: link:../nexus-sdk
+      '@templar/test-utils':
+        specifier: workspace:*
+        version: link:../test-utils
+      '@types/node':
+        specifier: ^25.0.0
+        version: 25.2.2
+      vitest:
+        specifier: ^4.0.0
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.2.2)(yaml@2.8.2)
+
   packages/engine:
     dependencies:
       '@langchain/langgraph':


### PR DESCRIPTION
## Summary

- Introduces `@templar/doctor` — a new package providing pluggable security scanning with 7 built-in checks, parallel audit engine (concurrency-limited via semaphore), OWASP Agentic Top 10 mapping, terminal/JSON reporters, `DoctorMiddleware` wrapper, and `templar-doctor` CLI
- Adds 4 doctor error codes to `@templar/errors` catalog (`DOCTOR_CONFIGURATION_INVALID`, `DOCTOR_CHECK_FAILED`, `DOCTOR_NEXUS_UNAVAILABLE`, `DOCTOR_SCAN_TIMEOUT`) with corresponding error classes
- Built-in checks: filesystem permissions, channel security, secrets scanning, gateway exposure, multi-tenant isolation (Nexus), budget leak detection (Nexus), skill code safety, plus attack surface summary aggregator

### Architecture

Three-layer design: **Audit Engine** (pure, parallel `Promise.allSettled` with concurrency 4) → **CLI Reporter** (terminal ANSI + JSON) → **Middleware Wrapper** (gates sessions on CRITICAL findings). NexusClient is optional — local checks always run, Nexus checks auto-skip when no client is provided. Each check is isolated via try/catch — failures produce error results, never crash the engine.

### Key decisions
- Pluggable `DoctorCheck` interface — users can add custom checks
- 4 severity levels: CRITICAL (exit 2), HIGH (exit 1), MEDIUM/LOW (exit 0)
- `createFinding()` factory for DRY finding construction
- Regex-based skill code safety (v1), swappable later
- No external CLI lib for v1 — minimal arg parsing

## Test plan

- [x] 82 tests across 14 files (65 unit + 15 integration + 2 E2E-ready)
- [x] `pnpm -F @templar/doctor build` — ESM + DTS pass
- [x] `pnpm -F @templar/doctor typecheck` — 0 errors
- [x] `pnpm -F @templar/doctor lint` — Biome v2 passes
- [x] `pnpm -F @templar/errors test` — 253 tests pass (no regression)
- [ ] CI pipeline validates full monorepo build
- [ ] E2E with real `nexus serve` for multi-tenant checks

Closes #27