### PR TITLE
feat(guardrails): add @templar/guardrails Zod output validation middleware (#28)

### DIFF
--- a/packages/errors/src/catalog.ts
+++ b/packages/errors/src/catalog.ts
@@ -2164,6 +2164,46 @@ export const ERROR_CATALOG = {
     title: "Invalid pairing configuration",
     description: "The pairing configuration is invalid.",
   },
+
+  // ============================================================================
+  // GUARDRAIL ERRORS — Output validation guardrails (#28)
+  // ============================================================================
+  GUARDRAIL_SCHEMA_FAILED: {
+    domain: "guardrail",
+    httpStatus: 422,
+    grpcCode: "INVALID_ARGUMENT" as const,
+    baseType: "ValidationError" as const,
+    isExpected: true,
+    title: "Guardrail schema validation failed",
+    description: "The LLM output failed Zod schema validation",
+  },
+  GUARDRAIL_RETRY_EXHAUSTED: {
+    domain: "guardrail",
+    httpStatus: 422,
+    grpcCode: "INVALID_ARGUMENT" as const,
+    baseType: "ValidationError" as const,
+    isExpected: true,
+    title: "Guardrail retry exhausted",
+    description: "All retry attempts failed to produce valid output",
+  },
+  GUARDRAIL_EVIDENCE_MISSING: {
+    domain: "guardrail",
+    httpStatus: 422,
+    grpcCode: "INVALID_ARGUMENT" as const,
+    baseType: "ValidationError" as const,
+    isExpected: true,
+    title: "Guardrail evidence missing",
+    description: "The output is missing required evidence or citations",
+  },
+  GUARDRAIL_CONFIGURATION_INVALID: {
+    domain: "guardrail",
+    httpStatus: 400,
+    grpcCode: "INVALID_ARGUMENT" as const,
+    baseType: "ValidationError" as const,
+    isExpected: true,
+    title: "Invalid guardrail configuration",
+    description: "The guardrails middleware configuration is invalid",
+  },
 } as const;
 
 // ============================================================================

--- a/packages/errors/src/guardrails.ts
+++ b/packages/errors/src/guardrails.ts
@@ -1,0 +1,139 @@
+import { TemplarError } from "./base.js";
+import {
+  ERROR_CATALOG,
+  type ErrorDomain,
+  type GrpcStatusCode,
+  type HttpStatusCode,
+} from "./catalog.js";
+
+// ---------------------------------------------------------------------------
+// Shared issue type for guard validation results
+// ---------------------------------------------------------------------------
+
+export interface GuardIssue {
+  readonly guard: string;
+  readonly path: readonly (string | number)[];
+  readonly message: string;
+  readonly code: string;
+  readonly severity: "error" | "warning";
+}
+
+// ---------------------------------------------------------------------------
+// Base class for all guardrail errors
+// ---------------------------------------------------------------------------
+
+/**
+ * Abstract base class for guardrail errors.
+ *
+ * Enables generic catch: `if (e instanceof GuardrailError)`
+ * while specific subclasses allow precise handling.
+ */
+export abstract class GuardrailError extends TemplarError {}
+
+// ---------------------------------------------------------------------------
+// Guardrail configuration invalid
+// ---------------------------------------------------------------------------
+
+/**
+ * Thrown when the guardrails middleware configuration is invalid.
+ */
+export class GuardrailConfigurationError extends GuardrailError {
+  readonly _tag = "ValidationError" as const;
+  readonly code = "GUARDRAIL_CONFIGURATION_INVALID" as const;
+  readonly httpStatus: HttpStatusCode;
+  readonly grpcCode: GrpcStatusCode;
+  readonly domain: ErrorDomain;
+  readonly isExpected: boolean;
+
+  constructor(message: string) {
+    super(`Invalid guardrail configuration: ${message}`);
+    const entry = ERROR_CATALOG.GUARDRAIL_CONFIGURATION_INVALID;
+    this.httpStatus = entry.httpStatus as HttpStatusCode;
+    this.grpcCode = entry.grpcCode as GrpcStatusCode;
+    this.domain = entry.domain as ErrorDomain;
+    this.isExpected = entry.isExpected;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Guardrail schema validation failed
+// ---------------------------------------------------------------------------
+
+/**
+ * Thrown when the LLM output fails Zod schema validation.
+ */
+export class GuardrailSchemaError extends GuardrailError {
+  readonly _tag = "ValidationError" as const;
+  readonly code = "GUARDRAIL_SCHEMA_FAILED" as const;
+  readonly httpStatus: HttpStatusCode;
+  readonly grpcCode: GrpcStatusCode;
+  readonly domain: ErrorDomain;
+  readonly isExpected: boolean;
+  readonly issues: readonly GuardIssue[];
+
+  constructor(message: string, issues: readonly GuardIssue[]) {
+    super(`Guardrail schema validation failed: ${message}`);
+    const entry = ERROR_CATALOG.GUARDRAIL_SCHEMA_FAILED;
+    this.httpStatus = entry.httpStatus as HttpStatusCode;
+    this.grpcCode = entry.grpcCode as GrpcStatusCode;
+    this.domain = entry.domain as ErrorDomain;
+    this.isExpected = entry.isExpected;
+    this.issues = issues;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Guardrail retry exhausted
+// ---------------------------------------------------------------------------
+
+/**
+ * Thrown when all retry attempts fail to produce valid output.
+ */
+export class GuardrailRetryExhaustedError extends GuardrailError {
+  readonly _tag = "ValidationError" as const;
+  readonly code = "GUARDRAIL_RETRY_EXHAUSTED" as const;
+  readonly httpStatus: HttpStatusCode;
+  readonly grpcCode: GrpcStatusCode;
+  readonly domain: ErrorDomain;
+  readonly isExpected: boolean;
+  readonly attempts: number;
+  readonly lastIssues: readonly GuardIssue[];
+
+  constructor(attempts: number, lastIssues: readonly GuardIssue[]) {
+    super(`Guardrail validation failed after ${attempts} attempts`);
+    const entry = ERROR_CATALOG.GUARDRAIL_RETRY_EXHAUSTED;
+    this.httpStatus = entry.httpStatus as HttpStatusCode;
+    this.grpcCode = entry.grpcCode as GrpcStatusCode;
+    this.domain = entry.domain as ErrorDomain;
+    this.isExpected = entry.isExpected;
+    this.attempts = attempts;
+    this.lastIssues = lastIssues;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Guardrail evidence missing
+// ---------------------------------------------------------------------------
+
+/**
+ * Thrown when the output is missing required evidence or citations.
+ */
+export class GuardrailEvidenceError extends GuardrailError {
+  readonly _tag = "ValidationError" as const;
+  readonly code = "GUARDRAIL_EVIDENCE_MISSING" as const;
+  readonly httpStatus: HttpStatusCode;
+  readonly grpcCode: GrpcStatusCode;
+  readonly domain: ErrorDomain;
+  readonly isExpected: boolean;
+  readonly missingFields: readonly string[];
+
+  constructor(missingFields: readonly string[]) {
+    super(`Missing required evidence fields: ${missingFields.join(", ")}`);
+    const entry = ERROR_CATALOG.GUARDRAIL_EVIDENCE_MISSING;
+    this.httpStatus = entry.httpStatus as HttpStatusCode;
+    this.grpcCode = entry.grpcCode as GrpcStatusCode;
+    this.domain = entry.domain as ErrorDomain;
+    this.isExpected = entry.isExpected;
+    this.missingFields = missingFields;
+  }
+}

--- a/packages/errors/src/index.ts
+++ b/packages/errors/src/index.ts
@@ -253,6 +253,19 @@ export {
 } from "./pairing.js";
 
 // ============================================================================
+// GUARDRAIL ERRORS — Output validation guardrails (#28)
+// ============================================================================
+
+export {
+  type GuardIssue,
+  GuardrailConfigurationError,
+  GuardrailError,
+  GuardrailEvidenceError,
+  GuardrailRetryExhaustedError,
+  GuardrailSchemaError,
+} from "./guardrails.js";
+
+// ============================================================================
 // WEB SEARCH ERRORS — Pluggable search providers (#119)
 // ============================================================================
 

--- a/packages/guardrails/package.json
+++ b/packages/guardrails/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@templar/guardrails",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./evidence": {
+      "types": "./dist/evidence.d.ts",
+      "import": "./dist/evidence.js"
+    }
+  },
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check .",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@templar/errors": "workspace:*",
+    "zod": "^3.24.0"
+  },
+  "devDependencies": {
+    "@templar/core": "workspace:*",
+    "@types/node": "^22.0.0",
+    "tsup": "^8.0.0",
+    "vitest": "^4.0.0"
+  },
+  "peerDependencies": {
+    "@templar/core": "workspace:*"
+  }
+}

--- a/packages/guardrails/src/__tests__/e2e/guardrails-e2e.test.ts
+++ b/packages/guardrails/src/__tests__/e2e/guardrails-e2e.test.ts
@@ -1,0 +1,198 @@
+import type {
+  ModelHandler,
+  ModelRequest,
+  ModelResponse,
+  ToolHandler,
+  ToolRequest,
+  ToolResponse,
+  TurnContext,
+} from "@templar/core";
+import { GuardrailRetryExhaustedError } from "@templar/errors";
+import { describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+import { createCustomGuard } from "../../guards/custom-guard.js";
+import { EvidenceGuard } from "../../guards/evidence-guard.js";
+import { createGuardrailsMiddleware } from "../../middleware.js";
+import type { ValidationMetrics } from "../../types.js";
+
+describe("Guardrails E2E", () => {
+  it("full session lifecycle with mock LLM", async () => {
+    const schema = z.object({
+      answer: z.string(),
+      sources: z.array(z.string()).min(1),
+      confidence: z.number().min(0).max(1),
+    });
+
+    const evidenceGuard = new EvidenceGuard({
+      requiredFields: ["sources"],
+      minEvidence: 1,
+    });
+
+    const mw = createGuardrailsMiddleware({
+      guards: [evidenceGuard],
+      schema,
+      maxRetries: 2,
+      validateModelCalls: true,
+      validateToolCalls: true,
+      validateTurns: true,
+      onFailure: "retry",
+    });
+
+    // Simulate model call that succeeds on first try
+    const modelNext: ModelHandler = vi.fn().mockResolvedValue({
+      content: JSON.stringify({
+        answer: "The capital of France is Paris",
+        sources: ["wikipedia.org/france"],
+        confidence: 0.95,
+      }),
+    } satisfies ModelResponse);
+
+    const modelReq: ModelRequest = {
+      messages: [{ role: "user", content: "What is the capital of France?" }],
+    };
+
+    // biome-ignore lint/style/noNonNullAssertion: test - hook always defined
+    const modelResult = await mw.wrapModelCall!(modelReq, modelNext);
+    const modelMetrics = modelResult.metadata?.guardrails as ValidationMetrics;
+    expect(modelMetrics.passed).toBe(true);
+    expect(modelMetrics.hook).toBe("model");
+
+    // Simulate tool call
+    const toolSchema = z.object({ result: z.string() });
+    const toolMw = createGuardrailsMiddleware({
+      guards: [],
+      schema: toolSchema,
+      validateToolCalls: true,
+    });
+
+    const toolNext: ToolHandler = vi.fn().mockResolvedValue({
+      output: { result: "search completed" },
+    } satisfies ToolResponse);
+
+    const toolReq: ToolRequest = { toolName: "web_search", input: { q: "France capital" } };
+    // biome-ignore lint/style/noNonNullAssertion: test - hook always defined
+    const toolResult = await toolMw.wrapToolCall!(toolReq, toolNext);
+    const toolMetrics = toolResult.metadata?.guardrails as ValidationMetrics;
+    expect(toolMetrics.passed).toBe(true);
+
+    // Simulate turn validation
+    const turnCtx: TurnContext = {
+      sessionId: "session-1",
+      turnNumber: 1,
+      output: {
+        answer: "Paris",
+        sources: ["wiki"],
+        confidence: 0.9,
+      },
+    };
+
+    // biome-ignore lint/style/noNonNullAssertion: test - hook always defined
+    await mw.onAfterTurn!(turnCtx);
+    const turnMetrics = turnCtx.metadata?.guardrails as ValidationMetrics;
+    expect(turnMetrics.passed).toBe(true);
+  });
+
+  it("retry exhaustion scenario with progressive failures", async () => {
+    const schema = z.object({
+      status: z.literal("complete"),
+      data: z.object({ count: z.number().int().positive() }),
+    });
+
+    const mw = createGuardrailsMiddleware({
+      guards: [],
+      schema,
+      maxRetries: 2,
+      onFailure: "retry",
+    });
+
+    // All attempts return invalid data
+    const next: ModelHandler = vi
+      .fn()
+      .mockResolvedValueOnce({ content: JSON.stringify({ status: "partial" }) })
+      .mockResolvedValueOnce({ content: JSON.stringify({ status: "complete", data: {} }) })
+      .mockResolvedValueOnce({
+        content: JSON.stringify({ status: "complete", data: { count: -1 } }),
+      });
+
+    const req: ModelRequest = { messages: [{ role: "user", content: "process data" }] };
+
+    try {
+      // biome-ignore lint/style/noNonNullAssertion: test - hook always defined
+      await mw.wrapModelCall!(req, next);
+      expect.fail("Should throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(GuardrailRetryExhaustedError);
+      expect((err as GuardrailRetryExhaustedError).attempts).toBe(3);
+    }
+
+    expect(next).toHaveBeenCalledTimes(3);
+  });
+
+  it("mixed validation modes across different hooks", async () => {
+    const warnings: unknown[] = [];
+    const modelSchema = z.object({ text: z.string() });
+    const customGuard = createCustomGuard("length-check", (ctx) => {
+      // In model hook, response is ModelResponse; in turn hook, it's raw output
+      let text: string;
+      if (ctx.hook === "model") {
+        const resp = ctx.response as ModelResponse;
+        const parsed = JSON.parse(resp.content) as { text: string };
+        text = parsed.text;
+      } else {
+        const data = ctx.response as { text: string };
+        text = data.text;
+      }
+      if (text.length < 10) {
+        return {
+          valid: true,
+          issues: [
+            {
+              guard: "length-check",
+              path: ["text"],
+              message: "Response is very short",
+              code: "SHORT",
+              severity: "warning" as const,
+            },
+          ],
+        };
+      }
+      return { valid: true, issues: [] };
+    });
+
+    const mw = createGuardrailsMiddleware({
+      guards: [customGuard],
+      schema: modelSchema,
+      validateModelCalls: true,
+      validateToolCalls: false,
+      validateTurns: true,
+      onFailure: "warn",
+      onWarning: (issues) => warnings.push(...issues),
+    });
+
+    // Model call — should validate
+    const modelNext: ModelHandler = vi.fn().mockResolvedValue({
+      content: JSON.stringify({ text: "short" }),
+    });
+    const modelReq: ModelRequest = { messages: [{ role: "user", content: "test" }] };
+    // biome-ignore lint/style/noNonNullAssertion: test - hook always defined
+    const modelResult = await mw.wrapModelCall!(modelReq, modelNext);
+    expect(modelResult.metadata?.guardrails).toBeDefined();
+
+    // Tool call — should skip validation
+    const toolNext: ToolHandler = vi.fn().mockResolvedValue({ output: "anything" });
+    const toolReq: ToolRequest = { toolName: "test", input: {} };
+    // biome-ignore lint/style/noNonNullAssertion: test - hook always defined
+    const toolResult = await mw.wrapToolCall!(toolReq, toolNext);
+    expect(toolResult.metadata?.guardrails).toBeUndefined();
+
+    // Turn — should validate
+    const turnCtx: TurnContext = {
+      sessionId: "s1",
+      turnNumber: 1,
+      output: { text: "hi" },
+    };
+    // biome-ignore lint/style/noNonNullAssertion: test - hook always defined
+    await mw.onAfterTurn!(turnCtx);
+    expect(turnCtx.metadata?.guardrails).toBeDefined();
+  });
+});

--- a/packages/guardrails/src/__tests__/integration/guard-composition.test.ts
+++ b/packages/guardrails/src/__tests__/integration/guard-composition.test.ts
@@ -1,0 +1,115 @@
+import type { ModelRequest, ModelResponse } from "@templar/core";
+import { describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+import { createCustomGuard } from "../../guards/custom-guard.js";
+import { EvidenceGuard } from "../../guards/evidence-guard.js";
+import { createGuardrailsMiddleware } from "../../middleware.js";
+import type { ValidationMetrics } from "../../types.js";
+
+describe("Guard composition integration", () => {
+  it("runs schema + evidence + custom guards together", async () => {
+    const schema = z.object({
+      answer: z.string(),
+      sources: z.array(z.string()),
+      confidence: z.number(),
+    });
+
+    const evidenceGuard = new EvidenceGuard({
+      requiredFields: ["sources"],
+      minEvidence: 1,
+    });
+
+    const customGuard = createCustomGuard("confidence-check", (ctx) => {
+      const data = JSON.parse((ctx.response as ModelResponse).content);
+      if (data.confidence < 0.5) {
+        return {
+          valid: false,
+          issues: [
+            {
+              guard: "confidence-check",
+              path: ["confidence"],
+              message: "Confidence too low",
+              code: "LOW_CONFIDENCE",
+              severity: "error" as const,
+            },
+          ],
+        };
+      }
+      return { valid: true, issues: [] };
+    });
+
+    const mw = createGuardrailsMiddleware({
+      guards: [evidenceGuard, customGuard],
+      schema,
+    });
+
+    const validOutput = JSON.stringify({
+      answer: "The answer is 42",
+      sources: ["hitchhikers-guide"],
+      confidence: 0.95,
+    });
+
+    const next = vi.fn().mockResolvedValue({ content: validOutput } satisfies ModelResponse);
+    const req: ModelRequest = { messages: [{ role: "user", content: "test" }] };
+
+    // biome-ignore lint/style/noNonNullAssertion: test - hook always defined
+    const result = await mw.wrapModelCall!(req, next);
+    const metrics = result.metadata?.guardrails as ValidationMetrics;
+
+    expect(metrics.passed).toBe(true);
+    // Schema guard + evidence guard + custom guard = 3
+    expect(metrics.guardResults).toHaveLength(3);
+  });
+
+  it("sequential mode fails fast on schema error", async () => {
+    const evidenceGuard = new EvidenceGuard({ requiredFields: ["sources"] });
+    const neverGuard = createCustomGuard("never", () => {
+      throw new Error("should not run");
+    });
+
+    const mw = createGuardrailsMiddleware({
+      guards: [evidenceGuard, neverGuard],
+      schema: z.object({ x: z.number() }),
+      executionStrategy: "sequential",
+      onFailure: "throw",
+      maxRetries: 0,
+    });
+
+    const next = vi.fn().mockResolvedValue({ content: "not json" } satisfies ModelResponse);
+    const req: ModelRequest = { messages: [{ role: "user", content: "test" }] };
+
+    // Should fail on schema guard and not reach the never guard
+    // biome-ignore lint/style/noNonNullAssertion: test - hook always defined
+    await expect(mw.wrapModelCall!(req, next)).rejects.toThrow();
+  });
+
+  it("parallel mode aggregates all guard results", async () => {
+    const guard1 = createCustomGuard("g1", () => ({
+      valid: false,
+      issues: [{ guard: "g1", path: [], message: "err1", code: "E1", severity: "error" as const }],
+    }));
+    const guard2 = createCustomGuard("g2", () => ({
+      valid: false,
+      issues: [{ guard: "g2", path: [], message: "err2", code: "E2", severity: "error" as const }],
+    }));
+
+    const mw = createGuardrailsMiddleware({
+      guards: [guard1, guard2],
+      executionStrategy: "parallel",
+      onFailure: "throw",
+      maxRetries: 0,
+    });
+
+    const next = vi.fn().mockResolvedValue({ content: "test" } satisfies ModelResponse);
+    const req: ModelRequest = { messages: [{ role: "user", content: "test" }] };
+
+    try {
+      // biome-ignore lint/style/noNonNullAssertion: test - hook always defined
+      await mw.wrapModelCall!(req, next);
+      expect.fail("Should have thrown");
+    } catch {
+      // Both guards should have run in parallel
+      expect(next).toHaveBeenCalledTimes(1);
+    }
+  });
+});

--- a/packages/guardrails/src/__tests__/integration/metadata-flow.test.ts
+++ b/packages/guardrails/src/__tests__/integration/metadata-flow.test.ts
@@ -1,0 +1,90 @@
+import type { ModelRequest, ModelResponse } from "@templar/core";
+import { describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+import { createGuardrailsMiddleware } from "../../middleware.js";
+import type { ValidationMetrics } from "../../types.js";
+
+describe("Metadata flow integration", () => {
+  it("uses config default schema when no per-request override", async () => {
+    const schema = z.object({ name: z.string() });
+    const mw = createGuardrailsMiddleware({ guards: [], schema });
+
+    const next = vi.fn().mockResolvedValue({
+      content: JSON.stringify({ name: "Alice" }),
+    } satisfies ModelResponse);
+
+    const req: ModelRequest = { messages: [{ role: "user", content: "test" }] };
+    // biome-ignore lint/style/noNonNullAssertion: test - hook always defined
+    const result = await mw.wrapModelCall!(req, next);
+
+    const metrics = result.metadata?.guardrails as ValidationMetrics;
+    expect(metrics.passed).toBe(true);
+  });
+
+  it("uses per-request schema override from metadata", async () => {
+    const defaultSchema = z.object({ x: z.number() });
+    const overrideSchema = z.object({ y: z.string() });
+
+    const mw = createGuardrailsMiddleware({ guards: [], schema: defaultSchema });
+
+    const next = vi.fn().mockResolvedValue({
+      content: JSON.stringify({ y: "hello" }),
+    } satisfies ModelResponse);
+
+    const req: ModelRequest = {
+      messages: [{ role: "user", content: "test" }],
+      metadata: { guardrailSchema: overrideSchema },
+    };
+
+    // biome-ignore lint/style/noNonNullAssertion: test - hook always defined
+    const result = await mw.wrapModelCall!(req, next);
+
+    const metrics = result.metadata?.guardrails as ValidationMetrics;
+    expect(metrics.passed).toBe(true);
+  });
+
+  it("passes through without validation when no guards and no schema", async () => {
+    // Can't create middleware with no guards AND no schema — it throws.
+    // But we can test with guards only (no schema)
+    const passGuard = {
+      name: "pass",
+      validate: () => ({ valid: true, issues: [] }),
+    };
+    const mw = createGuardrailsMiddleware({ guards: [passGuard] });
+
+    const next = vi.fn().mockResolvedValue({
+      content: "arbitrary content",
+    } satisfies ModelResponse);
+
+    const req: ModelRequest = { messages: [{ role: "user", content: "test" }] };
+    // biome-ignore lint/style/noNonNullAssertion: test - hook always defined
+    const result = await mw.wrapModelCall!(req, next);
+
+    const metrics = result.metadata?.guardrails as ValidationMetrics;
+    expect(metrics.passed).toBe(true);
+  });
+
+  it("attaches metrics to response metadata immutably", async () => {
+    const mw = createGuardrailsMiddleware({
+      guards: [],
+      schema: z.object({ ok: z.boolean() }),
+    });
+
+    const originalMetadata = { existingKey: "value" };
+    const next = vi.fn().mockResolvedValue({
+      content: JSON.stringify({ ok: true }),
+      metadata: originalMetadata,
+    } satisfies ModelResponse);
+
+    const req: ModelRequest = { messages: [{ role: "user", content: "test" }] };
+    // biome-ignore lint/style/noNonNullAssertion: test - hook always defined
+    const result = await mw.wrapModelCall!(req, next);
+
+    // Original metadata preserved
+    expect(result.metadata?.existingKey).toBe("value");
+    // New metrics added
+    expect(result.metadata?.guardrails).toBeDefined();
+    // Original object not mutated
+    expect(originalMetadata).not.toHaveProperty("guardrails");
+  });
+});

--- a/packages/guardrails/src/__tests__/integration/middleware.test.ts
+++ b/packages/guardrails/src/__tests__/integration/middleware.test.ts
@@ -1,0 +1,162 @@
+import type {
+  ModelRequest,
+  ModelResponse,
+  ToolRequest,
+  ToolResponse,
+  TurnContext,
+} from "@templar/core";
+import { describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+import { createGuardrailsMiddleware } from "../../middleware.js";
+import type { ValidationMetrics } from "../../types.js";
+
+function makeModelReq(_content: string, metadata?: Record<string, unknown>): ModelRequest {
+  return {
+    messages: [{ role: "user", content: "test" }],
+    ...(metadata ? { metadata } : {}),
+  };
+}
+
+function makeModelRes(content: string, metadata?: Record<string, unknown>): ModelResponse {
+  return {
+    content,
+    ...(metadata ? { metadata } : {}),
+  };
+}
+
+describe("GuardrailsMiddleware integration", () => {
+  const schema = z.object({
+    answer: z.string(),
+    confidence: z.number().min(0).max(1),
+  });
+
+  describe("wrapModelCall", () => {
+    it("validates model output and attaches metrics", async () => {
+      const mw = createGuardrailsMiddleware({ guards: [], schema });
+      const validOutput = JSON.stringify({ answer: "hello", confidence: 0.9 });
+      const next = vi.fn().mockResolvedValue(makeModelRes(validOutput));
+
+      // biome-ignore lint/style/noNonNullAssertion: test - hook always defined
+      const result = await mw.wrapModelCall!(makeModelReq("test"), next);
+
+      expect(result.content).toBe(validOutput);
+      const metrics = result.metadata?.guardrails as ValidationMetrics;
+      expect(metrics).toBeDefined();
+      expect(metrics.passed).toBe(true);
+      expect(metrics.hook).toBe("model");
+    });
+
+    it("retries on validation failure with feedback", async () => {
+      const mw = createGuardrailsMiddleware({
+        guards: [],
+        schema,
+        maxRetries: 1,
+      });
+
+      const badOutput = JSON.stringify({ answer: 123 });
+      const goodOutput = JSON.stringify({ answer: "hello", confidence: 0.9 });
+
+      const next = vi
+        .fn()
+        .mockResolvedValueOnce(makeModelRes(badOutput))
+        .mockResolvedValueOnce(makeModelRes(goodOutput));
+
+      // biome-ignore lint/style/noNonNullAssertion: test - hook always defined
+      const result = await mw.wrapModelCall!(makeModelReq("test"), next);
+
+      expect(next).toHaveBeenCalledTimes(2);
+      // Second call should have feedback injected
+      const secondCall = next.mock.calls[1]?.[0] as ModelRequest;
+      expect(secondCall.messages.length).toBeGreaterThan(1);
+      expect(secondCall.messages[secondCall.messages.length - 1]?.content).toContain(
+        "failed validation",
+      );
+
+      const metrics = result.metadata?.guardrails as ValidationMetrics;
+      expect(metrics.totalAttempts).toBe(2);
+      expect(metrics.passed).toBe(true);
+    });
+
+    it("skips validation when validateModelCalls is false", async () => {
+      const mw = createGuardrailsMiddleware({
+        guards: [],
+        schema,
+        validateModelCalls: false,
+      });
+      const next = vi.fn().mockResolvedValue(makeModelRes("not json"));
+
+      // biome-ignore lint/style/noNonNullAssertion: test - hook always defined
+      const result = await mw.wrapModelCall!(makeModelReq("test"), next);
+
+      expect(result.content).toBe("not json");
+      expect(result.metadata?.guardrails).toBeUndefined();
+    });
+  });
+
+  describe("wrapToolCall", () => {
+    it("validates tool output when enabled", async () => {
+      const toolSchema = z.object({ result: z.string() });
+      const mw = createGuardrailsMiddleware({
+        guards: [],
+        schema: toolSchema,
+        validateToolCalls: true,
+      });
+
+      const toolReq: ToolRequest = { toolName: "search", input: { q: "test" } };
+      const toolRes: ToolResponse = { output: { result: "found" } };
+      const next = vi.fn().mockResolvedValue(toolRes);
+
+      // biome-ignore lint/style/noNonNullAssertion: test - hook always defined
+      const result = await mw.wrapToolCall!(toolReq, next);
+
+      const metrics = result.metadata?.guardrails as ValidationMetrics;
+      expect(metrics).toBeDefined();
+      expect(metrics.hook).toBe("tool");
+      expect(metrics.passed).toBe(true);
+    });
+  });
+
+  describe("onAfterTurn", () => {
+    it("validates turn output when enabled", async () => {
+      const turnSchema = z.object({ summary: z.string() });
+      const mw = createGuardrailsMiddleware({
+        guards: [],
+        schema: turnSchema,
+        validateTurns: true,
+        onFailure: "warn",
+        onWarning: vi.fn(),
+      });
+
+      const ctx: TurnContext = {
+        sessionId: "s1",
+        turnNumber: 1,
+        output: { summary: "done" },
+      };
+
+      // biome-ignore lint/style/noNonNullAssertion: test - hook always defined
+      await mw.onAfterTurn!(ctx);
+
+      const metrics = ctx.metadata?.guardrails as ValidationMetrics;
+      expect(metrics).toBeDefined();
+      expect(metrics.hook).toBe("turn");
+    });
+
+    it("throws on invalid turn output with onFailure: throw", async () => {
+      const mw = createGuardrailsMiddleware({
+        guards: [],
+        schema: z.object({ required: z.string() }),
+        validateTurns: true,
+        onFailure: "throw",
+      });
+
+      const ctx: TurnContext = {
+        sessionId: "s1",
+        turnNumber: 1,
+        output: { wrong: 123 },
+      };
+
+      // biome-ignore lint/style/noNonNullAssertion: test - hook always defined
+      await expect(mw.onAfterTurn!(ctx)).rejects.toThrow("Turn validation failed");
+    });
+  });
+});

--- a/packages/guardrails/src/__tests__/integration/retry-flow.test.ts
+++ b/packages/guardrails/src/__tests__/integration/retry-flow.test.ts
@@ -1,0 +1,95 @@
+import type { ModelRequest, ModelResponse } from "@templar/core";
+import { GuardrailRetryExhaustedError } from "@templar/errors";
+import { describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+import { createGuardrailsMiddleware } from "../../middleware.js";
+import type { ValidationMetrics } from "../../types.js";
+
+describe("Retry flow integration", () => {
+  const schema = z.object({
+    answer: z.string(),
+    score: z.number(),
+  });
+
+  it("injects error feedback into model messages across retries", async () => {
+    const mw = createGuardrailsMiddleware({
+      guards: [],
+      schema,
+      maxRetries: 2,
+    });
+
+    const next = vi
+      .fn<(req: ModelRequest) => Promise<ModelResponse>>()
+      .mockResolvedValueOnce({ content: JSON.stringify({ answer: 123 }) })
+      .mockResolvedValueOnce({ content: JSON.stringify({ answer: "ok", score: "bad" }) })
+      .mockResolvedValueOnce({ content: JSON.stringify({ answer: "ok", score: 0.9 }) });
+
+    const req: ModelRequest = { messages: [{ role: "user", content: "test" }] };
+    // biome-ignore lint/style/noNonNullAssertion: test - hook always defined
+    const result = await mw.wrapModelCall!(req, next);
+
+    expect(next).toHaveBeenCalledTimes(3);
+
+    // First retry should include feedback about first failure
+    const call2 = next.mock.calls[1]?.[0] as ModelRequest;
+    expect(call2.messages.length).toBe(2);
+    expect(call2.messages[1]?.content).toContain("failed validation");
+
+    // Second retry should include feedback about second failure
+    const call3 = next.mock.calls[2]?.[0] as ModelRequest;
+    expect(call3.messages.length).toBe(3);
+
+    const metrics = result.metadata?.guardrails as ValidationMetrics;
+    expect(metrics.totalAttempts).toBe(3);
+    expect(metrics.passed).toBe(true);
+  });
+
+  it("preserves request metadata across retries", async () => {
+    const mw = createGuardrailsMiddleware({
+      guards: [],
+      schema,
+      maxRetries: 1,
+    });
+
+    const next = vi
+      .fn<(req: ModelRequest) => Promise<ModelResponse>>()
+      .mockResolvedValueOnce({ content: JSON.stringify({ wrong: true }) })
+      .mockResolvedValueOnce({ content: JSON.stringify({ answer: "ok", score: 1 }) });
+
+    const req: ModelRequest = {
+      messages: [{ role: "user", content: "test" }],
+      metadata: { customKey: "preserved" },
+    };
+
+    // biome-ignore lint/style/noNonNullAssertion: test - hook always defined
+    const result = await mw.wrapModelCall!(req, next);
+
+    // Metadata should be preserved in retry requests
+    const retryReq = next.mock.calls[1]?.[0] as ModelRequest;
+    expect(retryReq.metadata?.customKey).toBe("preserved");
+
+    expect(result.metadata?.guardrails).toBeDefined();
+  });
+
+  it("exhaustion error includes attempt count and last issues", async () => {
+    const mw = createGuardrailsMiddleware({
+      guards: [],
+      schema,
+      maxRetries: 1,
+    });
+
+    const next = vi.fn().mockResolvedValue({ content: "not json at all" });
+    const req: ModelRequest = { messages: [{ role: "user", content: "test" }] };
+
+    try {
+      // biome-ignore lint/style/noNonNullAssertion: test - hook always defined
+      await mw.wrapModelCall!(req, next);
+      expect.fail("Should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(GuardrailRetryExhaustedError);
+      const retryErr = err as GuardrailRetryExhaustedError;
+      expect(retryErr.attempts).toBe(2);
+      expect(retryErr.lastIssues.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/packages/guardrails/src/__tests__/unit/collector.test.ts
+++ b/packages/guardrails/src/__tests__/unit/collector.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { EvidenceCollector } from "../../evidence/collector.js";
+import type { EvidenceRecord } from "../../evidence/types.js";
+
+function makeRecord(overrides: Partial<EvidenceRecord> = {}): EvidenceRecord {
+  return {
+    sessionId: "session-1",
+    turnNumber: 1,
+    guard: "test-guard",
+    field: "sources",
+    value: ["evidence"],
+    timestamp: Date.now(),
+    ...overrides,
+  };
+}
+
+describe("EvidenceCollector", () => {
+  it("records entries with immutable append", () => {
+    const collector = new EvidenceCollector();
+    const r1 = makeRecord({ field: "a" });
+    const r2 = makeRecord({ field: "b" });
+
+    collector.record(r1);
+    const afterFirst = collector.getRecords();
+    collector.record(r2);
+    const afterSecond = collector.getRecords();
+
+    // Original reference should not be mutated
+    expect(afterFirst).toHaveLength(1);
+    expect(afterSecond).toHaveLength(2);
+    expect(afterFirst).not.toBe(afterSecond);
+  });
+
+  it("generates a report for a session", () => {
+    const collector = new EvidenceCollector();
+    collector.record(makeRecord({ guard: "g1", field: "f1" }));
+    collector.record(makeRecord({ guard: "g1", field: "f2" }));
+    collector.record(makeRecord({ guard: "g2", field: "f1" }));
+    collector.record(makeRecord({ sessionId: "other" }));
+
+    const report = collector.report("session-1");
+
+    expect(report.sessionId).toBe("session-1");
+    expect(report.totalRecords).toBe(3);
+    expect(report.byGuard).toEqual({ g1: 2, g2: 1 });
+    expect(report.byField).toEqual({ f1: 2, f2: 1 });
+    expect(report.generatedAt).toBeGreaterThan(0);
+  });
+
+  it("caps at maxRecords", () => {
+    const collector = new EvidenceCollector({ maxRecords: 3 });
+
+    collector.record(makeRecord({ field: "a" }));
+    collector.record(makeRecord({ field: "b" }));
+    collector.record(makeRecord({ field: "c" }));
+    collector.record(makeRecord({ field: "d" }));
+
+    const records = collector.getRecords();
+    expect(records).toHaveLength(3);
+    // Oldest (a) should be dropped
+    expect(records[0]?.field).toBe("b");
+    expect(records[2]?.field).toBe("d");
+  });
+
+  it("resets all records", () => {
+    const collector = new EvidenceCollector();
+    collector.record(makeRecord());
+    collector.record(makeRecord());
+
+    collector.reset();
+    expect(collector.getRecords()).toHaveLength(0);
+  });
+});

--- a/packages/guardrails/src/__tests__/unit/config.test.ts
+++ b/packages/guardrails/src/__tests__/unit/config.test.ts
@@ -1,0 +1,83 @@
+import { GuardrailConfigurationError } from "@templar/errors";
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { resolveGuardrailsConfig } from "../../config.js";
+import type { Guard } from "../../types.js";
+
+const dummyGuard: Guard = {
+  name: "dummy",
+  validate: () => ({ valid: true, issues: [] }),
+};
+
+describe("resolveGuardrailsConfig", () => {
+  it("throws on empty guards and no schema", () => {
+    expect(() => resolveGuardrailsConfig({ guards: [] })).toThrow(GuardrailConfigurationError);
+  });
+
+  it("accepts empty guards when schema is provided", () => {
+    const config = resolveGuardrailsConfig({
+      guards: [],
+      schema: z.object({ x: z.number() }),
+    });
+    expect(config.guards).toHaveLength(0);
+    expect(config.schema).toBeDefined();
+  });
+
+  it("throws on invalid maxRetries", () => {
+    expect(() => resolveGuardrailsConfig({ guards: [dummyGuard], maxRetries: -1 })).toThrow(
+      GuardrailConfigurationError,
+    );
+
+    expect(() => resolveGuardrailsConfig({ guards: [dummyGuard], maxRetries: 11 })).toThrow(
+      GuardrailConfigurationError,
+    );
+
+    expect(() => resolveGuardrailsConfig({ guards: [dummyGuard], maxRetries: 1.5 })).toThrow(
+      GuardrailConfigurationError,
+    );
+  });
+
+  it("throws on invalid validationTimeoutMs", () => {
+    expect(() => resolveGuardrailsConfig({ guards: [dummyGuard], validationTimeoutMs: 0 })).toThrow(
+      GuardrailConfigurationError,
+    );
+
+    expect(() =>
+      resolveGuardrailsConfig({ guards: [dummyGuard], validationTimeoutMs: -100 }),
+    ).toThrow(GuardrailConfigurationError);
+  });
+
+  it("applies defaults for omitted fields", () => {
+    const config = resolveGuardrailsConfig({ guards: [dummyGuard] });
+
+    expect(config.maxRetries).toBe(2);
+    expect(config.onFailure).toBe("retry");
+    expect(config.executionStrategy).toBe("sequential");
+    expect(config.validationTimeoutMs).toBe(5000);
+    expect(config.validateModelCalls).toBe(true);
+    expect(config.validateToolCalls).toBe(false);
+    expect(config.validateTurns).toBe(false);
+    expect(config.onWarning).toBeUndefined();
+  });
+
+  it("preserves user-provided values", () => {
+    const config = resolveGuardrailsConfig({
+      guards: [dummyGuard],
+      maxRetries: 5,
+      onFailure: "throw",
+      executionStrategy: "parallel",
+      validationTimeoutMs: 10_000,
+      validateModelCalls: false,
+      validateToolCalls: true,
+      validateTurns: true,
+    });
+
+    expect(config.maxRetries).toBe(5);
+    expect(config.onFailure).toBe("throw");
+    expect(config.executionStrategy).toBe("parallel");
+    expect(config.validationTimeoutMs).toBe(10_000);
+    expect(config.validateModelCalls).toBe(false);
+    expect(config.validateToolCalls).toBe(true);
+    expect(config.validateTurns).toBe(true);
+  });
+});

--- a/packages/guardrails/src/__tests__/unit/custom-guard.test.ts
+++ b/packages/guardrails/src/__tests__/unit/custom-guard.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { createCustomGuard } from "../../guards/custom-guard.js";
+import type { GuardContext } from "../../types.js";
+
+function makeContext(): GuardContext {
+  return {
+    hook: "model",
+    response: { content: "test" },
+    attempt: 1,
+    previousIssues: [],
+    metadata: {},
+  };
+}
+
+describe("createCustomGuard", () => {
+  it("wraps a synchronous validation function", () => {
+    const guard = createCustomGuard("sync-guard", () => ({
+      valid: true,
+      issues: [],
+    }));
+
+    expect(guard.name).toBe("sync-guard");
+    const result = guard.validate(makeContext());
+    expect(result).toEqual({ valid: true, issues: [] });
+  });
+
+  it("wraps an async validation function", async () => {
+    const guard = createCustomGuard("async-guard", async () => ({
+      valid: false,
+      issues: [
+        {
+          guard: "async-guard",
+          path: [],
+          message: "Custom validation failed",
+          code: "CUSTOM",
+          severity: "error" as const,
+        },
+      ],
+    }));
+
+    expect(guard.name).toBe("async-guard");
+    const result = await guard.validate(makeContext());
+    expect(result.valid).toBe(false);
+    expect(result.issues).toHaveLength(1);
+  });
+});

--- a/packages/guardrails/src/__tests__/unit/evidence-guard.test.ts
+++ b/packages/guardrails/src/__tests__/unit/evidence-guard.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { EvidenceGuard } from "../../guards/evidence-guard.js";
+import type { GuardContext } from "../../types.js";
+
+function makeContext(response: unknown): GuardContext {
+  return {
+    hook: "model",
+    response,
+    attempt: 1,
+    previousIssues: [],
+    metadata: {},
+  };
+}
+
+describe("EvidenceGuard", () => {
+  it("passes when all required fields are present", () => {
+    const guard = new EvidenceGuard({ requiredFields: ["sources", "reasoning"] });
+    const ctx = makeContext({
+      content: JSON.stringify({
+        sources: ["source1"],
+        reasoning: "because...",
+      }),
+    });
+
+    const result = guard.validate(ctx);
+    expect(result.valid).toBe(true);
+    expect(result.issues).toHaveLength(0);
+  });
+
+  it("fails when a required field is missing", () => {
+    const guard = new EvidenceGuard({ requiredFields: ["sources", "reasoning"] });
+    const ctx = makeContext({
+      content: JSON.stringify({ sources: ["source1"] }),
+    });
+
+    const result = guard.validate(ctx);
+    expect(result.valid).toBe(false);
+    expect(result.issues).toHaveLength(1);
+    expect(result.issues[0]?.code).toBe("EVIDENCE_MISSING");
+    expect(result.issues[0]?.path).toEqual(["reasoning"]);
+  });
+
+  it("fails when array field has fewer items than minEvidence", () => {
+    const guard = new EvidenceGuard({
+      requiredFields: ["sources"],
+      minEvidence: 3,
+    });
+    const ctx = makeContext({
+      content: JSON.stringify({ sources: ["s1", "s2"] }),
+    });
+
+    const result = guard.validate(ctx);
+    expect(result.valid).toBe(false);
+    expect(result.issues[0]?.message).toContain("2 items");
+    expect(result.issues[0]?.message).toContain("minimum is 3");
+  });
+
+  it("fails when output is not an object", () => {
+    const guard = new EvidenceGuard({ requiredFields: ["sources"] });
+    const ctx = makeContext({ content: "just a plain string" });
+
+    const result = guard.validate(ctx);
+    expect(result.valid).toBe(false);
+    expect(result.issues[0]?.message).toContain("not an object");
+  });
+
+  it("handles tool response with output field", () => {
+    const guard = new EvidenceGuard({ requiredFields: ["data"] });
+    const ctx = makeContext({ output: { data: [1, 2, 3] } });
+
+    const result = guard.validate(ctx);
+    expect(result.valid).toBe(true);
+  });
+
+  it("handles null response", () => {
+    const guard = new EvidenceGuard({ requiredFields: ["sources"] });
+    const ctx = makeContext(null);
+
+    const result = guard.validate(ctx);
+    expect(result.valid).toBe(false);
+  });
+});

--- a/packages/guardrails/src/__tests__/unit/retry.test.ts
+++ b/packages/guardrails/src/__tests__/unit/retry.test.ts
@@ -1,0 +1,117 @@
+import { GuardrailRetryExhaustedError } from "@templar/errors";
+import { describe, expect, it, vi } from "vitest";
+import { buildFeedbackMessage, RetryExecutor } from "../../retry.js";
+import type { AggregatedGuardResult, GuardIssue } from "../../types.js";
+
+const validResult: AggregatedGuardResult = {
+  valid: true,
+  issues: [],
+  guardResults: [{ guard: "test", durationMs: 1, valid: true }],
+};
+
+const invalidResult: AggregatedGuardResult = {
+  valid: false,
+  issues: [
+    {
+      guard: "test",
+      path: ["field"],
+      message: "invalid",
+      code: "ERR",
+      severity: "error",
+    },
+  ],
+  guardResults: [{ guard: "test", durationMs: 1, valid: false }],
+};
+
+describe("RetryExecutor", () => {
+  it("returns immediately when first attempt succeeds", async () => {
+    const executor = new RetryExecutor({ maxRetries: 2, onFailure: "retry" });
+    const next = vi.fn().mockResolvedValue("response");
+    const validate = vi.fn().mockResolvedValue(validResult);
+
+    const { response, metrics } = await executor.execute("req", next, validate, (r) => r, "model");
+
+    expect(response).toBe("response");
+    expect(metrics.totalAttempts).toBe(1);
+    expect(metrics.passed).toBe(true);
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it("succeeds on second attempt after retry", async () => {
+    const executor = new RetryExecutor({ maxRetries: 2, onFailure: "retry" });
+    const next = vi.fn().mockResolvedValueOnce("bad").mockResolvedValueOnce("good");
+    const validate = vi
+      .fn()
+      .mockResolvedValueOnce(invalidResult)
+      .mockResolvedValueOnce(validResult);
+    const feedback = vi.fn().mockReturnValue("req-with-feedback");
+
+    const { response, metrics } = await executor.execute("req", next, validate, feedback, "model");
+
+    expect(response).toBe("good");
+    expect(metrics.totalAttempts).toBe(2);
+    expect(metrics.passed).toBe(true);
+    expect(feedback).toHaveBeenCalledOnce();
+  });
+
+  it("throws GuardrailRetryExhaustedError after all retries", async () => {
+    const executor = new RetryExecutor({ maxRetries: 1, onFailure: "retry" });
+    const next = vi.fn().mockResolvedValue("bad");
+    const validate = vi.fn().mockResolvedValue(invalidResult);
+
+    await expect(executor.execute("req", next, validate, (r) => r, "model")).rejects.toBeInstanceOf(
+      GuardrailRetryExhaustedError,
+    );
+
+    // 1 initial + 1 retry = 2 total
+    expect(next).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws immediately with onFailure: throw", async () => {
+    const executor = new RetryExecutor({ maxRetries: 2, onFailure: "throw" });
+    const next = vi.fn().mockResolvedValue("bad");
+    const validate = vi.fn().mockResolvedValue(invalidResult);
+
+    await expect(executor.execute("req", next, validate, (r) => r, "model")).rejects.toBeInstanceOf(
+      GuardrailRetryExhaustedError,
+    );
+
+    // Only one attempt with "throw" — no retries
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onWarning and returns response with onFailure: warn", async () => {
+    const onWarning = vi.fn();
+    const executor = new RetryExecutor({ maxRetries: 0, onFailure: "warn", onWarning });
+    const next = vi.fn().mockResolvedValue("response");
+    const validate = vi.fn().mockResolvedValue(invalidResult);
+
+    const { response, metrics } = await executor.execute("req", next, validate, (r) => r, "model");
+
+    expect(onWarning).toHaveBeenCalledWith(invalidResult.issues);
+    expect(metrics.passed).toBe(false);
+    expect(response).toBe("response");
+  });
+});
+
+describe("buildFeedbackMessage", () => {
+  it("formats issues into feedback text", () => {
+    const issues: GuardIssue[] = [
+      {
+        guard: "test",
+        path: ["name"],
+        message: "Expected string",
+        code: "type",
+        severity: "error",
+      },
+      { guard: "test", path: [], message: "Root error", code: "type", severity: "error" },
+      { guard: "test", path: ["x"], message: "warn", code: "type", severity: "warning" },
+    ];
+
+    const msg = buildFeedbackMessage(issues);
+    expect(msg).toContain("name: Expected string");
+    expect(msg).toContain("(root): Root error");
+    // Warnings are filtered out
+    expect(msg).not.toContain("warn");
+  });
+});

--- a/packages/guardrails/src/__tests__/unit/runner.test.ts
+++ b/packages/guardrails/src/__tests__/unit/runner.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from "vitest";
+import { GuardRunner } from "../../runner.js";
+import type { Guard, GuardContext, GuardResult } from "../../types.js";
+
+function makeContext(): GuardContext {
+  return {
+    hook: "model",
+    response: { content: "test" },
+    attempt: 1,
+    previousIssues: [],
+    metadata: {},
+  };
+}
+
+function makeGuard(name: string, result: GuardResult, delayMs = 0): Guard {
+  return {
+    name,
+    validate:
+      delayMs > 0
+        ? () => new Promise<GuardResult>((resolve) => setTimeout(() => resolve(result), delayMs))
+        : () => result,
+  };
+}
+
+describe("GuardRunner", () => {
+  describe("sequential execution", () => {
+    it("runs guards in order", async () => {
+      const order: string[] = [];
+      const g1: Guard = {
+        name: "first",
+        validate: () => {
+          order.push("first");
+          return { valid: true, issues: [] };
+        },
+      };
+      const g2: Guard = {
+        name: "second",
+        validate: () => {
+          order.push("second");
+          return { valid: true, issues: [] };
+        },
+      };
+
+      const runner = new GuardRunner([g1, g2], "sequential", 5000);
+      await runner.run(makeContext());
+
+      expect(order).toEqual(["first", "second"]);
+    });
+
+    it("short-circuits on first error", async () => {
+      const failGuard = makeGuard("fail", {
+        valid: false,
+        issues: [
+          {
+            guard: "fail",
+            path: [],
+            message: "failed",
+            code: "ERR",
+            severity: "error",
+          },
+        ],
+      });
+      const neverGuard: Guard = {
+        name: "never",
+        validate: () => {
+          throw new Error("should not be called");
+        },
+      };
+
+      const runner = new GuardRunner([failGuard, neverGuard], "sequential", 5000);
+      const result = await runner.run(makeContext());
+
+      expect(result.valid).toBe(false);
+      expect(result.guardResults).toHaveLength(1);
+    });
+
+    it("continues past warnings", async () => {
+      const warnGuard = makeGuard("warn", {
+        valid: true,
+        issues: [
+          {
+            guard: "warn",
+            path: [],
+            message: "warning",
+            code: "WARN",
+            severity: "warning",
+          },
+        ],
+      });
+      const passGuard = makeGuard("pass", { valid: true, issues: [] });
+
+      const runner = new GuardRunner([warnGuard, passGuard], "sequential", 5000);
+      const result = await runner.run(makeContext());
+
+      expect(result.valid).toBe(true);
+      expect(result.guardResults).toHaveLength(2);
+      expect(result.issues).toHaveLength(1);
+    });
+  });
+
+  describe("parallel execution", () => {
+    it("runs guards concurrently", async () => {
+      const start = performance.now();
+      const g1 = makeGuard("slow1", { valid: true, issues: [] }, 50);
+      const g2 = makeGuard("slow2", { valid: true, issues: [] }, 50);
+
+      const runner = new GuardRunner([g1, g2], "parallel", 5000);
+      await runner.run(makeContext());
+
+      const elapsed = performance.now() - start;
+      // Both should run in ~50ms, not ~100ms
+      expect(elapsed).toBeLessThan(100);
+    });
+
+    it("aggregates all results (no short-circuit)", async () => {
+      const fail1 = makeGuard("fail1", {
+        valid: false,
+        issues: [{ guard: "fail1", path: [], message: "f1", code: "E", severity: "error" }],
+      });
+      const fail2 = makeGuard("fail2", {
+        valid: false,
+        issues: [{ guard: "fail2", path: [], message: "f2", code: "E", severity: "error" }],
+      });
+
+      const runner = new GuardRunner([fail1, fail2], "parallel", 5000);
+      const result = await runner.run(makeContext());
+
+      expect(result.valid).toBe(false);
+      expect(result.issues).toHaveLength(2);
+      expect(result.guardResults).toHaveLength(2);
+    });
+  });
+
+  it("handles guard timeout", async () => {
+    const hangingGuard: Guard = {
+      name: "hanging",
+      validate: () => new Promise(() => {}), // never resolves
+    };
+
+    const runner = new GuardRunner([hangingGuard], "sequential", 50);
+
+    await expect(runner.run(makeContext())).rejects.toThrow("timed out");
+  });
+
+  it("handles empty guard array", async () => {
+    const runner = new GuardRunner([], "sequential", 5000);
+    const result = await runner.run(makeContext());
+
+    expect(result.valid).toBe(true);
+    expect(result.issues).toHaveLength(0);
+    expect(result.guardResults).toHaveLength(0);
+  });
+});

--- a/packages/guardrails/src/__tests__/unit/schema-guard.test.ts
+++ b/packages/guardrails/src/__tests__/unit/schema-guard.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { SchemaGuard } from "../../guards/schema-guard.js";
+import type { GuardContext } from "../../types.js";
+
+function makeContext(response: unknown, metadata: Record<string, unknown> = {}): GuardContext {
+  return {
+    hook: "model",
+    response,
+    attempt: 1,
+    previousIssues: [],
+    metadata,
+  };
+}
+
+describe("SchemaGuard", () => {
+  const schema = z.object({
+    name: z.string(),
+    age: z.number(),
+  });
+
+  it("passes when output matches schema", async () => {
+    const guard = new SchemaGuard(schema);
+    const ctx = makeContext({ content: JSON.stringify({ name: "Alice", age: 30 }) });
+
+    const result = await guard.validate(ctx);
+    expect(result.valid).toBe(true);
+    expect(result.issues).toHaveLength(0);
+  });
+
+  it("fails when output violates schema", async () => {
+    const guard = new SchemaGuard(schema);
+    const ctx = makeContext({ content: JSON.stringify({ name: 123, age: "old" }) });
+
+    const result = await guard.validate(ctx);
+    expect(result.valid).toBe(false);
+    expect(result.issues.length).toBeGreaterThan(0);
+    expect(result.issues[0]?.severity).toBe("error");
+  });
+
+  it("reports nested path correctly", async () => {
+    const nestedSchema = z.object({
+      user: z.object({
+        profile: z.object({
+          email: z.string().email(),
+        }),
+      }),
+    });
+    const guard = new SchemaGuard(nestedSchema);
+    const ctx = makeContext({
+      content: JSON.stringify({ user: { profile: { email: "not-an-email" } } }),
+    });
+
+    const result = await guard.validate(ctx);
+    expect(result.valid).toBe(false);
+    expect(result.issues[0]?.path).toEqual(["user", "profile", "email"]);
+  });
+
+  it("reports array indices in path", async () => {
+    const arraySchema = z.object({
+      items: z.array(z.object({ id: z.number() })),
+    });
+    const guard = new SchemaGuard(arraySchema);
+    const ctx = makeContext({
+      content: JSON.stringify({ items: [{ id: 1 }, { id: "bad" }] }),
+    });
+
+    const result = await guard.validate(ctx);
+    expect(result.valid).toBe(false);
+    const paths = result.issues.map((i) => i.path);
+    expect(paths.some((p) => p.includes(1))).toBe(true);
+  });
+
+  it("supports per-request schema override via metadata", async () => {
+    const defaultGuard = new SchemaGuard(z.object({ x: z.number() }));
+    const overrideSchema = z.object({ y: z.string() });
+
+    const ctx = makeContext(
+      { content: JSON.stringify({ y: "hello" }) },
+      { guardrailSchema: overrideSchema },
+    );
+
+    const result = await defaultGuard.validate(ctx);
+    expect(result.valid).toBe(true);
+  });
+
+  it("handles non-JSON string content", async () => {
+    const guard = new SchemaGuard(z.string());
+    const ctx = makeContext({ content: "plain text" });
+
+    const result = await guard.validate(ctx);
+    expect(result.valid).toBe(true);
+  });
+
+  it("handles tool response output directly", async () => {
+    const guard = new SchemaGuard(z.object({ result: z.string() }));
+    const ctx = makeContext({ output: { result: "ok" } });
+
+    const result = await guard.validate(ctx);
+    expect(result.valid).toBe(true);
+  });
+});

--- a/packages/guardrails/src/__tests__/unit/validator.test.ts
+++ b/packages/guardrails/src/__tests__/unit/validator.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { SchemaValidator } from "../../validator.js";
+
+describe("SchemaValidator", () => {
+  it("returns valid for matching data", async () => {
+    const validator = new SchemaValidator(z.object({ x: z.number() }), 5000);
+    const result = await validator.validate({ x: 42 }, "test");
+
+    expect(result.valid).toBe(true);
+    expect(result.issues).toHaveLength(0);
+  });
+
+  it("returns issues for invalid data", async () => {
+    const validator = new SchemaValidator(z.object({ x: z.number() }), 5000);
+    const result = await validator.validate({ x: "not a number" }, "test");
+
+    expect(result.valid).toBe(false);
+    expect(result.issues.length).toBeGreaterThan(0);
+    expect(result.issues[0]?.guard).toBe("test");
+    expect(result.issues[0]?.severity).toBe("error");
+  });
+
+  it("times out for slow validation", async () => {
+    // Create a schema that would be very slow via a refine
+    const slowSchema = z.string().refine(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 10_000));
+      return true;
+    });
+
+    const validator = new SchemaValidator(slowSchema, 50);
+    await expect(validator.validate("test", "test")).rejects.toThrow("timed out");
+  });
+
+  it("validates complex nested schemas", async () => {
+    const schema = z.object({
+      user: z.object({
+        name: z.string().min(1),
+        emails: z.array(z.string().email()),
+        address: z.object({
+          city: z.string(),
+          zip: z.string().regex(/^\d{5}$/),
+        }),
+      }),
+    });
+
+    const validator = new SchemaValidator(schema, 5000);
+
+    const validData = {
+      user: {
+        name: "Alice",
+        emails: ["alice@example.com"],
+        address: { city: "Springfield", zip: "12345" },
+      },
+    };
+    const valid = await validator.validate(validData, "test");
+    expect(valid.valid).toBe(true);
+
+    const invalidData = {
+      user: {
+        name: "",
+        emails: ["not-an-email"],
+        address: { city: "Springfield", zip: "abc" },
+      },
+    };
+    const invalid = await validator.validate(invalidData, "test");
+    expect(invalid.valid).toBe(false);
+    expect(invalid.issues.length).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/packages/guardrails/src/config.ts
+++ b/packages/guardrails/src/config.ts
@@ -1,0 +1,53 @@
+import { GuardrailConfigurationError } from "@templar/errors";
+import {
+  DEFAULT_EXECUTION_STRATEGY,
+  DEFAULT_MAX_RETRIES,
+  DEFAULT_ON_FAILURE,
+  DEFAULT_VALIDATION_TIMEOUT_MS,
+} from "./constants.js";
+import type { GuardrailsConfig, ResolvedGuardrailsConfig } from "./types.js";
+
+const MAX_RETRIES_UPPER_BOUND = 10;
+
+/**
+ * Validates and resolves a {@link GuardrailsConfig} into a fully-resolved config
+ * with all defaults applied. Throws {@link GuardrailConfigurationError} on invalid input.
+ */
+export function resolveGuardrailsConfig(config: GuardrailsConfig): ResolvedGuardrailsConfig {
+  if (config.guards.length === 0 && config.schema === undefined) {
+    throw new GuardrailConfigurationError("At least one guard or a schema must be provided");
+  }
+
+  if (config.maxRetries !== undefined) {
+    if (
+      !Number.isInteger(config.maxRetries) ||
+      config.maxRetries < 0 ||
+      config.maxRetries > MAX_RETRIES_UPPER_BOUND
+    ) {
+      throw new GuardrailConfigurationError(
+        `maxRetries must be an integer between 0 and ${MAX_RETRIES_UPPER_BOUND}, got ${config.maxRetries}`,
+      );
+    }
+  }
+
+  if (config.validationTimeoutMs !== undefined) {
+    if (!Number.isFinite(config.validationTimeoutMs) || config.validationTimeoutMs <= 0) {
+      throw new GuardrailConfigurationError(
+        `validationTimeoutMs must be a positive number, got ${config.validationTimeoutMs}`,
+      );
+    }
+  }
+
+  return {
+    guards: config.guards,
+    schema: config.schema,
+    onFailure: config.onFailure ?? DEFAULT_ON_FAILURE,
+    maxRetries: config.maxRetries ?? DEFAULT_MAX_RETRIES,
+    executionStrategy: config.executionStrategy ?? DEFAULT_EXECUTION_STRATEGY,
+    validationTimeoutMs: config.validationTimeoutMs ?? DEFAULT_VALIDATION_TIMEOUT_MS,
+    validateModelCalls: config.validateModelCalls ?? true,
+    validateToolCalls: config.validateToolCalls ?? false,
+    validateTurns: config.validateTurns ?? false,
+    onWarning: config.onWarning,
+  };
+}

--- a/packages/guardrails/src/constants.ts
+++ b/packages/guardrails/src/constants.ts
@@ -1,0 +1,8 @@
+import type { ExecutionStrategy, OnFailureMode } from "./types.js";
+
+export const PACKAGE_NAME = "@templar/guardrails" as const;
+
+export const DEFAULT_MAX_RETRIES = 2;
+export const DEFAULT_VALIDATION_TIMEOUT_MS = 5_000;
+export const DEFAULT_ON_FAILURE: OnFailureMode = "retry";
+export const DEFAULT_EXECUTION_STRATEGY: ExecutionStrategy = "sequential";

--- a/packages/guardrails/src/evidence/collector.ts
+++ b/packages/guardrails/src/evidence/collector.ts
@@ -1,0 +1,53 @@
+import type { EvidenceCollectorConfig, EvidenceRecord, EvidenceReport } from "./types.js";
+
+const DEFAULT_MAX_RECORDS = 10_000;
+
+/**
+ * Collects evidence records from guard validations.
+ * Uses immutable append pattern for all state mutations.
+ */
+export class EvidenceCollector {
+  private records: readonly EvidenceRecord[] = [];
+  private readonly maxRecords: number;
+
+  constructor(config?: EvidenceCollectorConfig) {
+    this.maxRecords = config?.maxRecords ?? DEFAULT_MAX_RECORDS;
+  }
+
+  record(entry: EvidenceRecord): void {
+    if (this.records.length >= this.maxRecords) {
+      // Drop oldest records to maintain cap
+      this.records = [...this.records.slice(1), entry];
+    } else {
+      this.records = [...this.records, entry];
+    }
+  }
+
+  report(sessionId: string): EvidenceReport {
+    const filtered = this.records.filter((r) => r.sessionId === sessionId);
+
+    const byGuard: Record<string, number> = {};
+    const byField: Record<string, number> = {};
+
+    for (const rec of filtered) {
+      byGuard[rec.guard] = (byGuard[rec.guard] ?? 0) + 1;
+      byField[rec.field] = (byField[rec.field] ?? 0) + 1;
+    }
+
+    return {
+      sessionId,
+      totalRecords: filtered.length,
+      byGuard,
+      byField,
+      generatedAt: Date.now(),
+    };
+  }
+
+  getRecords(): readonly EvidenceRecord[] {
+    return this.records;
+  }
+
+  reset(): void {
+    this.records = [];
+  }
+}

--- a/packages/guardrails/src/evidence/index.ts
+++ b/packages/guardrails/src/evidence/index.ts
@@ -1,0 +1,2 @@
+export { EvidenceCollector } from "./collector.js";
+export type { EvidenceCollectorConfig, EvidenceRecord, EvidenceReport } from "./types.js";

--- a/packages/guardrails/src/evidence/types.ts
+++ b/packages/guardrails/src/evidence/types.ts
@@ -1,0 +1,20 @@
+export interface EvidenceRecord {
+  readonly sessionId: string;
+  readonly turnNumber: number;
+  readonly guard: string;
+  readonly field: string;
+  readonly value: unknown;
+  readonly timestamp: number;
+}
+
+export interface EvidenceReport {
+  readonly sessionId: string;
+  readonly totalRecords: number;
+  readonly byGuard: Readonly<Record<string, number>>;
+  readonly byField: Readonly<Record<string, number>>;
+  readonly generatedAt: number;
+}
+
+export interface EvidenceCollectorConfig {
+  readonly maxRecords?: number;
+}

--- a/packages/guardrails/src/guards/custom-guard.ts
+++ b/packages/guardrails/src/guards/custom-guard.ts
@@ -1,0 +1,14 @@
+import type { Guard, GuardContext, GuardResult } from "../types.js";
+
+/**
+ * Creates a custom guard from a validation function.
+ */
+export function createCustomGuard(
+  name: string,
+  validateFn: (context: GuardContext) => GuardResult | Promise<GuardResult>,
+): Guard {
+  return {
+    name,
+    validate: validateFn,
+  };
+}

--- a/packages/guardrails/src/guards/evidence-guard.ts
+++ b/packages/guardrails/src/guards/evidence-guard.ts
@@ -1,0 +1,102 @@
+import type { Guard, GuardContext, GuardIssue, GuardResult } from "../types.js";
+
+export interface EvidenceGuardConfig {
+  readonly requiredFields: readonly string[];
+  readonly minEvidence?: number;
+}
+
+/**
+ * Guard that validates output contains required evidence fields.
+ * Checks for required fields with optional minimum count per field.
+ */
+export class EvidenceGuard implements Guard {
+  readonly name = "EvidenceGuard";
+  private readonly requiredFields: readonly string[];
+  private readonly minEvidence: number;
+
+  constructor(config: EvidenceGuardConfig) {
+    this.requiredFields = config.requiredFields;
+    this.minEvidence = config.minEvidence ?? 1;
+  }
+
+  validate(context: GuardContext): GuardResult {
+    const data = extractData(context.response);
+
+    if (data === null || typeof data !== "object") {
+      return {
+        valid: false,
+        issues: [
+          {
+            guard: this.name,
+            path: [],
+            message: "Output is not an object; cannot check evidence fields",
+            code: "EVIDENCE_MISSING",
+            severity: "error",
+          },
+        ],
+      };
+    }
+
+    const record = data as Record<string, unknown>;
+    const issues: GuardIssue[] = [];
+
+    for (const field of this.requiredFields) {
+      const value = record[field];
+
+      if (value === undefined || value === null) {
+        issues.push({
+          guard: this.name,
+          path: [field],
+          message: `Required evidence field "${field}" is missing`,
+          code: "EVIDENCE_MISSING",
+          severity: "error",
+        });
+        continue;
+      }
+
+      if (Array.isArray(value) && value.length < this.minEvidence) {
+        issues.push({
+          guard: this.name,
+          path: [field],
+          message: `Evidence field "${field}" has ${value.length} items, minimum is ${this.minEvidence}`,
+          code: "EVIDENCE_MISSING",
+          severity: "error",
+        });
+      }
+    }
+
+    return { valid: issues.length === 0, issues };
+  }
+}
+
+function extractData(response: unknown): unknown {
+  if (response === null || response === undefined) {
+    return null;
+  }
+
+  if (typeof response === "string") {
+    try {
+      return JSON.parse(response) as unknown;
+    } catch {
+      return null;
+    }
+  }
+
+  if (typeof response === "object" && "content" in response) {
+    const content = (response as { content: unknown }).content;
+    if (typeof content === "string") {
+      try {
+        return JSON.parse(content) as unknown;
+      } catch {
+        return null;
+      }
+    }
+    return content;
+  }
+
+  if (typeof response === "object" && "output" in response) {
+    return (response as { output: unknown }).output;
+  }
+
+  return response;
+}

--- a/packages/guardrails/src/guards/index.ts
+++ b/packages/guardrails/src/guards/index.ts
@@ -1,0 +1,3 @@
+export { createCustomGuard } from "./custom-guard.js";
+export { EvidenceGuard, type EvidenceGuardConfig } from "./evidence-guard.js";
+export { SchemaGuard } from "./schema-guard.js";

--- a/packages/guardrails/src/guards/schema-guard.ts
+++ b/packages/guardrails/src/guards/schema-guard.ts
@@ -1,0 +1,61 @@
+import type { z } from "zod";
+import { DEFAULT_VALIDATION_TIMEOUT_MS } from "../constants.js";
+import type { Guard, GuardContext, GuardResult } from "../types.js";
+import { SchemaValidator } from "../validator.js";
+
+/**
+ * Guard that validates output against a Zod schema.
+ * Supports per-request schema override via `context.metadata.guardrailSchema`.
+ */
+export class SchemaGuard implements Guard {
+  readonly name = "SchemaGuard";
+  private readonly validator: SchemaValidator;
+  private readonly timeoutMs: number;
+
+  constructor(schema: z.ZodType, timeoutMs?: number) {
+    this.timeoutMs = timeoutMs ?? DEFAULT_VALIDATION_TIMEOUT_MS;
+    this.validator = new SchemaValidator(schema, this.timeoutMs);
+  }
+
+  async validate(context: GuardContext): Promise<GuardResult> {
+    const overrideSchema = context.metadata.guardrailSchema as z.ZodType | undefined;
+
+    const validator = overrideSchema
+      ? new SchemaValidator(overrideSchema, this.timeoutMs)
+      : this.validator;
+
+    const data = extractOutputData(context.response);
+    const result = await validator.validate(data, this.name);
+
+    return { valid: result.valid, issues: result.issues };
+  }
+}
+
+/**
+ * Extract the data to validate from the response.
+ * For model responses, parse content as JSON if possible.
+ * For tool responses, use the output directly.
+ */
+function extractOutputData(response: unknown): unknown {
+  if (response === null || response === undefined) {
+    return response;
+  }
+
+  if (typeof response === "object" && "content" in response) {
+    const content = (response as { content: unknown }).content;
+    if (typeof content === "string") {
+      try {
+        return JSON.parse(content) as unknown;
+      } catch {
+        return content;
+      }
+    }
+    return content;
+  }
+
+  if (typeof response === "object" && "output" in response) {
+    return (response as { output: unknown }).output;
+  }
+
+  return response;
+}

--- a/packages/guardrails/src/index.ts
+++ b/packages/guardrails/src/index.ts
@@ -1,0 +1,47 @@
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+export { createGuardrailsMiddleware } from "./middleware.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type {
+  AggregatedGuardResult,
+  ExecutionStrategy,
+  Guard,
+  GuardContext,
+  GuardIssue,
+  GuardResult,
+  GuardrailsConfig,
+  GuardTimingResult,
+  OnFailureMode,
+  ResolvedGuardrailsConfig,
+  SchemaValidationResult,
+  ValidationMetrics,
+} from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Built-in guards
+// ---------------------------------------------------------------------------
+
+export { createCustomGuard } from "./guards/custom-guard.js";
+export { EvidenceGuard, type EvidenceGuardConfig } from "./guards/evidence-guard.js";
+export { SchemaGuard } from "./guards/schema-guard.js";
+
+// ---------------------------------------------------------------------------
+// Internals (for advanced usage)
+// ---------------------------------------------------------------------------
+
+export { resolveGuardrailsConfig } from "./config.js";
+export { buildFeedbackMessage, RetryExecutor } from "./retry.js";
+export { GuardRunner } from "./runner.js";
+export { SchemaValidator } from "./validator.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+export { PACKAGE_NAME } from "./constants.js";

--- a/packages/guardrails/src/middleware.ts
+++ b/packages/guardrails/src/middleware.ts
@@ -1,0 +1,229 @@
+import type {
+  ModelHandler,
+  ModelRequest,
+  ModelResponse,
+  TemplarMiddleware,
+  ToolHandler,
+  ToolRequest,
+  ToolResponse,
+  TurnContext,
+} from "@templar/core";
+import { GuardrailSchemaError } from "@templar/errors";
+import { resolveGuardrailsConfig } from "./config.js";
+import { PACKAGE_NAME } from "./constants.js";
+import { SchemaGuard } from "./guards/schema-guard.js";
+import { buildFeedbackMessage, RetryExecutor } from "./retry.js";
+import { GuardRunner } from "./runner.js";
+import type {
+  AggregatedGuardResult,
+  Guard,
+  GuardContext,
+  GuardIssue,
+  GuardrailsConfig,
+  ResolvedGuardrailsConfig,
+  ValidationMetrics,
+} from "./types.js";
+
+/**
+ * Creates a Templar middleware that validates LLM outputs against guards.
+ */
+export function createGuardrailsMiddleware(config: GuardrailsConfig): TemplarMiddleware {
+  const resolved = resolveGuardrailsConfig(config);
+  return new GuardrailsMiddleware(resolved);
+}
+
+class GuardrailsMiddleware implements TemplarMiddleware {
+  readonly name = PACKAGE_NAME;
+  private readonly config: ResolvedGuardrailsConfig;
+
+  constructor(config: ResolvedGuardrailsConfig) {
+    this.config = config;
+  }
+
+  async wrapModelCall(req: ModelRequest, next: ModelHandler): Promise<ModelResponse> {
+    if (!this.config.validateModelCalls) {
+      return next(req);
+    }
+
+    const guards = this.resolveGuards(req.metadata);
+    if (guards.length === 0) {
+      return next(req);
+    }
+
+    const runner = new GuardRunner(
+      guards,
+      this.config.executionStrategy,
+      this.config.validationTimeoutMs,
+    );
+
+    const executor = new RetryExecutor<ModelRequest, ModelResponse>({
+      maxRetries: this.config.maxRetries,
+      onFailure: this.config.onFailure,
+      ...(this.config.onWarning ? { onWarning: this.config.onWarning } : {}),
+    });
+
+    const { response, metrics } = await executor.execute(
+      req,
+      next,
+      (res, attempt, previousIssues) =>
+        this.validateResponse(runner, "model", req, res, attempt, previousIssues),
+      injectModelFeedback,
+      "model",
+    );
+
+    return attachMetrics(response, metrics);
+  }
+
+  async wrapToolCall(req: ToolRequest, next: ToolHandler): Promise<ToolResponse> {
+    if (!this.config.validateToolCalls) {
+      return next(req);
+    }
+
+    const guards = this.resolveGuards(req.metadata);
+    if (guards.length === 0) {
+      return next(req);
+    }
+
+    const runner = new GuardRunner(
+      guards,
+      this.config.executionStrategy,
+      this.config.validationTimeoutMs,
+    );
+
+    const executor = new RetryExecutor<ToolRequest, ToolResponse>({
+      maxRetries: this.config.maxRetries,
+      onFailure: this.config.onFailure,
+      ...(this.config.onWarning ? { onWarning: this.config.onWarning } : {}),
+    });
+
+    const { response, metrics } = await executor.execute(
+      req,
+      next,
+      (res, attempt, previousIssues) =>
+        this.validateResponse(runner, "tool", req, res, attempt, previousIssues),
+      // Tool calls retry with the same request (no feedback injection)
+      (r) => r,
+      "tool",
+    );
+
+    return attachMetrics(response, metrics);
+  }
+
+  async onAfterTurn(context: TurnContext): Promise<void> {
+    if (!this.config.validateTurns) {
+      return;
+    }
+
+    const guards = this.resolveGuards(context.metadata);
+    if (guards.length === 0) {
+      return;
+    }
+
+    const runner = new GuardRunner(
+      guards,
+      this.config.executionStrategy,
+      this.config.validationTimeoutMs,
+    );
+
+    const guardContext: GuardContext = {
+      hook: "turn",
+      response: context.output,
+      attempt: 1,
+      previousIssues: [],
+      metadata: context.metadata ?? {},
+    };
+
+    const result = await runner.run(guardContext);
+
+    const metrics: ValidationMetrics = {
+      hook: "turn",
+      totalAttempts: 1,
+      totalDurationMs: result.guardResults.reduce((sum, r) => sum + r.durationMs, 0),
+      passed: result.valid,
+      guardResults: result.guardResults,
+    };
+
+    // Attach metrics to turn context metadata
+    context.metadata = {
+      ...context.metadata,
+      guardrails: metrics,
+    };
+
+    if (!result.valid) {
+      const errorIssues = result.issues.filter((i) => i.severity === "error");
+
+      if (this.config.onFailure === "warn") {
+        this.config.onWarning?.(result.issues);
+        return;
+      }
+
+      // No retry in onAfterTurn — throw directly
+      throw new GuardrailSchemaError(
+        `Turn validation failed with ${errorIssues.length} error(s)`,
+        result.issues,
+      );
+    }
+  }
+
+  private resolveGuards(metadata: Record<string, unknown> | undefined): readonly Guard[] {
+    const overrideSchema = metadata?.guardrailSchema;
+    const configGuards = [...this.config.guards];
+
+    if (overrideSchema) {
+      // Per-request schema override: prepend a SchemaGuard
+      const schemaGuard = new SchemaGuard(
+        overrideSchema as import("zod").ZodType,
+        this.config.validationTimeoutMs,
+      );
+      return [schemaGuard, ...configGuards];
+    }
+
+    if (this.config.schema) {
+      const schemaGuard = new SchemaGuard(this.config.schema, this.config.validationTimeoutMs);
+      return [schemaGuard, ...configGuards];
+    }
+
+    return configGuards;
+  }
+
+  private async validateResponse(
+    runner: GuardRunner,
+    hook: "model" | "tool",
+    request: ModelRequest | ToolRequest,
+    response: ModelResponse | ToolResponse,
+    attempt: number,
+    previousIssues: readonly GuardIssue[],
+  ): Promise<AggregatedGuardResult> {
+    const context: GuardContext = {
+      hook,
+      request,
+      response,
+      attempt,
+      previousIssues,
+      metadata: request.metadata ?? {},
+    };
+
+    return runner.run(context);
+  }
+}
+
+function injectModelFeedback(req: ModelRequest, issues: readonly GuardIssue[]): ModelRequest {
+  const feedback = buildFeedbackMessage(issues);
+  return {
+    ...req,
+    messages: [...req.messages, { role: "user", content: feedback }],
+  };
+}
+
+function attachMetrics<T extends { readonly metadata?: Record<string, unknown> }>(
+  response: T,
+  metrics: ValidationMetrics,
+): T {
+  return {
+    ...response,
+    metadata: {
+      ...response.metadata,
+      guardrails: metrics,
+    },
+  };
+}

--- a/packages/guardrails/src/retry.ts
+++ b/packages/guardrails/src/retry.ts
@@ -1,0 +1,114 @@
+import { GuardrailRetryExhaustedError } from "@templar/errors";
+import type {
+  AggregatedGuardResult,
+  GuardIssue,
+  GuardTimingResult,
+  OnFailureMode,
+  ValidationMetrics,
+} from "./types.js";
+
+export interface RetryExecutorConfig {
+  readonly maxRetries: number;
+  readonly onFailure: OnFailureMode;
+  readonly onWarning?: (issues: readonly GuardIssue[]) => void;
+}
+
+/**
+ * Retry executor that re-invokes the `next` handler when guards fail,
+ * optionally injecting error feedback into the request.
+ */
+export class RetryExecutor<TReq, TRes> {
+  private readonly config: RetryExecutorConfig;
+
+  constructor(config: RetryExecutorConfig) {
+    this.config = config;
+  }
+
+  async execute(
+    req: TReq,
+    next: (req: TReq) => Promise<TRes>,
+    validate: (
+      response: TRes,
+      attempt: number,
+      previousIssues: readonly GuardIssue[],
+    ) => Promise<AggregatedGuardResult>,
+    injectFeedback: (req: TReq, issues: readonly GuardIssue[]) => TReq,
+    hook: "model" | "tool" | "turn",
+  ): Promise<{ readonly response: TRes; readonly metrics: ValidationMetrics }> {
+    const overallStart = performance.now();
+    let currentReq = req;
+    let lastIssues: readonly GuardIssue[] = [];
+    let allGuardResults: GuardTimingResult[] = [];
+    let lastResponse: TRes | undefined;
+    const totalAttempts = 1 + this.config.maxRetries;
+
+    for (let attempt = 1; attempt <= totalAttempts; attempt++) {
+      const response = await next(currentReq);
+      lastResponse = response;
+      const result = await validate(response, attempt, lastIssues);
+
+      allGuardResults = [...allGuardResults, ...result.guardResults];
+
+      if (result.valid) {
+        return {
+          response,
+          metrics: {
+            hook,
+            totalAttempts: attempt,
+            totalDurationMs: performance.now() - overallStart,
+            passed: true,
+            guardResults: allGuardResults,
+          },
+        };
+      }
+
+      lastIssues = result.issues;
+
+      // Last attempt — no more retries
+      if (attempt === totalAttempts) {
+        break;
+      }
+
+      // Inject feedback for next attempt (only if retrying)
+      if (this.config.onFailure === "retry") {
+        currentReq = injectFeedback(currentReq, result.issues);
+      } else {
+        break;
+      }
+    }
+
+    const metrics: ValidationMetrics = {
+      hook,
+      totalAttempts,
+      totalDurationMs: performance.now() - overallStart,
+      passed: false,
+      guardResults: allGuardResults,
+    };
+
+    if (this.config.onFailure === "warn") {
+      this.config.onWarning?.(lastIssues);
+      return { response: lastResponse as TRes, metrics };
+    }
+
+    // "throw" or "retry" that exhausted attempts
+    throw new GuardrailRetryExhaustedError(totalAttempts, lastIssues);
+  }
+}
+
+/**
+ * Build error feedback message from guard issues for model call retries.
+ */
+export function buildFeedbackMessage(issues: readonly GuardIssue[]): string {
+  const lines = issues
+    .filter((i) => i.severity === "error")
+    .map((i) => {
+      const path = i.path.length > 0 ? i.path.join(".") : "(root)";
+      return `- ${path}: ${i.message}`;
+    });
+
+  return [
+    "Your previous response failed validation:",
+    ...lines,
+    "Please fix these issues in your next response.",
+  ].join("\n");
+}

--- a/packages/guardrails/src/runner.ts
+++ b/packages/guardrails/src/runner.ts
@@ -1,0 +1,129 @@
+import type {
+  AggregatedGuardResult,
+  ExecutionStrategy,
+  Guard,
+  GuardContext,
+  GuardIssue,
+  GuardResult,
+  GuardTimingResult,
+} from "./types.js";
+
+/**
+ * Runs a collection of guards either sequentially or in parallel.
+ * Sequential mode short-circuits on the first error-severity issue.
+ */
+export class GuardRunner {
+  private readonly guards: readonly Guard[];
+  private readonly strategy: ExecutionStrategy;
+  private readonly timeoutMs: number;
+
+  constructor(guards: readonly Guard[], strategy: ExecutionStrategy, timeoutMs: number) {
+    this.guards = guards;
+    this.strategy = strategy;
+    this.timeoutMs = timeoutMs;
+  }
+
+  async run(context: GuardContext): Promise<AggregatedGuardResult> {
+    if (this.guards.length === 0) {
+      return { valid: true, issues: [], guardResults: [] };
+    }
+
+    if (this.strategy === "parallel") {
+      return this.runParallel(context);
+    }
+
+    return this.runSequential(context);
+  }
+
+  private async runSequential(context: GuardContext): Promise<AggregatedGuardResult> {
+    const allIssues: GuardIssue[] = [];
+    const guardResults: GuardTimingResult[] = [];
+
+    for (const guard of this.guards) {
+      const start = performance.now();
+      const result = await this.runGuardWithTimeout(guard, context);
+      const durationMs = performance.now() - start;
+
+      guardResults.push({ guard: guard.name, durationMs, valid: result.valid });
+      allIssues.push(...result.issues);
+
+      // Short-circuit on first error
+      const hasError = result.issues.some((i) => i.severity === "error");
+      if (hasError) {
+        return { valid: false, issues: allIssues, guardResults };
+      }
+    }
+
+    return { valid: true, issues: allIssues, guardResults };
+  }
+
+  private async runParallel(context: GuardContext): Promise<AggregatedGuardResult> {
+    const entries = this.guards.map(async (guard) => {
+      const start = performance.now();
+      try {
+        const result = await this.runGuardWithTimeout(guard, context);
+        const durationMs = performance.now() - start;
+        return { guardName: guard.name, result, durationMs, error: null as Error | null };
+      } catch (err) {
+        const durationMs = performance.now() - start;
+        return {
+          guardName: guard.name,
+          result: null as GuardResult | null,
+          durationMs,
+          error: err instanceof Error ? err : new Error(String(err)),
+        };
+      }
+    });
+
+    const results = await Promise.all(entries);
+
+    const allIssues: GuardIssue[] = [];
+    const guardResults: GuardTimingResult[] = [];
+    let valid = true;
+
+    for (const entry of results) {
+      if (entry.result !== null) {
+        guardResults.push({
+          guard: entry.guardName,
+          durationMs: entry.durationMs,
+          valid: entry.result.valid,
+        });
+        allIssues.push(...entry.result.issues);
+        if (!entry.result.valid) {
+          valid = false;
+        }
+      } else {
+        const errorMessage = entry.error?.message ?? "Unknown error";
+        allIssues.push({
+          guard: entry.guardName,
+          path: [],
+          message: `Guard execution failed: ${errorMessage}`,
+          code: "GUARD_ERROR",
+          severity: "error",
+        });
+        guardResults.push({ guard: entry.guardName, durationMs: entry.durationMs, valid: false });
+        valid = false;
+      }
+    }
+
+    return { valid, issues: allIssues, guardResults };
+  }
+
+  private async runGuardWithTimeout(guard: Guard, context: GuardContext): Promise<GuardResult> {
+    const result = guard.validate(context);
+
+    // If synchronous, return immediately
+    if (!(result instanceof Promise)) {
+      return result;
+    }
+
+    return Promise.race([
+      result,
+      new Promise<never>((_, reject) => {
+        setTimeout(() => {
+          reject(new Error(`Guard "${guard.name}" timed out after ${this.timeoutMs}ms`));
+        }, this.timeoutMs);
+      }),
+    ]);
+  }
+}

--- a/packages/guardrails/src/types.ts
+++ b/packages/guardrails/src/types.ts
@@ -1,0 +1,111 @@
+import type { ModelRequest, ModelResponse, ToolRequest, ToolResponse } from "@templar/core";
+import type { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// Guard context — provided to each guard's validate()
+// ---------------------------------------------------------------------------
+
+export interface GuardContext {
+  readonly hook: "model" | "tool" | "turn";
+  readonly request?: ModelRequest | ToolRequest;
+  readonly response: ModelResponse | ToolResponse | unknown;
+  readonly attempt: number;
+  readonly previousIssues: readonly GuardIssue[];
+  readonly metadata: Readonly<Record<string, unknown>>;
+}
+
+// ---------------------------------------------------------------------------
+// Guard result types
+// ---------------------------------------------------------------------------
+
+export interface GuardIssue {
+  readonly guard: string;
+  readonly path: readonly (string | number)[];
+  readonly message: string;
+  readonly code: string;
+  readonly severity: "error" | "warning";
+}
+
+export interface GuardResult {
+  readonly valid: boolean;
+  readonly issues: readonly GuardIssue[];
+}
+
+export interface AggregatedGuardResult {
+  readonly valid: boolean;
+  readonly issues: readonly GuardIssue[];
+  readonly guardResults: readonly GuardTimingResult[];
+}
+
+export interface GuardTimingResult {
+  readonly guard: string;
+  readonly durationMs: number;
+  readonly valid: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Guard interface
+// ---------------------------------------------------------------------------
+
+export interface Guard {
+  readonly name: string;
+  validate(context: GuardContext): GuardResult | Promise<GuardResult>;
+}
+
+// ---------------------------------------------------------------------------
+// Configuration types
+// ---------------------------------------------------------------------------
+
+export type OnFailureMode = "retry" | "throw" | "warn";
+export type ExecutionStrategy = "sequential" | "parallel";
+
+export interface GuardrailsConfig {
+  readonly guards: readonly Guard[];
+  readonly schema?: z.ZodType;
+  readonly onFailure?: OnFailureMode;
+  readonly maxRetries?: number;
+  readonly executionStrategy?: ExecutionStrategy;
+  readonly validationTimeoutMs?: number;
+  readonly validateModelCalls?: boolean;
+  readonly validateToolCalls?: boolean;
+  readonly validateTurns?: boolean;
+  readonly onWarning?: (issues: readonly GuardIssue[]) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Resolved configuration (all fields required)
+// ---------------------------------------------------------------------------
+
+export interface ResolvedGuardrailsConfig {
+  readonly guards: readonly Guard[];
+  readonly schema: z.ZodType | undefined;
+  readonly onFailure: OnFailureMode;
+  readonly maxRetries: number;
+  readonly executionStrategy: ExecutionStrategy;
+  readonly validationTimeoutMs: number;
+  readonly validateModelCalls: boolean;
+  readonly validateToolCalls: boolean;
+  readonly validateTurns: boolean;
+  readonly onWarning: ((issues: readonly GuardIssue[]) => void) | undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Validation metrics — attached to response metadata
+// ---------------------------------------------------------------------------
+
+export interface ValidationMetrics {
+  readonly hook: "model" | "tool" | "turn";
+  readonly totalAttempts: number;
+  readonly totalDurationMs: number;
+  readonly passed: boolean;
+  readonly guardResults: readonly GuardTimingResult[];
+}
+
+// ---------------------------------------------------------------------------
+// Schema validation result (internal)
+// ---------------------------------------------------------------------------
+
+export interface SchemaValidationResult {
+  readonly valid: boolean;
+  readonly issues: readonly GuardIssue[];
+}

--- a/packages/guardrails/src/validator.ts
+++ b/packages/guardrails/src/validator.ts
@@ -1,0 +1,46 @@
+import type { z } from "zod";
+import type { GuardIssue, SchemaValidationResult } from "./types.js";
+
+/**
+ * Wraps a Zod schema and validates data with a configurable timeout.
+ */
+export class SchemaValidator {
+  private readonly schema: z.ZodType;
+  private readonly timeoutMs: number;
+
+  constructor(schema: z.ZodType, timeoutMs: number) {
+    this.schema = schema;
+    this.timeoutMs = timeoutMs;
+  }
+
+  async validate(data: unknown, guardName: string): Promise<SchemaValidationResult> {
+    const result = await Promise.race([this.runValidation(data, guardName), this.timeoutPromise()]);
+    return result;
+  }
+
+  private async runValidation(data: unknown, guardName: string): Promise<SchemaValidationResult> {
+    const result = await this.schema.safeParseAsync(data);
+
+    if (result.success) {
+      return { valid: true, issues: [] };
+    }
+
+    const issues: readonly GuardIssue[] = result.error.issues.map((issue) => ({
+      guard: guardName,
+      path: issue.path,
+      message: issue.message,
+      code: String(issue.code),
+      severity: "error" as const,
+    }));
+
+    return { valid: false, issues };
+  }
+
+  private timeoutPromise(): Promise<never> {
+    return new Promise<never>((_, reject) => {
+      setTimeout(() => {
+        reject(new Error(`Schema validation timed out after ${this.timeoutMs}ms`));
+      }, this.timeoutMs);
+    });
+  }
+}

--- a/packages/guardrails/tsconfig.json
+++ b/packages/guardrails/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": ["node"]
+  },
+  "include": ["src"],
+  "references": [{ "path": "../errors" }, { "path": "../core" }]
+}

--- a/packages/guardrails/tsup.config.ts
+++ b/packages/guardrails/tsup.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: {
+    index: "src/index.ts",
+    evidence: "src/evidence/index.ts",
+  },
+  format: ["esm"],
+  dts: {
+    compilerOptions: {
+      composite: false,
+      isolatedDeclarations: false,
+    },
+  },
+  clean: true,
+  treeshake: true,
+  target: "node22",
+});

--- a/packages/guardrails/vitest.config.ts
+++ b/packages/guardrails/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -387,6 +387,28 @@ importers:
         specifier: ^8.19.0
         version: 8.19.0
 
+  packages/guardrails:
+    dependencies:
+      '@templar/errors':
+        specifier: workspace:*
+        version: link:../errors
+      zod:
+        specifier: ^3.24.0
+        version: 3.25.76
+    devDependencies:
+      '@templar/core':
+        specifier: workspace:*
+        version: link:../core
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.11
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(postcss@8.5.6)(typescript@5.9.3)(yaml@2.8.2)
+      vitest:
+        specifier: ^4.0.0
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(yaml@2.8.2)
+
   packages/hooks:
     dependencies:
       '@templar/core':


### PR DESCRIPTION
## Summary

- Add new `@templar/guardrails` package for LLM output validation with Zod schema guards, evidence checking, custom validators, and configurable retry with error feedback
- Add 4 `GUARDRAIL_*` error types (schema failed, retry exhausted, evidence missing, config invalid) to `@templar/errors` catalog
- Implement three middleware hooks (`wrapModelCall`, `wrapToolCall`, `onAfterTurn`) with sequential/parallel guard execution, per-request schema overrides via metadata, and validation metrics emission

## Key Components

| Component | Description |
|-----------|-------------|
| `SchemaGuard` | Zod validation with per-request override via `metadata.guardrailSchema` |
| `EvidenceGuard` | Required fields + minimum evidence count checking |
| `createCustomGuard()` | Factory for ad-hoc validation functions |
| `GuardRunner` | Sequential (fail-fast) + parallel execution strategies with per-guard timeout |
| `RetryExecutor` | Configurable retry (max 2 default) with error feedback injection into model messages |
| `GuardrailsMiddleware` | Full `TemplarMiddleware` implementation with `onFailure: "retry" \| "throw" \| "warn"` |
| `EvidenceCollector` | Subpath entry (`@templar/guardrails/evidence`) for evidence tracking |

## Test plan

- [x] 8 unit test files (schema-guard, evidence-guard, custom-guard, runner, retry, validator, config, collector)
- [x] 4 integration test files (middleware, retry-flow, guard-composition, metadata-flow)
- [x] 1 E2E test file (full session lifecycle, retry exhaustion, mixed validation modes)
- [x] 61 tests total, all passing
- [x] Build + typecheck + lint all clean
- [x] Cross-package verification: @templar/errors (253 tests) still passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)