### PR TITLE
feat(create-templar): add CLI scaffolder for new agent projects

### DIFF
--- a/packages/create-templar/package.json
+++ b/packages/create-templar/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "create-templar",
+  "version": "0.0.0",
+  "private": false,
+  "type": "module",
+  "description": "Scaffold a new Templar agent project",
+  "bin": {
+    "create-templar": "./dist/index.js"
+  },
+  "files": [
+    "dist",
+    "templates"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check .",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "picocolors": "^1.1.0"
+  },
+  "devDependencies": {
+    "@templar/manifest": "workspace:*",
+    "@types/node": "^25.2.2"
+  }
+}

--- a/packages/create-templar/src/__tests__/cli.test.ts
+++ b/packages/create-templar/src/__tests__/cli.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { parseArgs } from "../cli.js";
+
+describe("parseArgs", () => {
+  it("parses positional project name", () => {
+    const args = parseArgs(["my-agent"]);
+    expect(args.projectName).toBe("my-agent");
+  });
+
+  it("returns undefined when no project name given", () => {
+    const args = parseArgs([]);
+    expect(args.projectName).toBeUndefined();
+  });
+
+  it("parses --template flag", () => {
+    const args = parseArgs(["--template", "code-builder"]);
+    expect(args.template).toBe("code-builder");
+  });
+
+  it("parses -t shorthand for template", () => {
+    const args = parseArgs(["-t", "daily-digest"]);
+    expect(args.template).toBe("daily-digest");
+  });
+
+  it("parses --yes flag", () => {
+    const args = parseArgs(["my-agent", "--yes"]);
+    expect(args.yes).toBe(true);
+  });
+
+  it("parses -y shorthand for yes", () => {
+    const args = parseArgs(["my-agent", "-y"]);
+    expect(args.yes).toBe(true);
+  });
+
+  it("parses --overwrite flag", () => {
+    const args = parseArgs(["my-agent", "--overwrite"]);
+    expect(args.overwrite).toBe(true);
+  });
+
+  it("parses -o shorthand for overwrite", () => {
+    const args = parseArgs(["my-agent", "-o"]);
+    expect(args.overwrite).toBe(true);
+  });
+
+  it("defaults yes and overwrite to false", () => {
+    const args = parseArgs(["my-agent"]);
+    expect(args.yes).toBe(false);
+    expect(args.overwrite).toBe(false);
+  });
+
+  it("parses all flags together", () => {
+    const args = parseArgs(["my-agent", "--template", "research-tracker", "--yes", "--overwrite"]);
+    expect(args.projectName).toBe("my-agent");
+    expect(args.template).toBe("research-tracker");
+    expect(args.yes).toBe(true);
+    expect(args.overwrite).toBe(true);
+  });
+});

--- a/packages/create-templar/src/__tests__/scaffold.test.ts
+++ b/packages/create-templar/src/__tests__/scaffold.test.ts
@@ -1,0 +1,152 @@
+import { randomUUID } from "node:crypto";
+import { existsSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { getAvailableTemplates, scaffold } from "../scaffold.js";
+
+function makeTmpDir(): string {
+  const dir = join(tmpdir(), `create-templar-test-${randomUUID()}`);
+  return dir;
+}
+
+const TEMPLATES = getAvailableTemplates();
+
+describe("scaffold", () => {
+  const dirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of dirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+    dirs.length = 0;
+  });
+
+  it("lists all 5 templates", () => {
+    expect(TEMPLATES).toHaveLength(5);
+    expect(TEMPLATES).toContain("code-builder");
+    expect(TEMPLATES).toContain("daily-digest");
+    expect(TEMPLATES).toContain("inbox-assistant");
+    expect(TEMPLATES).toContain("knowledge-base");
+    expect(TEMPLATES).toContain("research-tracker");
+  });
+
+  it.each(TEMPLATES)("scaffolds %s with all expected files", (template) => {
+    const targetDir = makeTmpDir();
+    dirs.push(targetDir);
+
+    const result = scaffold({
+      projectName: "test-agent",
+      template,
+      description: "Test description",
+      targetDir,
+      overwrite: false,
+    });
+
+    // Core files exist
+    expect(existsSync(join(targetDir, "templar.yaml"))).toBe(true);
+    expect(existsSync(join(targetDir, "README.md"))).toBe(true);
+    expect(existsSync(join(targetDir, "package.json"))).toBe(true);
+
+    // Renamed files
+    expect(existsSync(join(targetDir, ".gitignore"))).toBe(true);
+    expect(existsSync(join(targetDir, ".env.example"))).toBe(true);
+
+    // Originals should NOT exist
+    expect(existsSync(join(targetDir, "_gitignore"))).toBe(false);
+    expect(existsSync(join(targetDir, "_env.example"))).toBe(false);
+
+    expect(result.targetDir).toBe(targetDir);
+    expect(result.files.length).toBeGreaterThan(0);
+  });
+
+  it.each(TEMPLATES)("substitutes variables in %s package.json", (template) => {
+    const targetDir = makeTmpDir();
+    dirs.push(targetDir);
+
+    scaffold({
+      projectName: "my-cool-agent",
+      template,
+      description: "A cool agent",
+      targetDir,
+      overwrite: false,
+    });
+
+    const pkg = JSON.parse(readFileSync(join(targetDir, "package.json"), "utf-8"));
+    expect(pkg.name).toBe("my-cool-agent");
+    expect(pkg.description).toBe("A cool agent");
+  });
+
+  it("overwrites existing directory when overwrite is true", () => {
+    const targetDir = makeTmpDir();
+    dirs.push(targetDir);
+
+    // First scaffold
+    scaffold({
+      projectName: "test-agent",
+      template: "code-builder",
+      description: "First",
+      targetDir,
+      overwrite: false,
+    });
+
+    // Second scaffold with overwrite
+    const result = scaffold({
+      projectName: "test-agent-v2",
+      template: "code-builder",
+      description: "Second",
+      targetDir,
+      overwrite: true,
+    });
+
+    const pkg = JSON.parse(readFileSync(join(targetDir, "package.json"), "utf-8"));
+    expect(pkg.name).toBe("test-agent-v2");
+    expect(pkg.description).toBe("Second");
+    expect(result.files.length).toBeGreaterThan(0);
+  });
+
+  it("throws for unknown template", () => {
+    const targetDir = makeTmpDir();
+    dirs.push(targetDir);
+
+    expect(() =>
+      scaffold({
+        projectName: "test",
+        template: "nonexistent",
+        description: "test",
+        targetDir,
+        overwrite: false,
+      }),
+    ).toThrow('Template "nonexistent" not found');
+  });
+
+  it("creates target directory if it does not exist", () => {
+    const targetDir = join(makeTmpDir(), "nested", "deep");
+    dirs.push(targetDir);
+
+    scaffold({
+      projectName: "test-agent",
+      template: "code-builder",
+      description: "Test",
+      targetDir,
+      overwrite: false,
+    });
+
+    expect(existsSync(join(targetDir, "package.json"))).toBe(true);
+  });
+
+  it("code-builder includes TEMPLAR.md", () => {
+    const targetDir = makeTmpDir();
+    dirs.push(targetDir);
+
+    scaffold({
+      projectName: "test-agent",
+      template: "code-builder",
+      description: "Test",
+      targetDir,
+      overwrite: false,
+    });
+
+    expect(existsSync(join(targetDir, "TEMPLAR.md"))).toBe(true);
+  });
+});

--- a/packages/create-templar/src/__tests__/template-integrity.test.ts
+++ b/packages/create-templar/src/__tests__/template-integrity.test.ts
@@ -1,0 +1,62 @@
+import { readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { parseManifestYaml } from "@templar/manifest";
+import { describe, expect, it } from "vitest";
+import { getAvailableTemplates } from "../scaffold.js";
+
+const TEMPLATES = getAvailableTemplates();
+
+describe("template integrity", () => {
+  it("has at least one template available", () => {
+    expect(TEMPLATES.length).toBeGreaterThan(0);
+  });
+
+  it.each(TEMPLATES)("templates/%s/templar.yaml parses through manifest schema", (template) => {
+    const currentDir = dirname(fileURLToPath(import.meta.url));
+    const templatesDir = resolve(currentDir, "../../templates");
+    const yamlPath = join(templatesDir, template, "templar.yaml");
+    const yaml = readFileSync(yamlPath, "utf-8");
+
+    const manifest = parseManifestYaml(yaml, { skipInterpolation: true });
+    expect(manifest.name).toBe(template);
+    expect(manifest.version).toBeDefined();
+    expect(manifest.description).toBeDefined();
+  });
+
+  it.each(TEMPLATES)("templates/%s/package.json is valid JSON with template vars", (template) => {
+    const currentDir = dirname(fileURLToPath(import.meta.url));
+    const templatesDir = resolve(currentDir, "../../templates");
+    const pkgPath = join(templatesDir, template, "package.json");
+    const raw = readFileSync(pkgPath, "utf-8");
+
+    // Should contain template variables before substitution
+    expect(raw).toContain("{{name}}");
+    expect(raw).toContain("{{description}}");
+
+    // Should be valid JSON (template vars are in string positions)
+    const pkg = JSON.parse(raw);
+    expect(pkg.name).toBe("{{name}}");
+    expect(pkg.scripts).toBeDefined();
+    expect(pkg.dependencies).toBeDefined();
+  });
+
+  it.each(TEMPLATES)("templates/%s has _gitignore file", (template) => {
+    const currentDir = dirname(fileURLToPath(import.meta.url));
+    const templatesDir = resolve(currentDir, "../../templates");
+    const gitignorePath = join(templatesDir, template, "_gitignore");
+    const content = readFileSync(gitignorePath, "utf-8");
+
+    expect(content).toContain("node_modules");
+    expect(content).toContain(".env");
+  });
+
+  it.each(TEMPLATES)("templates/%s has _env.example file", (template) => {
+    const currentDir = dirname(fileURLToPath(import.meta.url));
+    const templatesDir = resolve(currentDir, "../../templates");
+    const envPath = join(templatesDir, template, "_env.example");
+    const content = readFileSync(envPath, "utf-8");
+
+    expect(content).toContain("ANTHROPIC_API_KEY");
+  });
+});

--- a/packages/create-templar/src/__tests__/utils.test.ts
+++ b/packages/create-templar/src/__tests__/utils.test.ts
@@ -1,0 +1,204 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  detectPackageManager,
+  formatTargetDir,
+  isTextFile,
+  replaceTemplateVars,
+  validateProjectName,
+} from "../utils.js";
+
+describe("validateProjectName", () => {
+  it("accepts a valid name", () => {
+    expect(validateProjectName("my-agent")).toEqual({ valid: true });
+  });
+
+  it("accepts names with dots, underscores, tildes", () => {
+    expect(validateProjectName("my.agent")).toEqual({ valid: true });
+    expect(validateProjectName("my_agent")).toEqual({ valid: true });
+    expect(validateProjectName("my~agent")).toEqual({ valid: true });
+  });
+
+  it("rejects empty string", () => {
+    const result = validateProjectName("");
+    expect(result.valid).toBe(false);
+    expect(result.message).toContain("empty");
+  });
+
+  it("rejects whitespace-only string", () => {
+    const result = validateProjectName("   ");
+    expect(result.valid).toBe(false);
+    expect(result.message).toContain("empty");
+  });
+
+  it("rejects dots-only names", () => {
+    const result = validateProjectName("...");
+    expect(result.valid).toBe(false);
+    expect(result.message).toContain("dots");
+  });
+
+  it("rejects names starting with dot", () => {
+    const result = validateProjectName(".hidden");
+    expect(result.valid).toBe(false);
+    expect(result.message).toContain("dot or hyphen");
+  });
+
+  it("rejects names starting with hyphen", () => {
+    const result = validateProjectName("-bad");
+    expect(result.valid).toBe(false);
+    expect(result.message).toContain("dot or hyphen");
+  });
+
+  it("rejects uppercase names", () => {
+    const result = validateProjectName("MyAgent");
+    expect(result.valid).toBe(false);
+    expect(result.message).toContain("lowercase");
+  });
+
+  it("rejects names with spaces", () => {
+    const result = validateProjectName("my agent");
+    expect(result.valid).toBe(false);
+    expect(result.message).toContain("lowercase letters");
+  });
+
+  it("rejects reserved names", () => {
+    const result = validateProjectName("node_modules");
+    expect(result.valid).toBe(false);
+    expect(result.message).toContain("reserved");
+  });
+
+  it("rejects names longer than 214 characters", () => {
+    const result = validateProjectName("a".repeat(215));
+    expect(result.valid).toBe(false);
+    expect(result.message).toContain("214");
+  });
+
+  it("accepts a 214-character name", () => {
+    expect(validateProjectName("a".repeat(214))).toEqual({ valid: true });
+  });
+});
+
+describe("detectPackageManager", () => {
+  const originalEnv = process.env.npm_config_user_agent;
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.npm_config_user_agent;
+    } else {
+      process.env.npm_config_user_agent = originalEnv;
+    }
+  });
+
+  it("detects pnpm", () => {
+    process.env.npm_config_user_agent = "pnpm/10.0.0 node/v22.0.0";
+    expect(detectPackageManager()).toBe("pnpm");
+  });
+
+  it("detects yarn", () => {
+    process.env.npm_config_user_agent = "yarn/4.0.0 node/v22.0.0";
+    expect(detectPackageManager()).toBe("yarn");
+  });
+
+  it("detects bun", () => {
+    process.env.npm_config_user_agent = "bun/1.0.0 node/v22.0.0";
+    expect(detectPackageManager()).toBe("bun");
+  });
+
+  it("detects npm", () => {
+    process.env.npm_config_user_agent = "npm/10.0.0 node/v22.0.0";
+    expect(detectPackageManager()).toBe("npm");
+  });
+
+  it("defaults to npm when agent is undefined", () => {
+    delete process.env.npm_config_user_agent;
+    expect(detectPackageManager()).toBe("npm");
+  });
+});
+
+describe("replaceTemplateVars", () => {
+  it("replaces a single variable", () => {
+    expect(replaceTemplateVars("Hello {{name}}", { name: "world" })).toBe("Hello world");
+  });
+
+  it("replaces multiple variables", () => {
+    const result = replaceTemplateVars("{{name}}: {{description}}", {
+      name: "my-agent",
+      description: "A test agent",
+    });
+    expect(result).toBe("my-agent: A test agent");
+  });
+
+  it("replaces multiple occurrences of the same variable", () => {
+    expect(replaceTemplateVars("{{name}} is {{name}}", { name: "foo" })).toBe("foo is foo");
+  });
+
+  it("returns content unchanged when no variables match", () => {
+    expect(replaceTemplateVars("no vars here", { name: "test" })).toBe("no vars here");
+  });
+
+  it("returns empty string unchanged", () => {
+    expect(replaceTemplateVars("", { name: "test" })).toBe("");
+  });
+
+  it("leaves unmatched placeholders as-is", () => {
+    expect(replaceTemplateVars("{{unknown}}", { name: "test" })).toBe("{{unknown}}");
+  });
+});
+
+describe("isTextFile", () => {
+  it("identifies .yaml as text", () => {
+    expect(isTextFile("templar.yaml")).toBe(true);
+  });
+
+  it("identifies .yml as text", () => {
+    expect(isTextFile("config.yml")).toBe(true);
+  });
+
+  it("identifies .md as text", () => {
+    expect(isTextFile("README.md")).toBe(true);
+  });
+
+  it("identifies .json as text", () => {
+    expect(isTextFile("package.json")).toBe(true);
+  });
+
+  it("identifies .ts as text", () => {
+    expect(isTextFile("index.ts")).toBe(true);
+  });
+
+  it("identifies .js as text", () => {
+    expect(isTextFile("index.js")).toBe(true);
+  });
+
+  it("identifies .env as text", () => {
+    expect(isTextFile(".env")).toBe(true);
+  });
+
+  it("identifies .example as text", () => {
+    expect(isTextFile(".env.example")).toBe(true);
+  });
+
+  it("identifies _-prefixed files as text", () => {
+    expect(isTextFile("_gitignore")).toBe(true);
+  });
+
+  it("rejects binary files", () => {
+    expect(isTextFile("image.png")).toBe(false);
+    expect(isTextFile("photo.jpg")).toBe(false);
+    expect(isTextFile("icon.ico")).toBe(false);
+  });
+});
+
+describe("formatTargetDir", () => {
+  it("trims whitespace", () => {
+    expect(formatTargetDir("  my-agent  ")).toBe("my-agent");
+  });
+
+  it("removes trailing slashes", () => {
+    expect(formatTargetDir("my-agent/")).toBe("my-agent");
+    expect(formatTargetDir("my-agent///")).toBe("my-agent");
+  });
+
+  it("handles clean input unchanged", () => {
+    expect(formatTargetDir("my-agent")).toBe("my-agent");
+  });
+});

--- a/packages/create-templar/src/args.ts
+++ b/packages/create-templar/src/args.ts
@@ -1,0 +1,69 @@
+/**
+ * Minimal argument parser (replaces mri).
+ */
+
+export interface ParsedArgs {
+  readonly positionals: readonly string[];
+  readonly flags: Readonly<Record<string, string | boolean>>;
+}
+
+const ALIASES: Readonly<Record<string, string>> = {
+  y: "yes",
+  o: "overwrite",
+  t: "template",
+  h: "help",
+};
+
+const BOOLEAN_FLAGS = new Set(["yes", "overwrite", "help"]);
+
+export function parseArgv(argv: readonly string[]): ParsedArgs {
+  const positionals: string[] = [];
+  const flags: Record<string, string | boolean> = {};
+
+  let i = 0;
+  while (i < argv.length) {
+    const arg = argv[i];
+    if (arg === undefined) break;
+
+    if (arg === "--") {
+      // Everything after -- is positional
+      positionals.push(...argv.slice(i + 1));
+      break;
+    }
+
+    if (arg.startsWith("--")) {
+      const key = arg.slice(2);
+      if (BOOLEAN_FLAGS.has(key)) {
+        flags[key] = true;
+      } else {
+        const next = argv[i + 1];
+        if (next !== undefined && !next.startsWith("-")) {
+          flags[key] = next;
+          i++;
+        } else {
+          flags[key] = true;
+        }
+      }
+    } else if (arg.startsWith("-") && arg.length === 2) {
+      const short = arg.slice(1);
+      const long = ALIASES[short] ?? short;
+      if (BOOLEAN_FLAGS.has(long)) {
+        flags[long] = true;
+      } else {
+        const next = argv[i + 1];
+        if (next !== undefined && !next.startsWith("-")) {
+          flags[long] = next;
+          i++;
+        } else {
+          flags[long] = true;
+        }
+      }
+    } else {
+      positionals.push(arg);
+    }
+
+    i++;
+  }
+
+  return { positionals, flags };
+}

--- a/packages/create-templar/src/cli.ts
+++ b/packages/create-templar/src/cli.ts
@@ -1,0 +1,215 @@
+/**
+ * CLI pipeline: parse args -> prompt for missing -> validate -> scaffold -> post-scaffold.
+ */
+
+import { existsSync, readdirSync } from "node:fs";
+import { resolve } from "node:path";
+import { parseArgv } from "./args.js";
+import { postScaffold } from "./post-scaffold.js";
+import * as p from "./prompts.js";
+import { getAvailableTemplates, scaffold } from "./scaffold.js";
+import { detectPackageManager, formatTargetDir, validateProjectName } from "./utils.js";
+
+export interface CliArgs {
+  readonly projectName: string | undefined;
+  readonly template: string | undefined;
+  readonly yes: boolean;
+  readonly overwrite: boolean;
+  readonly help: boolean;
+}
+
+const TEMPLATE_DESCRIPTIONS: Readonly<Record<string, string>> = {
+  "code-builder": "Overnight CI agent that builds, tests, and reports",
+  "research-tracker": "Publication monitoring every 6 hours",
+  "daily-digest": "Morning Slack summary at 8 AM",
+  "inbox-assistant": "Email triage every 30 minutes",
+  "knowledge-base": "RAG-powered document Q&A",
+};
+
+export function parseArgs(argv: readonly string[]): CliArgs {
+  const { positionals, flags } = parseArgv(argv);
+
+  return {
+    projectName: positionals[0],
+    template: typeof flags.template === "string" ? flags.template : undefined,
+    yes: flags.yes === true,
+    overwrite: flags.overwrite === true,
+    help: flags.help === true,
+  };
+}
+
+function isCi(): boolean {
+  return Boolean(process.env.CI);
+}
+
+function isDirEmpty(dir: string): boolean {
+  if (!existsSync(dir)) return true;
+  const entries = readdirSync(dir);
+  return entries.length === 0;
+}
+
+function printHelp(): void {
+  console.log(`
+  create-templar - Scaffold a new Templar agent project
+
+  Usage:
+    create-templar [project-name] [options]
+
+  Options:
+    -t, --template <name>  Template to use
+    -y, --yes              Skip prompts, use defaults
+    -o, --overwrite        Overwrite existing directory
+    -h, --help             Show this help message
+
+  Templates:
+    code-builder           Overnight CI agent
+    research-tracker       Publication monitoring
+    daily-digest           Morning Slack summary
+    inbox-assistant        Email triage
+    knowledge-base         RAG document Q&A
+
+  Examples:
+    create-templar my-agent
+    create-templar my-agent --template daily-digest --yes
+`);
+}
+
+export async function main(argv: readonly string[]): Promise<void> {
+  const cliArgs = parseArgs(argv);
+
+  if (cliArgs.help) {
+    printHelp();
+    return;
+  }
+
+  const nonInteractive = cliArgs.yes || isCi();
+
+  p.intro("create-templar");
+
+  // 1. Project name
+  let projectName = cliArgs.projectName;
+  if (!projectName) {
+    if (nonInteractive) {
+      p.cancel("Project name is required in non-interactive mode.");
+      process.exit(1);
+    }
+    projectName = await p.text({
+      message: "Project name",
+      placeholder: "my-agent",
+      validate(value) {
+        const result = validateProjectName(value);
+        if (!result.valid) return result.message;
+      },
+    });
+  } else {
+    const validation = validateProjectName(projectName);
+    if (!validation.valid) {
+      p.cancel(validation.message ?? "Invalid project name.");
+      process.exit(1);
+    }
+  }
+
+  // 2. Template selection
+  const availableTemplates = getAvailableTemplates();
+  let template = cliArgs.template;
+  if (!template) {
+    if (nonInteractive) {
+      template = availableTemplates[0] ?? "code-builder";
+    } else {
+      template = await p.select({
+        message: "Select a template",
+        options: availableTemplates.map((t) => ({
+          value: t,
+          label: t
+            .split("-")
+            .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+            .join(" "),
+          hint: TEMPLATE_DESCRIPTIONS[t] ?? "",
+        })),
+      });
+    }
+  }
+
+  if (!availableTemplates.includes(template)) {
+    p.cancel(`Unknown template "${template}". Available: ${availableTemplates.join(", ")}`);
+    process.exit(1);
+  }
+
+  // 3. Description
+  let description: string;
+  if (nonInteractive) {
+    description = TEMPLATE_DESCRIPTIONS[template] ?? "A Templar agent project";
+  } else {
+    description = await p.text({
+      message: "Description (optional)",
+      defaultValue: TEMPLATE_DESCRIPTIONS[template] ?? "A Templar agent project",
+    });
+  }
+
+  // 4. Target directory
+  const targetDir = resolve(process.cwd(), formatTargetDir(projectName));
+  let overwrite = cliArgs.overwrite;
+
+  if (!isDirEmpty(targetDir) && !overwrite) {
+    if (nonInteractive) {
+      p.cancel(`Directory "${projectName}" is not empty. Use --overwrite to replace.`);
+      process.exit(1);
+    }
+    overwrite = await p.confirm({
+      message: `Directory "${projectName}" is not empty. Overwrite?`,
+      initialValue: false,
+    });
+    if (!overwrite) {
+      p.cancel("Operation cancelled.");
+      process.exit(0);
+    }
+  }
+
+  // 5. Git init
+  let initGit: boolean;
+  if (nonInteractive) {
+    initGit = true;
+  } else {
+    initGit = await p.confirm({
+      message: "Initialize a git repository?",
+      initialValue: true,
+    });
+  }
+
+  // 6. Install deps
+  const packageManager = detectPackageManager();
+  let installDeps: boolean;
+  if (nonInteractive) {
+    installDeps = true;
+  } else {
+    installDeps = await p.confirm({
+      message: `Install dependencies? (using ${packageManager})`,
+      initialValue: true,
+    });
+  }
+
+  // Scaffold
+  const s = p.spinner();
+  s.start("Scaffolding project...");
+
+  const result = scaffold({
+    projectName,
+    template,
+    description,
+    targetDir,
+    overwrite,
+  });
+
+  s.stop(`Scaffolded ${result.files.length} files.`);
+
+  // Post-scaffold
+  postScaffold({
+    targetDir,
+    projectName,
+    packageManager,
+    initGit,
+    installDeps,
+  });
+
+  p.outro("Done! Your agent is ready.");
+}

--- a/packages/create-templar/src/index.ts
+++ b/packages/create-templar/src/index.ts
@@ -1,0 +1,6 @@
+import { main } from "./cli.js";
+
+main(process.argv.slice(2)).catch((error: unknown) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/create-templar/src/post-scaffold.ts
+++ b/packages/create-templar/src/post-scaffold.ts
@@ -1,0 +1,63 @@
+/**
+ * Post-scaffold actions: git init, dependency install, next steps.
+ */
+
+import { spawnSync } from "node:child_process";
+import pc from "picocolors";
+import type { PackageManager } from "./utils.js";
+
+export interface PostScaffoldOptions {
+  readonly targetDir: string;
+  readonly projectName: string;
+  readonly packageManager: PackageManager;
+  readonly initGit: boolean;
+  readonly installDeps: boolean;
+}
+
+function exec(command: string, args: readonly string[], cwd: string): { ok: boolean } {
+  const result = spawnSync(command, [...args], { cwd, stdio: "ignore" });
+  return { ok: result.status === 0 };
+}
+
+export function postScaffold(options: PostScaffoldOptions): void {
+  const { targetDir, projectName, packageManager, initGit, installDeps } = options;
+
+  if (initGit) {
+    const init = exec("git", ["init"], targetDir);
+    if (init.ok) {
+      exec("git", ["add", "-A"], targetDir);
+      exec("git", ["commit", "-m", "Initial commit from create-templar"], targetDir);
+    } else {
+      console.log(`  ${pc.yellow("!")} Failed to initialize git repository`);
+    }
+  }
+
+  if (installDeps) {
+    const install = exec(packageManager, ["install"], targetDir);
+    if (!install.ok) {
+      console.log(
+        `  ${pc.yellow("!")} Failed to install dependencies. Run ${packageManager} install manually.`,
+      );
+    }
+  }
+
+  printNextSteps({ projectName, packageManager, installDeps });
+}
+
+function printNextSteps(opts: {
+  readonly projectName: string;
+  readonly packageManager: PackageManager;
+  readonly installDeps: boolean;
+}): void {
+  const { projectName, packageManager, installDeps } = opts;
+
+  console.log();
+  console.log(`  ${pc.bold("Next steps:")}`);
+  console.log();
+  console.log(`  ${pc.cyan(`cd ${projectName}`)}`);
+  if (!installDeps) {
+    console.log(`  ${pc.cyan(`${packageManager} install`)}`);
+  }
+  console.log(`  ${pc.cyan(`${packageManager} start`)}`);
+  console.log();
+}

--- a/packages/create-templar/src/prompts.ts
+++ b/packages/create-templar/src/prompts.ts
@@ -1,0 +1,120 @@
+/**
+ * Minimal interactive prompt helpers using node:readline.
+ */
+
+import { stdin, stdout } from "node:process";
+import { createInterface } from "node:readline/promises";
+import pc from "picocolors";
+
+function createRl() {
+  return createInterface({ input: stdin, output: stdout });
+}
+
+export async function text(opts: {
+  readonly message: string;
+  readonly placeholder?: string;
+  readonly defaultValue?: string;
+  readonly validate?: (value: string) => string | undefined;
+}): Promise<string> {
+  const rl = createRl();
+  const suffix = opts.defaultValue ? pc.dim(` (${opts.defaultValue})`) : "";
+  try {
+    for (;;) {
+      const answer = await rl.question(`${pc.cyan("?")} ${opts.message}${suffix}: `);
+      const value = answer.trim() || opts.defaultValue || "";
+      if (opts.validate) {
+        const error = opts.validate(value);
+        if (error) {
+          console.log(`  ${pc.red(error)}`);
+          continue;
+        }
+      }
+      return value;
+    }
+  } finally {
+    rl.close();
+  }
+}
+
+export async function select<T extends string>(opts: {
+  readonly message: string;
+  readonly options: ReadonlyArray<{
+    readonly value: T;
+    readonly label: string;
+    readonly hint?: string;
+  }>;
+}): Promise<T> {
+  const rl = createRl();
+  try {
+    console.log(`${pc.cyan("?")} ${opts.message}`);
+    for (let i = 0; i < opts.options.length; i++) {
+      const opt = opts.options[i];
+      if (!opt) continue;
+      const hint = opt.hint ? pc.dim(` — ${opt.hint}`) : "";
+      console.log(`  ${pc.bold(`${i + 1})`)} ${opt.label}${hint}`);
+    }
+    for (;;) {
+      const answer = await rl.question(`${pc.cyan("?")} Choose [1-${opts.options.length}]: `);
+      const num = Number.parseInt(answer.trim(), 10);
+      if (num >= 1 && num <= opts.options.length) {
+        const selected = opts.options[num - 1];
+        if (selected) return selected.value;
+      }
+      console.log(`  ${pc.red(`Please enter a number between 1 and ${opts.options.length}`)}`);
+    }
+  } finally {
+    rl.close();
+  }
+}
+
+export async function confirm(opts: {
+  readonly message: string;
+  readonly initialValue?: boolean;
+}): Promise<boolean> {
+  const rl = createRl();
+  const hint = opts.initialValue ? "Y/n" : "y/N";
+  try {
+    const answer = await rl.question(`${pc.cyan("?")} ${opts.message} (${hint}): `);
+    const trimmed = answer.trim().toLowerCase();
+    if (trimmed === "") return opts.initialValue ?? false;
+    return trimmed === "y" || trimmed === "yes";
+  } finally {
+    rl.close();
+  }
+}
+
+export function intro(title: string): void {
+  console.log();
+  console.log(`  ${pc.bgCyan(pc.black(` ${title} `))}`);
+  console.log();
+}
+
+export function outro(message: string): void {
+  console.log();
+  console.log(`  ${message}`);
+  console.log();
+}
+
+export function cancel(message: string): void {
+  console.log();
+  console.log(`  ${pc.red(message)}`);
+}
+
+export function spinner() {
+  let timer: ReturnType<typeof setInterval> | undefined;
+  const frames = [".", "..", "..."];
+  let i = 0;
+
+  return {
+    start(message: string) {
+      process.stdout.write(`  ${message}`);
+      timer = setInterval(() => {
+        process.stdout.write(`\r  ${message}${frames[i++ % frames.length] ?? ""}`);
+      }, 300);
+    },
+    stop(message: string) {
+      if (timer) clearInterval(timer);
+      process.stdout.write(`\r  ${pc.green("✓")} ${message}\n`);
+    },
+  };
+}

--- a/packages/create-templar/src/scaffold.ts
+++ b/packages/create-templar/src/scaffold.ts
@@ -1,0 +1,127 @@
+/**
+ * Pure scaffold function: options -> files on disk.
+ */
+
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { isTextFile, replaceTemplateVars } from "./utils.js";
+
+export interface ScaffoldOptions {
+  readonly projectName: string;
+  readonly template: string;
+  readonly description: string;
+  readonly targetDir: string;
+  readonly overwrite: boolean;
+}
+
+export interface ScaffoldResult {
+  readonly files: readonly string[];
+  readonly targetDir: string;
+}
+
+/** File renames applied during scaffolding. */
+const FILE_RENAMES: Readonly<Record<string, string>> = {
+  _gitignore: ".gitignore",
+  "_env.example": ".env.example",
+};
+
+function getTemplatesDir(): string {
+  const currentDir = dirname(fileURLToPath(import.meta.url));
+  // In dev: src/ -> packages/create-templar/templates/
+  // In dist: dist/ -> packages/create-templar/templates/
+  return resolve(currentDir, "..", "templates");
+}
+
+function collectFiles(dir: string, base: string = ""): readonly string[] {
+  const entries = readdirSync(dir, { withFileTypes: true });
+  const files: string[] = [];
+  for (const entry of entries) {
+    const relative = base ? `${base}/${entry.name}` : entry.name;
+    if (entry.isDirectory()) {
+      files.push(...collectFiles(join(dir, entry.name), relative));
+    } else {
+      files.push(relative);
+    }
+  }
+  return files;
+}
+
+export function scaffold(options: ScaffoldOptions): ScaffoldResult {
+  const { projectName, template, description, targetDir, overwrite } = options;
+
+  const templatesDir = getTemplatesDir();
+  const templateDir = join(templatesDir, template);
+
+  if (!existsSync(templateDir)) {
+    throw new Error(`Template "${template}" not found at ${templateDir}`);
+  }
+
+  // Handle target directory
+  if (existsSync(targetDir)) {
+    if (overwrite) {
+      rmSync(targetDir, { recursive: true, force: true });
+    }
+  }
+  mkdirSync(targetDir, { recursive: true });
+
+  const vars: Record<string, string> = {
+    name: projectName,
+    description,
+  };
+
+  const templateFiles = collectFiles(templateDir);
+  const writtenFiles: string[] = [];
+
+  for (const relativePath of templateFiles) {
+    // Apply file renames
+    const parts = relativePath.split("/");
+    const fileName = parts.at(-1) ?? "";
+    const renamed = FILE_RENAMES[fileName] ?? fileName;
+    parts[parts.length - 1] = renamed;
+    const destRelative = parts.join("/");
+
+    const srcPath = join(templateDir, relativePath);
+    const destPath = join(targetDir, destRelative);
+
+    // Guard against path traversal
+    if (!resolve(srcPath).startsWith(resolve(templateDir))) {
+      throw new Error(`Invalid template path: ${relativePath}`);
+    }
+    if (!resolve(destPath).startsWith(resolve(targetDir))) {
+      throw new Error(`Invalid destination path: ${destRelative}`);
+    }
+
+    // Ensure parent directory exists
+    mkdirSync(dirname(destPath), { recursive: true });
+
+    if (isTextFile(fileName) || isTextFile(renamed)) {
+      const content = readFileSync(srcPath, "utf-8");
+      const substituted = replaceTemplateVars(content, vars);
+      writeFileSync(destPath, substituted, "utf-8");
+    } else {
+      cpSync(srcPath, destPath);
+    }
+
+    writtenFiles.push(destRelative);
+  }
+
+  return { files: writtenFiles, targetDir };
+}
+
+export function getAvailableTemplates(): readonly string[] {
+  const templatesDir = getTemplatesDir();
+  if (!existsSync(templatesDir)) return [];
+  return readdirSync(templatesDir, { withFileTypes: true })
+    .filter((d) => d.isDirectory())
+    .map((d) => d.name)
+    .sort();
+}

--- a/packages/create-templar/src/utils.ts
+++ b/packages/create-templar/src/utils.ts
@@ -1,0 +1,112 @@
+/**
+ * Pure utility functions for the create-templar CLI.
+ */
+
+const INVALID_NAME_CHARS = /[^a-z0-9\-._~]/;
+const RESERVED_NAMES = new Set([
+  "node_modules",
+  "favicon.ico",
+  "package.json",
+  "package-lock.json",
+]);
+
+export interface ValidationResult {
+  readonly valid: boolean;
+  readonly message?: string;
+}
+
+export function validateProjectName(name: string): ValidationResult {
+  if (!name || name.trim().length === 0) {
+    return { valid: false, message: "Project name cannot be empty" };
+  }
+
+  const trimmed = name.trim();
+
+  if (/^\.+$/.test(trimmed)) {
+    return { valid: false, message: "Project name cannot be only dots" };
+  }
+
+  if (trimmed.startsWith(".") || trimmed.startsWith("-")) {
+    return {
+      valid: false,
+      message: "Project name cannot start with a dot or hyphen",
+    };
+  }
+
+  if (trimmed !== trimmed.toLowerCase()) {
+    return { valid: false, message: "Project name must be lowercase" };
+  }
+
+  if (INVALID_NAME_CHARS.test(trimmed)) {
+    return {
+      valid: false,
+      message:
+        "Project name can only contain lowercase letters, numbers, hyphens, dots, underscores, and tildes",
+    };
+  }
+
+  if (trimmed.length > 214) {
+    return {
+      valid: false,
+      message: "Project name must be 214 characters or fewer",
+    };
+  }
+
+  if (RESERVED_NAMES.has(trimmed)) {
+    return { valid: false, message: `"${trimmed}" is a reserved name` };
+  }
+
+  return { valid: true };
+}
+
+export type PackageManager = "npm" | "pnpm" | "yarn" | "bun";
+
+export function detectPackageManager(): PackageManager {
+  const agent = process.env.npm_config_user_agent ?? "";
+  if (agent.startsWith("pnpm/")) return "pnpm";
+  if (agent.startsWith("yarn/")) return "yarn";
+  if (agent.startsWith("bun/")) return "bun";
+  return "npm";
+}
+
+export function replaceTemplateVars(
+  content: string,
+  vars: Readonly<Record<string, string>>,
+): string {
+  let result = content;
+  for (const [key, value] of Object.entries(vars)) {
+    result = result.replaceAll(`{{${key}}}`, value);
+  }
+  return result;
+}
+
+const TEXT_EXTENSIONS = new Set([
+  ".yaml",
+  ".yml",
+  ".md",
+  ".json",
+  ".ts",
+  ".js",
+  ".mjs",
+  ".cjs",
+  ".env",
+  ".example",
+  ".txt",
+  ".gitignore",
+  ".npmrc",
+  ".editorconfig",
+]);
+
+export function isTextFile(filename: string): boolean {
+  const lower = filename.toLowerCase();
+  for (const ext of TEXT_EXTENSIONS) {
+    if (lower.endsWith(ext)) return true;
+  }
+  // Dotfiles without extension are typically text
+  if (lower.startsWith("_") || lower.startsWith(".")) return true;
+  return false;
+}
+
+export function formatTargetDir(name: string): string {
+  return name.trim().replace(/\/+$/g, "");
+}

--- a/packages/create-templar/templates/code-builder/README.md
+++ b/packages/create-templar/templates/code-builder/README.md
@@ -1,0 +1,16 @@
+# Code Builder
+
+A scheduled agent that runs nightly builds and test suites, then reports results to Slack.
+
+## Setup
+
+1. Copy `.env.example` to `.env` and fill in your tokens
+2. Copy `templar.yaml` to your project root
+3. Run `templar start`
+
+## What it does
+
+- Runs every night at 2:00 AM UTC
+- Executes the project build and test suite
+- Reports results to Slack with failure context
+- Suggests fixes for common build errors

--- a/packages/create-templar/templates/code-builder/TEMPLAR.md
+++ b/packages/create-templar/templates/code-builder/TEMPLAR.md
@@ -1,0 +1,15 @@
+# Code Builder Agent
+
+## Role
+You are a CI/CD build agent. Your primary responsibility is running automated builds, tests, and linting for the project.
+
+## Behavior
+- Execute the build pipeline in order: lint, build, test
+- Report results clearly with pass/fail status for each step
+- On failure, extract the relevant error context and suggest fixes
+- Never modify source code directly — only report findings
+
+## Communication
+- Post results to the configured Slack channel
+- Use code blocks for error output
+- Summarize the overall status in the first line (e.g., "Build PASSED" or "Build FAILED: 2 test failures")

--- a/packages/create-templar/templates/code-builder/_env.example
+++ b/packages/create-templar/templates/code-builder/_env.example
@@ -1,0 +1,8 @@
+# Slack Bot Token — required for the slack channel adapter
+SLACK_BOT_TOKEN=xoxb-your-token-here
+
+# Anthropic API Key — required for the model
+ANTHROPIC_API_KEY=sk-ant-your-key-here
+
+# Path to the project to build (defaults to current directory)
+PROJECT_PATH=.

--- a/packages/create-templar/templates/code-builder/_gitignore
+++ b/packages/create-templar/templates/code-builder/_gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+.env
+*.log

--- a/packages/create-templar/templates/code-builder/package.json
+++ b/packages/create-templar/templates/code-builder/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "{{name}}",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "{{description}}",
+  "scripts": {
+    "start": "templar start",
+    "dev": "templar dev"
+  },
+  "dependencies": {
+    "@templar/engine": "latest"
+  }
+}

--- a/packages/create-templar/templates/code-builder/templar.yaml
+++ b/packages/create-templar/templates/code-builder/templar.yaml
@@ -1,0 +1,30 @@
+name: code-builder
+version: 1.0.0
+description: Overnight CI agent that builds, tests, and reports results
+
+model: anthropic/claude-sonnet-4-5
+channels:
+  - slack
+
+schedule: "0 2 * * *"
+prompt: >
+  You are a CI/CD assistant. Run the project build and test suite,
+  then report the results. Highlight any failures with relevant
+  error context. Suggest fixes for common build errors when possible.
+
+tools:
+  - name: shell_exec
+    description: Execute shell commands for building and testing
+    parameters:
+      allowedCommands:
+        - npm test
+        - npm run build
+        - npm run lint
+
+identity:
+  default:
+    name: Code Builder
+    bio: Nightly builds and test reports at 2 AM
+
+bootstrap:
+  instructions: TEMPLAR.md

--- a/packages/create-templar/templates/daily-digest/README.md
+++ b/packages/create-templar/templates/daily-digest/README.md
@@ -1,0 +1,16 @@
+# Daily Digest
+
+A scheduled agent that delivers a morning summary of activity across your Slack workspace.
+
+## Setup
+
+1. Copy `.env.example` to `.env` and fill in your tokens
+2. Copy `templar.yaml` to your project root
+3. Run `templar start`
+
+## What it does
+
+- Runs every morning at 8:00 AM UTC
+- Collects messages from the past 24 hours
+- Groups updates by channel and priority
+- Posts a concise summary to Slack

--- a/packages/create-templar/templates/daily-digest/_env.example
+++ b/packages/create-templar/templates/daily-digest/_env.example
@@ -1,0 +1,5 @@
+# Slack Bot Token — required for the slack channel adapter
+SLACK_BOT_TOKEN=xoxb-your-token-here
+
+# Anthropic API Key — required for the model
+ANTHROPIC_API_KEY=sk-ant-your-key-here

--- a/packages/create-templar/templates/daily-digest/_gitignore
+++ b/packages/create-templar/templates/daily-digest/_gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+.env
+*.log

--- a/packages/create-templar/templates/daily-digest/package.json
+++ b/packages/create-templar/templates/daily-digest/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "{{name}}",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "{{description}}",
+  "scripts": {
+    "start": "templar start",
+    "dev": "templar dev"
+  },
+  "dependencies": {
+    "@templar/engine": "latest"
+  }
+}

--- a/packages/create-templar/templates/daily-digest/templar.yaml
+++ b/packages/create-templar/templates/daily-digest/templar.yaml
@@ -1,0 +1,18 @@
+name: daily-digest
+version: 1.0.0
+description: Summarizes key updates from connected channels on a daily schedule
+
+model: anthropic/claude-sonnet-4-5
+channels:
+  - slack
+
+schedule: "0 8 * * *"
+prompt: >
+  You are a daily digest bot. Each morning, collect the most important
+  messages, threads, and updates from the previous 24 hours. Produce a
+  concise, scannable summary grouped by channel and priority.
+
+identity:
+  default:
+    name: Daily Digest
+    bio: Your morning briefing, every day at 8 AM

--- a/packages/create-templar/templates/inbox-assistant/README.md
+++ b/packages/create-templar/templates/inbox-assistant/README.md
@@ -1,0 +1,16 @@
+# Inbox Assistant
+
+A scheduled agent that triages your email inbox and drafts replies for action items.
+
+## Setup
+
+1. Copy `.env.example` to `.env` and fill in your credentials
+2. Copy `templar.yaml` to your project root
+3. Run `templar start`
+
+## What it does
+
+- Checks for new emails every 30 minutes
+- Categorizes each email by priority level
+- Drafts reply suggestions for action-required items
+- Never sends emails automatically (human-in-the-loop)

--- a/packages/create-templar/templates/inbox-assistant/_env.example
+++ b/packages/create-templar/templates/inbox-assistant/_env.example
@@ -1,0 +1,7 @@
+# Email credentials — required for the email channel adapter
+EMAIL_HOST=imap.gmail.com
+EMAIL_USER=you@example.com
+EMAIL_PASSWORD=your-app-password
+
+# Anthropic API Key — required for the model
+ANTHROPIC_API_KEY=sk-ant-your-key-here

--- a/packages/create-templar/templates/inbox-assistant/_gitignore
+++ b/packages/create-templar/templates/inbox-assistant/_gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+.env
+*.log

--- a/packages/create-templar/templates/inbox-assistant/package.json
+++ b/packages/create-templar/templates/inbox-assistant/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "{{name}}",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "{{description}}",
+  "scripts": {
+    "start": "templar start",
+    "dev": "templar dev"
+  },
+  "dependencies": {
+    "@templar/engine": "latest"
+  }
+}

--- a/packages/create-templar/templates/inbox-assistant/templar.yaml
+++ b/packages/create-templar/templates/inbox-assistant/templar.yaml
@@ -1,0 +1,26 @@
+name: inbox-assistant
+version: 1.0.0
+description: Email triage agent that categorizes and drafts replies
+
+model: anthropic/claude-sonnet-4-5
+channels:
+  - email
+
+schedule: "*/30 * * * *"
+prompt: >
+  You are an email triage assistant. Categorize incoming emails as
+  urgent, action-required, informational, or low-priority. Draft
+  concise reply suggestions for action-required items. Never send
+  replies automatically — always present drafts for human approval.
+
+permissions:
+  allowed:
+    - email_read
+    - email_draft
+  denied:
+    - email_send
+
+identity:
+  default:
+    name: Inbox Assistant
+    bio: Smart email triage every 30 minutes

--- a/packages/create-templar/templates/knowledge-base/README.md
+++ b/packages/create-templar/templates/knowledge-base/README.md
@@ -1,0 +1,17 @@
+# Knowledge Base
+
+A conversational agent that answers questions from your indexed documents using RAG (retrieval-augmented generation).
+
+## Setup
+
+1. Copy `.env.example` to `.env` and fill in your tokens
+2. Copy `templar.yaml` to your project root
+3. Place documents in `./data/` and build the index
+4. Run `templar start`
+
+## What it does
+
+- Listens for questions in Slack
+- Searches indexed documents for relevant context
+- Provides cited answers with source references
+- Remembers conversation context per user

--- a/packages/create-templar/templates/knowledge-base/_env.example
+++ b/packages/create-templar/templates/knowledge-base/_env.example
@@ -1,0 +1,5 @@
+# Slack Bot Token — required for the slack channel adapter
+SLACK_BOT_TOKEN=xoxb-your-token-here
+
+# Anthropic API Key — required for the model
+ANTHROPIC_API_KEY=sk-ant-your-key-here

--- a/packages/create-templar/templates/knowledge-base/_gitignore
+++ b/packages/create-templar/templates/knowledge-base/_gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+.env
+*.log

--- a/packages/create-templar/templates/knowledge-base/package.json
+++ b/packages/create-templar/templates/knowledge-base/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "{{name}}",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "{{description}}",
+  "scripts": {
+    "start": "templar start",
+    "dev": "templar dev"
+  },
+  "dependencies": {
+    "@templar/engine": "latest"
+  }
+}

--- a/packages/create-templar/templates/knowledge-base/templar.yaml
+++ b/packages/create-templar/templates/knowledge-base/templar.yaml
@@ -1,0 +1,25 @@
+name: knowledge-base
+version: 1.0.0
+description: Personal knowledge assistant with RAG-powered document retrieval
+
+model: anthropic/claude-sonnet-4-5
+channels:
+  - slack
+
+prompt: >
+  You are a knowledge base assistant. When users ask questions, search
+  the indexed documents and provide accurate, cited answers. Always
+  include the source document name and section in your responses.
+
+middleware:
+  - name: memory
+    config:
+      scope: per-user
+  - name: rag
+    config:
+      indexPath: ./data/index
+
+identity:
+  default:
+    name: Knowledge Bot
+    bio: Ask me anything about your documents

--- a/packages/create-templar/templates/research-tracker/README.md
+++ b/packages/create-templar/templates/research-tracker/README.md
@@ -1,0 +1,16 @@
+# Research Tracker
+
+A scheduled agent that monitors new research publications and delivers summaries via email and Discord.
+
+## Setup
+
+1. Copy `.env.example` to `.env` and fill in your credentials
+2. Copy `templar.yaml` to your project root
+3. Run `templar start`
+
+## What it does
+
+- Checks for new publications every 6 hours
+- Searches configured research topics and keywords
+- Summarizes papers in 2-3 sentences with key findings
+- Delivers updates via email and Discord

--- a/packages/create-templar/templates/research-tracker/_env.example
+++ b/packages/create-templar/templates/research-tracker/_env.example
@@ -1,0 +1,10 @@
+# Email credentials — required for the email channel adapter
+EMAIL_HOST=imap.gmail.com
+EMAIL_USER=you@example.com
+EMAIL_PASSWORD=your-app-password
+
+# Discord Bot Token — required for the discord channel adapter
+DISCORD_BOT_TOKEN=your-discord-token-here
+
+# Anthropic API Key — required for the model
+ANTHROPIC_API_KEY=sk-ant-your-key-here

--- a/packages/create-templar/templates/research-tracker/_gitignore
+++ b/packages/create-templar/templates/research-tracker/_gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+.env
+*.log

--- a/packages/create-templar/templates/research-tracker/package.json
+++ b/packages/create-templar/templates/research-tracker/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "{{name}}",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "{{description}}",
+  "scripts": {
+    "start": "templar start",
+    "dev": "templar dev"
+  },
+  "dependencies": {
+    "@templar/engine": "latest"
+  }
+}

--- a/packages/create-templar/templates/research-tracker/templar.yaml
+++ b/packages/create-templar/templates/research-tracker/templar.yaml
@@ -1,0 +1,24 @@
+name: research-tracker
+version: 1.0.0
+description: Monitors research publications and reports new findings
+
+model: anthropic/claude-sonnet-4-5
+channels:
+  - email
+  - discord
+
+schedule: "0 */6 * * *"
+prompt: >
+  You are a research monitoring agent. Track new publications and
+  preprints matching the configured topics. Summarize each paper in
+  2-3 sentences, highlight key findings, and flag papers that are
+  highly relevant to the user's research interests.
+
+tools:
+  - name: web_search
+    description: Search the web for new research publications
+
+identity:
+  default:
+    name: Research Tracker
+    bio: Monitoring new publications every 6 hours

--- a/packages/create-templar/tsconfig.json
+++ b/packages/create-templar/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "isolatedDeclarations": false,
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "references": [{ "path": "../manifest" }]
+}

--- a/packages/create-templar/tsup.config.ts
+++ b/packages/create-templar/tsup.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  banner: { js: "#!/usr/bin/env node" },
+  sourcemap: true,
+  clean: true,
+  treeshake: true,
+  target: "node22",
+  noExternal: [/.*/],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -309,6 +309,19 @@ importers:
         specifier: ^25.2.2
         version: 25.2.2
 
+  packages/create-templar:
+    dependencies:
+      picocolors:
+        specifier: ^1.1.0
+        version: 1.1.1
+    devDependencies:
+      '@templar/manifest':
+        specifier: workspace:*
+        version: link:../manifest
+      '@types/node':
+        specifier: ^25.2.2
+        version: 25.2.2
+
   packages/doctor:
     dependencies:
       '@templar/core':

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,8 @@
     { "path": "packages/test-utils" },
     { "path": "packages/agui" },
     { "path": "packages/sanitize" },
-    { "path": "packages/canvas" }
+    { "path": "packages/canvas" },
+    { "path": "packages/create-templar" }
   ],
   "include": [],
   "exclude": ["node_modules", "dist", "coverage"]


### PR DESCRIPTION
## Summary

- Add `create-templar` package — a CLI scaffolder that generates complete Templar agent projects from bundled templates
- Bundles 5 templates: code-builder, research-tracker, daily-digest, inbox-assistant, knowledge-base
- Supports interactive prompts and non-interactive mode (`--yes` / `CI=true`)
- Scaffolds `package.json` (with `{{name}}`/`{{description}}` substitution), `templar.yaml`, `.env.example`, `.gitignore`, and README
- Post-scaffold: optional git init + dependency install with auto-detected package manager
- 82 tests across 4 test files (utils, CLI args, scaffold integration, template integrity via `@templar/manifest`)
- Single dependency (`picocolors`), 64KB bundle with shebang

Closes #165

## Test plan

- [ ] `pnpm --filter create-templar build` produces `dist/index.js` with shebang
- [ ] `pnpm --filter create-templar test` — 82 tests pass
- [ ] `pnpm --filter create-templar typecheck` — clean
- [ ] `pnpm biome check packages/create-templar/` — no issues
- [ ] Smoke test: `node packages/create-templar/dist/index.js my-agent --template code-builder --yes` scaffolds correctly
- [ ] `node packages/create-templar/dist/index.js --help` prints usage
- [ ] All 5 templates parse through `@templar/manifest` schema (template-integrity tests)
- [ ] Bundle size < 500KB (actual: 64KB)