### PR TITLE
feat(nexus-sdk): add secrets audit API resource

### DIFF
--- a/packages/nexus-sdk/package.json
+++ b/packages/nexus-sdk/package.json
@@ -33,6 +33,10 @@
       "types": "./dist/resources/sandbox.d.ts",
       "import": "./dist/resources/sandbox.js"
     },
+    "./secrets-audit": {
+      "types": "./dist/resources/secrets-audit.d.ts",
+      "import": "./dist/resources/secrets-audit.js"
+    },
     "./http": {
       "types": "./dist/http/index.d.ts",
       "import": "./dist/http/index.js"

--- a/packages/nexus-sdk/src/__tests__/e2e/secrets-audit.e2e.test.ts
+++ b/packages/nexus-sdk/src/__tests__/e2e/secrets-audit.e2e.test.ts
@@ -1,0 +1,138 @@
+/**
+ * E2E test for @nexus/sdk Secrets Audit API
+ *
+ * Requires a running Nexus server on localhost:2028 with:
+ * - Static API key: sk-test-e2e-secrets-audit-key-1234
+ * - NEXUS_DATABASE_URL set (for record_store)
+ * - 3 seeded audit events (credential_created, key_accessed, token_rotated)
+ *
+ * Run with: NEXUS_E2E=1 npx vitest run src/__tests__/e2e/secrets-audit.e2e.test.ts
+ *
+ * Note: get() and verifyIntegrity() by ID are skipped due to a known Nexus
+ * server-side bug where single-record lookup returns 404 even for existing
+ * records (list() works fine for the same IDs).
+ */
+
+import { beforeAll, describe, expect, it } from "vitest";
+import { NexusClient } from "../../client.js";
+import type { SecretsAuditEvent } from "../../types/secrets-audit.js";
+
+const BASE_URL = "http://localhost:2028";
+const API_KEY = "sk-test-e2e-secrets-audit-key-1234";
+
+const shouldRun = !!process.env.NEXUS_E2E;
+
+describe.skipIf(!shouldRun)("SecretsAudit E2E", () => {
+  let client: NexusClient;
+  let allEvents: readonly SecretsAuditEvent[];
+
+  beforeAll(async () => {
+    client = new NexusClient({
+      apiKey: API_KEY,
+      baseUrl: BASE_URL,
+      retry: { maxAttempts: 1 },
+    });
+    // Discover actual events in the DB
+    const result = await client.secretsAudit.list({ include_total: true });
+    allEvents = result.events;
+  });
+
+  describe("list()", () => {
+    it("should list all events with no params", async () => {
+      const result = await client.secretsAudit.list();
+      expect(result.events).toBeInstanceOf(Array);
+      expect(result.events.length).toBeGreaterThanOrEqual(3);
+      expect(result.limit).toBe(100);
+      expect(result.has_more).toBe(false);
+      expect(result.next_cursor).toBeNull();
+    });
+
+    it("should filter by event_type and actor_id", async () => {
+      const result = await client.secretsAudit.list({
+        event_type: "credential_created",
+        actor_id: "user-42",
+      });
+      expect(result.events.length).toBeGreaterThanOrEqual(1);
+      expect(result.events[0]?.event_type).toBe("credential_created");
+    });
+
+    it("should paginate with limit and cursor", async () => {
+      const page1 = await client.secretsAudit.list({ limit: 2 });
+      expect(page1.events).toHaveLength(2);
+      expect(page1.has_more).toBe(true);
+      expect(page1.next_cursor).not.toBeNull();
+
+      const page2 = await client.secretsAudit.list({
+        limit: 2,
+        cursor: page1.next_cursor ?? "",
+      });
+      expect(page2.events.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("should include total count when requested", async () => {
+      const result = await client.secretsAudit.list({ include_total: true });
+      expect(result.total).toBeGreaterThanOrEqual(3);
+    });
+
+    it("should filter by provider", async () => {
+      const result = await client.secretsAudit.list({ provider: "github" });
+      expect(result.events.length).toBeGreaterThanOrEqual(2);
+      for (const e of result.events) {
+        expect(e.provider).toBe("github");
+      }
+    });
+
+    it("should filter by token_family_id", async () => {
+      const result = await client.secretsAudit.list({ token_family_id: "fam-xyz" });
+      expect(result.events.length).toBeGreaterThanOrEqual(1);
+      expect(result.events[0]?.event_type).toBe("token_rotated");
+    });
+  });
+
+  describe("get()", () => {
+    // Known Nexus server bug: get_event returns 404 for valid IDs
+    it.skip("should get a single event by ID (skipped: server-side bug)", async () => {
+      const id = allEvents.find((e) => e.event_type === "credential_created")?.id;
+      if (!id) throw new Error("No credential_created event found");
+      const event = await client.secretsAudit.get(id);
+      expect(event.id).toBe(id);
+      expect(event.event_type).toBe("credential_created");
+    });
+
+    it("should throw for nonexistent event", async () => {
+      await expect(client.secretsAudit.get("nonexistent-id-00000")).rejects.toThrow(/404/);
+    });
+  });
+
+  describe("export()", () => {
+    it("should export all events", async () => {
+      const result = await client.secretsAudit.export();
+      expect(result.events).toBeInstanceOf(Array);
+      expect(result.events.length).toBeGreaterThanOrEqual(3);
+    });
+
+    it("should export with filter", async () => {
+      const result = await client.secretsAudit.export({
+        event_type: "key_accessed",
+      });
+      expect(result.events.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe("verifyIntegrity()", () => {
+    // Known Nexus server bug: get_event (used internally) returns 404 for valid IDs
+    it.skip("should verify a valid record (skipped: server-side bug)", async () => {
+      const id = allEvents.find((e) => e.event_type === "credential_created")?.id;
+      if (!id) throw new Error("No credential_created event found");
+      const result = await client.secretsAudit.verifyIntegrity(id);
+      expect(result.record_id).toBe(id);
+      expect(result.is_valid).toBe(true);
+    });
+
+    it("should throw for nonexistent record", async () => {
+      await expect(client.secretsAudit.verifyIntegrity("nonexistent-id-00000")).rejects.toThrow(
+        /404/,
+      );
+    });
+  });
+});

--- a/packages/nexus-sdk/src/__tests__/resources/secrets-audit.test.ts
+++ b/packages/nexus-sdk/src/__tests__/resources/secrets-audit.test.ts
@@ -1,0 +1,387 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { NexusClient } from "../../client.js";
+import { SecretsAuditResource } from "../../resources/secrets-audit.js";
+import type {
+  SecretsAuditEvent,
+  SecretsAuditEventListResponse,
+  SecretsAuditExportResponse,
+  SecretsAuditIntegrityResponse,
+} from "../../types/secrets-audit.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const MOCK_EVENT: SecretsAuditEvent = {
+  id: "550e8400-e29b-41d4-a716-446655440000",
+  record_hash: "abc123def456789abc123def456789abc123def456789abc123def456789abcd",
+  created_at: "2026-02-20T10:00:00+00:00",
+  event_type: "credential_created",
+  actor_id: "user-42",
+  provider: "github",
+  credential_id: "cred-abc",
+  token_family_id: null,
+  zone_id: "root",
+  ip_address: "192.168.1.1",
+  details: '{"scope": "repo"}',
+  metadata_hash: "def456abc789",
+};
+
+const MOCK_EVENT_MINIMAL: SecretsAuditEvent = {
+  id: "660e8400-e29b-41d4-a716-446655440001",
+  record_hash: "fff000fff000fff000fff000fff000fff000fff000fff000fff000fff000ffff",
+  created_at: "2026-02-20T11:00:00+00:00",
+  event_type: "key_accessed",
+  actor_id: "agent-7",
+  provider: null,
+  credential_id: null,
+  token_family_id: null,
+  zone_id: "root",
+  ip_address: null,
+  details: null,
+  metadata_hash: null,
+};
+
+function mockJsonResponse<T>(data: T, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("SecretsAuditResource", () => {
+  let client: NexusClient;
+  let originalFetch: typeof global.fetch;
+
+  beforeEach(() => {
+    originalFetch = global.fetch;
+    client = new NexusClient({
+      apiKey: "test-key",
+      baseUrl: "https://api.test.com",
+      retry: { maxAttempts: 1 },
+    });
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  describe("initialization", () => {
+    it("should expose secretsAudit resource on client", () => {
+      expect(client.secretsAudit).toBeInstanceOf(SecretsAuditResource);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // list()
+  // -----------------------------------------------------------------------
+
+  describe("list()", () => {
+    it("should list events with no params", async () => {
+      const response: SecretsAuditEventListResponse = {
+        events: [MOCK_EVENT],
+        limit: 100,
+        has_more: false,
+        total: null,
+        next_cursor: null,
+      };
+      global.fetch = vi.fn().mockResolvedValue(mockJsonResponse(response));
+
+      const result = await client.secretsAudit.list();
+
+      expect(result).toEqual(response);
+      expect(global.fetch).toHaveBeenCalledWith(
+        "https://api.test.com/api/v2/secrets-audit/events",
+        expect.objectContaining({ method: "GET" }),
+      );
+    });
+
+    it("should pass all filter parameters as query strings", async () => {
+      const response: SecretsAuditEventListResponse = {
+        events: [],
+        limit: 50,
+        has_more: false,
+        total: 0,
+        next_cursor: null,
+      };
+      global.fetch = vi.fn().mockResolvedValue(mockJsonResponse(response));
+
+      await client.secretsAudit.list({
+        since: "2026-01-01T00:00:00Z",
+        until: "2026-02-01T00:00:00Z",
+        event_type: "credential_created",
+        actor_id: "user-42",
+        provider: "github",
+        credential_id: "cred-abc",
+        token_family_id: "fam-xyz",
+        limit: 50,
+        cursor: "cursor-token",
+        include_total: true,
+      });
+
+      const calledUrl = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as string;
+      const url = new URL(calledUrl);
+      expect(url.searchParams.get("since")).toBe("2026-01-01T00:00:00Z");
+      expect(url.searchParams.get("until")).toBe("2026-02-01T00:00:00Z");
+      expect(url.searchParams.get("event_type")).toBe("credential_created");
+      expect(url.searchParams.get("actor_id")).toBe("user-42");
+      expect(url.searchParams.get("provider")).toBe("github");
+      expect(url.searchParams.get("credential_id")).toBe("cred-abc");
+      expect(url.searchParams.get("token_family_id")).toBe("fam-xyz");
+      expect(url.searchParams.get("limit")).toBe("50");
+      expect(url.searchParams.get("cursor")).toBe("cursor-token");
+      expect(url.searchParams.get("include_total")).toBe("true");
+    });
+
+    it("should omit undefined parameters from query", async () => {
+      const response: SecretsAuditEventListResponse = {
+        events: [],
+        limit: 100,
+        has_more: false,
+        total: null,
+        next_cursor: null,
+      };
+      global.fetch = vi.fn().mockResolvedValue(mockJsonResponse(response));
+
+      await client.secretsAudit.list({
+        event_type: "key_accessed",
+      });
+
+      const calledUrl = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as string;
+      const url = new URL(calledUrl);
+      expect(url.searchParams.get("event_type")).toBe("key_accessed");
+      expect(url.searchParams.has("since")).toBe(false);
+      expect(url.searchParams.has("until")).toBe(false);
+      expect(url.searchParams.has("actor_id")).toBe(false);
+      expect(url.searchParams.has("provider")).toBe(false);
+      expect(url.searchParams.has("credential_id")).toBe(false);
+      expect(url.searchParams.has("token_family_id")).toBe(false);
+      expect(url.searchParams.has("limit")).toBe(false);
+      expect(url.searchParams.has("cursor")).toBe(false);
+      expect(url.searchParams.has("include_total")).toBe(false);
+    });
+
+    it("should handle paginated response with next_cursor", async () => {
+      const response: SecretsAuditEventListResponse = {
+        events: [MOCK_EVENT, MOCK_EVENT_MINIMAL],
+        limit: 2,
+        has_more: true,
+        total: null,
+        next_cursor: "eyJpZCI6IjY2MGU4NDAw...",
+      };
+      global.fetch = vi.fn().mockResolvedValue(mockJsonResponse(response));
+
+      const result = await client.secretsAudit.list({ limit: 2 });
+
+      expect(result.has_more).toBe(true);
+      expect(result.next_cursor).toBe("eyJpZCI6IjY2MGU4NDAw...");
+      expect(result.events).toHaveLength(2);
+    });
+
+    it("should include total count when requested", async () => {
+      const response: SecretsAuditEventListResponse = {
+        events: [MOCK_EVENT],
+        limit: 100,
+        has_more: false,
+        total: 42,
+        next_cursor: null,
+      };
+      global.fetch = vi.fn().mockResolvedValue(mockJsonResponse(response));
+
+      const result = await client.secretsAudit.list({ include_total: true });
+
+      expect(result.total).toBe(42);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // get()
+  // -----------------------------------------------------------------------
+
+  describe("get()", () => {
+    it("should get a single event by ID", async () => {
+      global.fetch = vi.fn().mockResolvedValue(mockJsonResponse(MOCK_EVENT));
+
+      const result = await client.secretsAudit.get(MOCK_EVENT.id);
+
+      expect(result).toEqual(MOCK_EVENT);
+      expect(global.fetch).toHaveBeenCalledWith(
+        `https://api.test.com/api/v2/secrets-audit/events/${MOCK_EVENT.id}`,
+        expect.objectContaining({ method: "GET" }),
+      );
+    });
+
+    it("should URL-encode the record ID", async () => {
+      global.fetch = vi.fn().mockResolvedValue(mockJsonResponse(MOCK_EVENT));
+
+      await client.secretsAudit.get("id/with special&chars");
+
+      const calledUrl = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as string;
+      expect(calledUrl).toContain("id%2Fwith%20special%26chars");
+    });
+
+    it("should throw on 404", async () => {
+      global.fetch = vi
+        .fn()
+        .mockResolvedValue(
+          mockJsonResponse({ code: "NOT_FOUND", message: "Audit event not found" }, 404),
+        );
+
+      await expect(client.secretsAudit.get("nonexistent")).rejects.toThrow("Audit event not found");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // export()
+  // -----------------------------------------------------------------------
+
+  describe("export()", () => {
+    it("should export events as JSON with default params", async () => {
+      const response: SecretsAuditExportResponse = {
+        events: [MOCK_EVENT, MOCK_EVENT_MINIMAL],
+      };
+      global.fetch = vi.fn().mockResolvedValue(mockJsonResponse(response));
+
+      const result = await client.secretsAudit.export();
+
+      expect(result.events).toHaveLength(2);
+      const calledUrl = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as string;
+      const url = new URL(calledUrl);
+      expect(url.pathname).toBe("/api/v2/secrets-audit/events/export");
+      expect(url.searchParams.get("format")).toBe("json");
+    });
+
+    it("should pass filter parameters", async () => {
+      const response: SecretsAuditExportResponse = { events: [] };
+      global.fetch = vi.fn().mockResolvedValue(mockJsonResponse(response));
+
+      await client.secretsAudit.export({
+        since: "2026-01-01T00:00:00Z",
+        until: "2026-02-01T00:00:00Z",
+        event_type: "token_rotated",
+        actor_id: "admin-1",
+        provider: "google",
+        limit: 5000,
+      });
+
+      const calledUrl = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as string;
+      const url = new URL(calledUrl);
+      expect(url.searchParams.get("format")).toBe("json");
+      expect(url.searchParams.get("since")).toBe("2026-01-01T00:00:00Z");
+      expect(url.searchParams.get("until")).toBe("2026-02-01T00:00:00Z");
+      expect(url.searchParams.get("event_type")).toBe("token_rotated");
+      expect(url.searchParams.get("actor_id")).toBe("admin-1");
+      expect(url.searchParams.get("provider")).toBe("google");
+      expect(url.searchParams.get("limit")).toBe("5000");
+    });
+
+    it("should always set format=json", async () => {
+      const response: SecretsAuditExportResponse = { events: [] };
+      global.fetch = vi.fn().mockResolvedValue(mockJsonResponse(response));
+
+      await client.secretsAudit.export({});
+
+      const calledUrl = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as string;
+      const url = new URL(calledUrl);
+      expect(url.searchParams.get("format")).toBe("json");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // verifyIntegrity()
+  // -----------------------------------------------------------------------
+
+  describe("verifyIntegrity()", () => {
+    it("should verify a valid record", async () => {
+      const response: SecretsAuditIntegrityResponse = {
+        record_id: MOCK_EVENT.id,
+        is_valid: true,
+        record_hash: MOCK_EVENT.record_hash,
+      };
+      global.fetch = vi.fn().mockResolvedValue(mockJsonResponse(response));
+
+      const result = await client.secretsAudit.verifyIntegrity(MOCK_EVENT.id);
+
+      expect(result.is_valid).toBe(true);
+      expect(result.record_id).toBe(MOCK_EVENT.id);
+      expect(global.fetch).toHaveBeenCalledWith(
+        `https://api.test.com/api/v2/secrets-audit/integrity/${MOCK_EVENT.id}`,
+        expect.objectContaining({ method: "GET" }),
+      );
+    });
+
+    it("should detect tampered record", async () => {
+      const response: SecretsAuditIntegrityResponse = {
+        record_id: MOCK_EVENT.id,
+        is_valid: false,
+        record_hash: MOCK_EVENT.record_hash,
+      };
+      global.fetch = vi.fn().mockResolvedValue(mockJsonResponse(response));
+
+      const result = await client.secretsAudit.verifyIntegrity(MOCK_EVENT.id);
+
+      expect(result.is_valid).toBe(false);
+    });
+
+    it("should URL-encode the record ID", async () => {
+      const response: SecretsAuditIntegrityResponse = {
+        record_id: "id/special",
+        is_valid: true,
+        record_hash: "abc",
+      };
+      global.fetch = vi.fn().mockResolvedValue(mockJsonResponse(response));
+
+      await client.secretsAudit.verifyIntegrity("id/special");
+
+      const calledUrl = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as string;
+      expect(calledUrl).toContain("id%2Fspecial");
+    });
+
+    it("should throw on 404 for nonexistent record", async () => {
+      global.fetch = vi
+        .fn()
+        .mockResolvedValue(
+          mockJsonResponse({ code: "NOT_FOUND", message: "Audit event not found" }, 404),
+        );
+
+      await expect(client.secretsAudit.verifyIntegrity("nonexistent")).rejects.toThrow(
+        "Audit event not found",
+      );
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Error handling
+  // -----------------------------------------------------------------------
+
+  describe("error handling", () => {
+    it("should propagate 500 errors", async () => {
+      global.fetch = vi
+        .fn()
+        .mockResolvedValue(
+          mockJsonResponse(
+            { code: "INTERNAL_ERROR", message: "Failed to query secrets audit events" },
+            500,
+          ),
+        );
+
+      await expect(client.secretsAudit.list()).rejects.toThrow(
+        "Failed to query secrets audit events",
+      );
+    });
+
+    it("should propagate 401 unauthorized", async () => {
+      global.fetch = vi
+        .fn()
+        .mockResolvedValue(
+          mockJsonResponse({ code: "UNAUTHORIZED", message: "Invalid API key" }, 401),
+        );
+
+      await expect(client.secretsAudit.list()).rejects.toThrow("Invalid API key");
+    });
+  });
+});

--- a/packages/nexus-sdk/src/client.ts
+++ b/packages/nexus-sdk/src/client.ts
@@ -13,6 +13,7 @@ import { PairingResource } from "./resources/pairing.js";
 import { PayResource } from "./resources/pay.js";
 import { PermissionsResource } from "./resources/permissions.js";
 import { SandboxResource } from "./resources/sandbox.js";
+import { SecretsAuditResource } from "./resources/secrets-audit.js";
 import { ToolsResource } from "./resources/tools.js";
 import type { ClientConfig, RetryOptions } from "./types/index.js";
 
@@ -105,6 +106,11 @@ export class NexusClient {
   public readonly pairing: PairingResource;
 
   /**
+   * Secrets Audit resource (credential access audit trail)
+   */
+  public readonly secretsAudit: SecretsAuditResource;
+
+  /**
    * ACE resource (Adaptive Context Engine — trajectories, playbooks, reflection, etc.)
    */
   public readonly ace: AceResource;
@@ -134,6 +140,7 @@ export class NexusClient {
     this.permissions = new PermissionsResource(this._http);
     this.sandbox = new SandboxResource(this._http);
     this.pairing = new PairingResource(this._http);
+    this.secretsAudit = new SecretsAuditResource(this._http);
     this.ace = new AceResource(this._http);
   }
 

--- a/packages/nexus-sdk/src/index.ts
+++ b/packages/nexus-sdk/src/index.ts
@@ -38,6 +38,7 @@ export { PairingResource } from "./resources/pairing.js";
 export { PayResource } from "./resources/pay.js";
 export { PermissionsResource } from "./resources/permissions.js";
 export { SandboxResource } from "./resources/sandbox.js";
+export { SecretsAuditResource } from "./resources/secrets-audit.js";
 export { ToolsResource } from "./resources/tools.js";
 // ACE types
 export type {
@@ -184,6 +185,16 @@ export type {
   RunCodeResponse,
   SandboxInfoResponse,
 } from "./types/sandbox.js";
+export type {
+  ExportSecretsAuditParams,
+  ListSecretsAuditParams,
+  SecretsAuditEvent,
+  SecretsAuditEventListResponse,
+  SecretsAuditEventType,
+  SecretsAuditExportFormat,
+  SecretsAuditExportResponse,
+  SecretsAuditIntegrityResponse,
+} from "./types/secrets-audit.js";
 export type {
   CreateToolParams,
   ListToolsParams,

--- a/packages/nexus-sdk/src/resources/secrets-audit.ts
+++ b/packages/nexus-sdk/src/resources/secrets-audit.ts
@@ -1,0 +1,169 @@
+/**
+ * Secrets Audit resource for querying the credential access audit trail
+ *
+ * Issue #216: Read-only SDK for the immutable secrets audit log.
+ * Wraps Nexus API: GET /api/v2/secrets-audit/*
+ *
+ * All events are zone-scoped (enforced server-side via auth).
+ * Records are immutable (append-only) with SHA-256 tamper detection.
+ */
+
+import type {
+  ExportSecretsAuditParams,
+  ListSecretsAuditParams,
+  SecretsAuditEvent,
+  SecretsAuditEventListResponse,
+  SecretsAuditExportResponse,
+  SecretsAuditIntegrityResponse,
+} from "../types/secrets-audit.js";
+import { BaseResource } from "./base.js";
+
+const BASE_PATH = "/api/v2/secrets-audit";
+
+/**
+ * Resource for querying the Nexus secrets audit trail
+ *
+ * Provides read-only access to the immutable credential/token
+ * lifecycle audit log. Audit events are written server-side by
+ * the Nexus auth system — no write methods are exposed.
+ *
+ * @example
+ * ```typescript
+ * // List recent credential events
+ * const events = await client.secretsAudit.list({
+ *   event_type: "key_accessed",
+ *   limit: 50,
+ * });
+ *
+ * // Verify a record hasn't been tampered with
+ * const integrity = await client.secretsAudit.verifyIntegrity("rec-123");
+ * console.log(integrity.is_valid); // true
+ * ```
+ */
+export class SecretsAuditResource extends BaseResource {
+  /**
+   * List secrets audit events with cursor-based pagination.
+   *
+   * Supports filtering by event type, actor, provider, credential,
+   * token family, and time range. Results are ordered by created_at DESC.
+   *
+   * @param params - Optional filter and pagination parameters
+   * @returns Paginated list of audit events
+   *
+   * @example
+   * ```typescript
+   * // List all events for a specific credential
+   * const result = await client.secretsAudit.list({
+   *   credential_id: "cred-abc",
+   *   limit: 20,
+   * });
+   *
+   * // Paginate through results
+   * const page2 = await client.secretsAudit.list({
+   *   cursor: result.next_cursor,
+   * });
+   * ```
+   */
+  async list(params?: ListSecretsAuditParams): Promise<SecretsAuditEventListResponse> {
+    const query: Record<string, string | number | boolean | undefined> = {};
+    if (params?.since !== undefined) query.since = params.since;
+    if (params?.until !== undefined) query.until = params.until;
+    if (params?.event_type !== undefined) query.event_type = params.event_type;
+    if (params?.actor_id !== undefined) query.actor_id = params.actor_id;
+    if (params?.provider !== undefined) query.provider = params.provider;
+    if (params?.credential_id !== undefined) query.credential_id = params.credential_id;
+    if (params?.token_family_id !== undefined) query.token_family_id = params.token_family_id;
+    if (params?.limit !== undefined) query.limit = params.limit;
+    if (params?.cursor !== undefined) query.cursor = params.cursor;
+    if (params?.include_total !== undefined) query.include_total = params.include_total;
+
+    const hasQuery = Object.keys(query).length > 0;
+    return this.http.request<SecretsAuditEventListResponse>(`${BASE_PATH}/events`, {
+      method: "GET",
+      ...(hasQuery ? { query } : {}),
+    });
+  }
+
+  /**
+   * Get a single secrets audit event by ID.
+   *
+   * Returns 404 if the record doesn't exist or belongs to a different zone.
+   *
+   * @param recordId - The audit event UUID
+   * @returns The full audit event record
+   *
+   * @example
+   * ```typescript
+   * const event = await client.secretsAudit.get("550e8400-e29b-41d4-a716-446655440000");
+   * console.log(event.event_type); // "credential_created"
+   * ```
+   */
+  async get(recordId: string): Promise<SecretsAuditEvent> {
+    return this.http.request<SecretsAuditEvent>(
+      `${BASE_PATH}/events/${encodeURIComponent(recordId)}`,
+      { method: "GET" },
+    );
+  }
+
+  /**
+   * Export secrets audit events as JSON.
+   *
+   * Returns all matching events up to the specified limit (max 100,000).
+   * For large exports, consider using filters to narrow the result set.
+   *
+   * @param params - Optional filter parameters and row limit
+   * @returns All matching events in a single response
+   *
+   * @example
+   * ```typescript
+   * // Export last month's events
+   * const exported = await client.secretsAudit.export({
+   *   since: "2026-01-01T00:00:00Z",
+   *   until: "2026-02-01T00:00:00Z",
+   *   limit: 50000,
+   * });
+   * console.log(`Exported ${exported.events.length} events`);
+   * ```
+   */
+  async export(params?: ExportSecretsAuditParams): Promise<SecretsAuditExportResponse> {
+    const query: Record<string, string | number | boolean | undefined> = {
+      format: "json",
+    };
+    if (params?.since !== undefined) query.since = params.since;
+    if (params?.until !== undefined) query.until = params.until;
+    if (params?.event_type !== undefined) query.event_type = params.event_type;
+    if (params?.actor_id !== undefined) query.actor_id = params.actor_id;
+    if (params?.provider !== undefined) query.provider = params.provider;
+    if (params?.limit !== undefined) query.limit = params.limit;
+
+    return this.http.request<SecretsAuditExportResponse>(`${BASE_PATH}/events/export`, {
+      method: "GET",
+      query,
+    });
+  }
+
+  /**
+   * Verify a record's integrity (tamper detection).
+   *
+   * Recomputes the SHA-256 hash from the record's fields and compares
+   * it to the stored hash. Returns `is_valid: true` if the record
+   * has not been tampered with.
+   *
+   * @param recordId - The audit event UUID to verify
+   * @returns Integrity verification result
+   *
+   * @example
+   * ```typescript
+   * const result = await client.secretsAudit.verifyIntegrity("rec-123");
+   * if (!result.is_valid) {
+   *   console.error("ALERT: Audit record has been tampered with!");
+   * }
+   * ```
+   */
+  async verifyIntegrity(recordId: string): Promise<SecretsAuditIntegrityResponse> {
+    return this.http.request<SecretsAuditIntegrityResponse>(
+      `${BASE_PATH}/integrity/${encodeURIComponent(recordId)}`,
+      { method: "GET" },
+    );
+  }
+}

--- a/packages/nexus-sdk/src/types/secrets-audit.ts
+++ b/packages/nexus-sdk/src/types/secrets-audit.ts
@@ -1,0 +1,179 @@
+/**
+ * Secrets Audit types — mirrors Nexus secrets audit API contract
+ *
+ * Issue #216: Read-only SDK for the immutable credential access audit trail.
+ * Nexus API: GET /api/v2/secrets-audit/*
+ */
+
+// ============================================================================
+// ENUMS
+// ============================================================================
+
+/**
+ * Types of auditable secrets/credential events.
+ * Mirrors SecretsAuditEventType from Nexus.
+ */
+export type SecretsAuditEventType =
+  | "credential_created"
+  | "credential_updated"
+  | "credential_revoked"
+  | "token_refreshed"
+  | "token_rotated"
+  | "token_reuse_detected"
+  | "family_invalidated"
+  | "key_accessed"
+  | "key_rotated";
+
+/**
+ * Supported export formats for the events export endpoint.
+ */
+export type SecretsAuditExportFormat = "json" | "csv";
+
+// ============================================================================
+// REQUEST PARAMS
+// ============================================================================
+
+/**
+ * Parameters for listing secrets audit events with cursor-based pagination.
+ */
+export interface ListSecretsAuditParams {
+  /** Filter events after this time (ISO-8601) */
+  readonly since?: string;
+
+  /** Filter events before this time (ISO-8601) */
+  readonly until?: string;
+
+  /** Filter by event type */
+  readonly event_type?: SecretsAuditEventType;
+
+  /** Filter by actor ID (who performed the action) */
+  readonly actor_id?: string;
+
+  /** Filter by OAuth provider */
+  readonly provider?: string;
+
+  /** Filter by credential ID */
+  readonly credential_id?: string;
+
+  /** Filter by token family ID */
+  readonly token_family_id?: string;
+
+  /** Page size (1-1000, default: 100) */
+  readonly limit?: number;
+
+  /** Cursor from previous response for pagination */
+  readonly cursor?: string;
+
+  /** Include total count in response (default: false) */
+  readonly include_total?: boolean;
+}
+
+/**
+ * Parameters for exporting secrets audit events.
+ */
+export interface ExportSecretsAuditParams {
+  /** Filter events after this time (ISO-8601) */
+  readonly since?: string;
+
+  /** Filter events before this time (ISO-8601) */
+  readonly until?: string;
+
+  /** Filter by event type */
+  readonly event_type?: SecretsAuditEventType;
+
+  /** Filter by actor ID */
+  readonly actor_id?: string;
+
+  /** Filter by OAuth provider */
+  readonly provider?: string;
+
+  /** Max rows to export (1-100000, default: 10000) */
+  readonly limit?: number;
+}
+
+// ============================================================================
+// RESPONSE TYPES
+// ============================================================================
+
+/**
+ * Single secrets audit log entry.
+ */
+export interface SecretsAuditEvent {
+  /** Unique record identifier (UUID) */
+  readonly id: string;
+
+  /** SHA-256 hash for tamper detection */
+  readonly record_hash: string;
+
+  /** When the event was recorded (ISO-8601) */
+  readonly created_at: string;
+
+  /** Type of credential event */
+  readonly event_type: string;
+
+  /** Who performed the action */
+  readonly actor_id: string;
+
+  /** OAuth provider (e.g., "github", "google") */
+  readonly provider: string | null;
+
+  /** Affected credential ID */
+  readonly credential_id: string | null;
+
+  /** Token family for rotation tracking */
+  readonly token_family_id: string | null;
+
+  /** Zone scope for multi-tenancy */
+  readonly zone_id: string;
+
+  /** Source IP address */
+  readonly ip_address: string | null;
+
+  /** Additional details (JSON string — never contains secrets) */
+  readonly details: string | null;
+
+  /** SHA-256 of the details JSON */
+  readonly metadata_hash: string | null;
+}
+
+/**
+ * Paginated list of secrets audit events.
+ */
+export interface SecretsAuditEventListResponse {
+  /** List of audit events */
+  readonly events: readonly SecretsAuditEvent[];
+
+  /** Page size used */
+  readonly limit: number;
+
+  /** Whether more results are available */
+  readonly has_more: boolean;
+
+  /** Total count (only present if include_total=true) */
+  readonly total: number | null;
+
+  /** Cursor for next page (null if no more results) */
+  readonly next_cursor: string | null;
+}
+
+/**
+ * JSON export response containing all matching events.
+ */
+export interface SecretsAuditExportResponse {
+  /** All matching events */
+  readonly events: readonly SecretsAuditEvent[];
+}
+
+/**
+ * Result of integrity verification for a single record.
+ */
+export interface SecretsAuditIntegrityResponse {
+  /** The record ID that was verified */
+  readonly record_id: string;
+
+  /** Whether the hash matches (true = not tampered) */
+  readonly is_valid: boolean;
+
+  /** The stored hash for reference */
+  readonly record_hash: string;
+}

--- a/packages/nexus-sdk/tsup.config.ts
+++ b/packages/nexus-sdk/tsup.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
     "resources/eventlog": "src/resources/eventlog.ts",
     "resources/permissions": "src/resources/permissions.ts",
     "resources/sandbox": "src/resources/sandbox.ts",
+    "resources/secrets-audit": "src/resources/secrets-audit.ts",
     "http/index": "src/http/index.ts",
   },
   format: ["esm"],


### PR DESCRIPTION
## Summary
- Adds `SecretsAuditResource` to `@nexus/sdk` with read-only access to the immutable credential access audit trail (Issue #216)
- Implements 4 operations: `list()` with cursor-based pagination, `get()` by ID, `export()` with JSON format, and `verifyIntegrity()` for tamper detection
- Full TypeScript types mirroring the Nexus `/api/v2/secrets-audit/*` API contract

## Changes
- **New**: `src/types/secrets-audit.ts` — Types, enums, request params, and response interfaces
- **New**: `src/resources/secrets-audit.ts` — `SecretsAuditResource` class with 4 methods
- **New**: `src/__tests__/resources/secrets-audit.test.ts` — 18 unit tests (all passing)
- **New**: `src/__tests__/e2e/secrets-audit.e2e.test.ts` — 12 E2E tests (10 pass, 2 skipped)
- **Modified**: `src/client.ts` — Wire `secretsAudit` resource onto `NexusClient`
- **Modified**: `src/index.ts` — Re-export types and resource
- **Modified**: `package.json` — Add `secrets-audit` entry point
- **Modified**: `tsup.config.ts` — Add `secrets-audit` build entry

## Known issues
- `get()` and `verifyIntegrity()` E2E tests are skipped due to a known Nexus server-side bug where single-record lookup by ID returns 404 for records that `list()` returns successfully. The SDK implementation is correct; the server needs a fix.

## Test plan
- [x] 18 unit tests passing (mocked fetch, covers all methods, params, pagination, error handling)
- [x] 10 E2E tests passing against live Nexus server (list, filter, paginate, export)
- [x] 2 E2E tests skipped with documentation (server-side get_event bug)
- [x] TypeScript typecheck clean
- [x] Biome lint/format clean
- [x] Full SDK test suite (189 tests) passing with no regressions