### PR TITLE
feat(nexus-sdk): add webhook subscriptions API resource (#222)

### DIFF
--- a/packages/nexus-sdk/package.json
+++ b/packages/nexus-sdk/package.json
@@ -37,6 +37,10 @@
       "types": "./dist/resources/secrets-audit.d.ts",
       "import": "./dist/resources/secrets-audit.js"
     },
+    "./subscriptions": {
+      "types": "./dist/resources/subscriptions.d.ts",
+      "import": "./dist/resources/subscriptions.js"
+    },
     "./http": {
       "types": "./dist/http/index.d.ts",
       "import": "./dist/http/index.js"

--- a/packages/nexus-sdk/src/__tests__/e2e/subscriptions.e2e.test.ts
+++ b/packages/nexus-sdk/src/__tests__/e2e/subscriptions.e2e.test.ts
@@ -1,0 +1,184 @@
+/**
+ * E2E test for @nexus/sdk Subscriptions (Webhook Notifications) API
+ *
+ * Requires a running Nexus server on localhost:2028 with:
+ * - Subscriptions feature enabled
+ * - Open access mode (no auth) or a valid API key
+ *
+ * Run with: NEXUS_E2E=1 npx vitest run src/__tests__/e2e/subscriptions.e2e.test.ts
+ *
+ * Tests exercise the full subscription lifecycle:
+ * create → get → list → update → test → delete
+ *
+ * Note: Server-side SSRF protection blocks private IPs (RFC 1918, loopback,
+ * cloud metadata). We use https://httpbin.org/post as the webhook URL for
+ * E2E tests since the non-routable TEST-NET ranges may also be blocked.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { NexusClient } from "../../client.js";
+import type { Subscription } from "../../types/subscriptions.js";
+
+const BASE_URL = process.env.NEXUS_E2E_URL ?? "http://localhost:2028";
+const API_KEY = process.env.NEXUS_E2E_KEY ?? "sk-test-e2e-subscriptions-key-1234";
+
+const shouldRun = !!process.env.NEXUS_E2E;
+
+describe.skipIf(!shouldRun)("Subscriptions E2E", () => {
+  let client: NexusClient;
+  let createdSubscription: Subscription;
+
+  beforeAll(() => {
+    client = new NexusClient({
+      apiKey: API_KEY,
+      baseUrl: BASE_URL,
+      retry: { maxAttempts: 1 },
+    });
+  });
+
+  afterAll(async () => {
+    // Cleanup: delete the test subscription if it was created
+    if (createdSubscription?.id) {
+      try {
+        await client.subscriptions.delete(createdSubscription.id);
+      } catch {
+        // Ignore cleanup errors — subscription may already be deleted by test
+      }
+    }
+  });
+
+  // -----------------------------------------------------------------------
+  // create()
+  // -----------------------------------------------------------------------
+
+  describe("create()", () => {
+    it("should create a subscription with required fields only", async () => {
+      createdSubscription = await client.subscriptions.create({
+        url: "https://httpbin.org/post",
+        event_types: ["file_write", "file_delete"],
+        name: `e2e-test-${Date.now()}`,
+        description: "SDK E2E test subscription",
+      });
+
+      expect(createdSubscription.id).toBeDefined();
+      expect(createdSubscription.url).toBe("https://httpbin.org/post");
+      expect(createdSubscription.event_types).toEqual(
+        expect.arrayContaining(["file_write", "file_delete"]),
+      );
+      expect(createdSubscription.enabled).toBe(true);
+      expect(createdSubscription.consecutive_failures).toBe(0);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // get()
+  // -----------------------------------------------------------------------
+
+  describe("get()", () => {
+    it("should get the created subscription by ID", async () => {
+      const sub = await client.subscriptions.get(createdSubscription.id);
+
+      expect(sub.id).toBe(createdSubscription.id);
+      expect(sub.url).toBe(createdSubscription.url);
+      expect(sub.name).toBe(createdSubscription.name);
+    });
+
+    it("should throw for nonexistent subscription", async () => {
+      await expect(client.subscriptions.get("nonexistent-id-00000")).rejects.toThrow();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // list()
+  // -----------------------------------------------------------------------
+
+  describe("list()", () => {
+    it("should list subscriptions including the created one", async () => {
+      const result = await client.subscriptions.list();
+
+      expect(result.subscriptions).toBeInstanceOf(Array);
+      expect(result.subscriptions.length).toBeGreaterThanOrEqual(1);
+
+      const found = result.subscriptions.find((s) => s.id === createdSubscription.id);
+      expect(found).toBeDefined();
+    });
+
+    it("should paginate with limit and offset", async () => {
+      const page1 = await client.subscriptions.list({ limit: 1 });
+      expect(page1.subscriptions).toHaveLength(1);
+
+      const page2 = await client.subscriptions.list({ limit: 1, offset: 1 });
+      // May have 0 or more results depending on total count
+      expect(page2.subscriptions.length).toBeLessThanOrEqual(1);
+    });
+
+    it("should filter by enabled_only", async () => {
+      const result = await client.subscriptions.list({ enabled_only: true });
+
+      for (const sub of result.subscriptions) {
+        expect(sub.enabled).toBe(true);
+      }
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // update()
+  // -----------------------------------------------------------------------
+
+  describe("update()", () => {
+    it("should update the subscription name", async () => {
+      const newName = `e2e-updated-${Date.now()}`;
+      const updated = await client.subscriptions.update(createdSubscription.id, {
+        name: newName,
+      });
+
+      expect(updated.id).toBe(createdSubscription.id);
+      expect(updated.name).toBe(newName);
+    });
+
+    it("should disable and re-enable a subscription", async () => {
+      const disabled = await client.subscriptions.update(createdSubscription.id, {
+        enabled: false,
+      });
+      expect(disabled.enabled).toBe(false);
+
+      const reenabled = await client.subscriptions.update(createdSubscription.id, {
+        enabled: true,
+      });
+      expect(reenabled.enabled).toBe(true);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // test()
+  // -----------------------------------------------------------------------
+
+  describe("test()", () => {
+    it("should test webhook delivery", async () => {
+      const result = await client.subscriptions.test(createdSubscription.id);
+
+      expect(result.subscription_id).toBe(createdSubscription.id);
+      expect(result.event_id).toBeDefined();
+      // httpbin.org/post should accept the webhook, so success is likely
+      // but we don't assert success=true since network conditions vary
+      expect(typeof result.success).toBe("boolean");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // delete()
+  // -----------------------------------------------------------------------
+
+  describe("delete()", () => {
+    it("should delete the subscription", async () => {
+      const result = await client.subscriptions.delete(createdSubscription.id);
+      expect(result.deleted).toBe(true);
+
+      // Verify it's gone
+      await expect(client.subscriptions.get(createdSubscription.id)).rejects.toThrow();
+
+      // Prevent afterAll cleanup from trying to delete again
+      createdSubscription = undefined as unknown as Subscription;
+    });
+  });
+});

--- a/packages/nexus-sdk/src/__tests__/resources/subscriptions.test.ts
+++ b/packages/nexus-sdk/src/__tests__/resources/subscriptions.test.ts
@@ -1,0 +1,480 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { NexusClient } from "../../client.js";
+import { SubscriptionsResource } from "../../resources/subscriptions.js";
+import type {
+  DeleteSubscriptionResponse,
+  Subscription,
+  SubscriptionListResponse,
+  TestWebhookResponse,
+} from "../../types/subscriptions.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const MOCK_SUBSCRIPTION: Subscription = {
+  id: "550e8400-e29b-41d4-a716-446655440000",
+  zone_id: "root",
+  url: "https://example.com/webhooks",
+  event_types: ["file_write", "file_delete"],
+  patterns: ["/workspace/**/*"],
+  name: "Production webhook",
+  description: "Notifies on file changes",
+  metadata: { team: "platform" },
+  enabled: true,
+  last_delivery_at: null,
+  last_delivery_status: null,
+  consecutive_failures: 0,
+  created_at: "2026-02-20T10:00:00+00:00",
+  updated_at: "2026-02-20T10:00:00+00:00",
+  created_by: "user-42",
+};
+
+const MOCK_SUBSCRIPTION_MINIMAL: Subscription = {
+  id: "660e8400-e29b-41d4-a716-446655440001",
+  zone_id: "root",
+  url: "https://example.com/hooks",
+  event_types: ["file_write", "file_delete", "file_rename"],
+  patterns: null,
+  name: null,
+  description: null,
+  metadata: null,
+  enabled: true,
+  last_delivery_at: null,
+  last_delivery_status: null,
+  consecutive_failures: 0,
+  created_at: "2026-02-20T11:00:00+00:00",
+  updated_at: "2026-02-20T11:00:00+00:00",
+  created_by: null,
+};
+
+function mockJsonResponse<T>(data: T, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("SubscriptionsResource", () => {
+  let client: NexusClient;
+  let originalFetch: typeof global.fetch;
+
+  beforeEach(() => {
+    originalFetch = global.fetch;
+    client = new NexusClient({
+      apiKey: "test-key",
+      baseUrl: "https://api.test.com",
+      retry: { maxAttempts: 1 },
+    });
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  // -----------------------------------------------------------------------
+  // initialization
+  // -----------------------------------------------------------------------
+
+  describe("initialization", () => {
+    it("should expose subscriptions resource on client", () => {
+      expect(client.subscriptions).toBeInstanceOf(SubscriptionsResource);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // create()
+  // -----------------------------------------------------------------------
+
+  describe("create()", () => {
+    it("should create a subscription with all fields", async () => {
+      global.fetch = vi.fn().mockResolvedValue(mockJsonResponse(MOCK_SUBSCRIPTION, 201));
+
+      const result = await client.subscriptions.create({
+        url: "https://example.com/webhooks",
+        event_types: ["file_write", "file_delete"],
+        patterns: ["/workspace/**/*"],
+        secret: "whsec_test-secret",
+        name: "Production webhook",
+        description: "Notifies on file changes",
+        metadata: { team: "platform" },
+      });
+
+      expect(result).toEqual(MOCK_SUBSCRIPTION);
+      expect(global.fetch).toHaveBeenCalledWith(
+        "https://api.test.com/api/v2/subscriptions",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+
+    it("should send request body as JSON", async () => {
+      global.fetch = vi.fn().mockResolvedValue(mockJsonResponse(MOCK_SUBSCRIPTION_MINIMAL, 201));
+
+      await client.subscriptions.create({
+        url: "https://example.com/hooks",
+      });
+
+      const callArgs = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      const body = JSON.parse(callArgs?.[1]?.body as string);
+      expect(body.url).toBe("https://example.com/hooks");
+    });
+
+    it("should include event_types array in request body", async () => {
+      global.fetch = vi.fn().mockResolvedValue(mockJsonResponse(MOCK_SUBSCRIPTION, 201));
+
+      await client.subscriptions.create({
+        url: "https://example.com/webhooks",
+        event_types: ["file_write", "file_delete"],
+      });
+
+      const callArgs = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      const body = JSON.parse(callArgs?.[1]?.body as string);
+      expect(body.event_types).toEqual(["file_write", "file_delete"]);
+    });
+
+    it("should omit optional fields when not provided", async () => {
+      global.fetch = vi.fn().mockResolvedValue(mockJsonResponse(MOCK_SUBSCRIPTION_MINIMAL, 201));
+
+      await client.subscriptions.create({
+        url: "https://example.com/hooks",
+      });
+
+      const callArgs = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      const body = JSON.parse(callArgs?.[1]?.body as string);
+      expect(body.url).toBe("https://example.com/hooks");
+      expect(body.secret).toBeUndefined();
+      expect(body.name).toBeUndefined();
+      expect(body.patterns).toBeUndefined();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // list()
+  // -----------------------------------------------------------------------
+
+  describe("list()", () => {
+    it("should list subscriptions with no params", async () => {
+      const response: SubscriptionListResponse = {
+        subscriptions: [MOCK_SUBSCRIPTION],
+      };
+      global.fetch = vi.fn().mockResolvedValue(mockJsonResponse(response));
+
+      const result = await client.subscriptions.list();
+
+      expect(result).toEqual(response);
+      expect(global.fetch).toHaveBeenCalledWith(
+        "https://api.test.com/api/v2/subscriptions",
+        expect.objectContaining({ method: "GET" }),
+      );
+    });
+
+    it("should pass all filter parameters as query strings", async () => {
+      const response: SubscriptionListResponse = {
+        subscriptions: [],
+      };
+      global.fetch = vi.fn().mockResolvedValue(mockJsonResponse(response));
+
+      await client.subscriptions.list({
+        enabled_only: true,
+        limit: 50,
+        offset: 10,
+      });
+
+      const calledUrl = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as string;
+      const url = new URL(calledUrl);
+      expect(url.searchParams.get("enabled_only")).toBe("true");
+      expect(url.searchParams.get("limit")).toBe("50");
+      expect(url.searchParams.get("offset")).toBe("10");
+    });
+
+    it("should omit undefined parameters from query", async () => {
+      const response: SubscriptionListResponse = {
+        subscriptions: [],
+      };
+      global.fetch = vi.fn().mockResolvedValue(mockJsonResponse(response));
+
+      await client.subscriptions.list({ enabled_only: true });
+
+      const calledUrl = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as string;
+      const url = new URL(calledUrl);
+      expect(url.searchParams.get("enabled_only")).toBe("true");
+      expect(url.searchParams.has("limit")).toBe(false);
+      expect(url.searchParams.has("offset")).toBe(false);
+    });
+
+    it("should handle multiple subscriptions in response", async () => {
+      const response: SubscriptionListResponse = {
+        subscriptions: [MOCK_SUBSCRIPTION, MOCK_SUBSCRIPTION_MINIMAL],
+      };
+      global.fetch = vi.fn().mockResolvedValue(mockJsonResponse(response));
+
+      const result = await client.subscriptions.list();
+
+      expect(result.subscriptions).toHaveLength(2);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // get()
+  // -----------------------------------------------------------------------
+
+  describe("get()", () => {
+    it("should get a single subscription by ID", async () => {
+      global.fetch = vi.fn().mockResolvedValue(mockJsonResponse(MOCK_SUBSCRIPTION));
+
+      const result = await client.subscriptions.get(MOCK_SUBSCRIPTION.id);
+
+      expect(result).toEqual(MOCK_SUBSCRIPTION);
+      expect(global.fetch).toHaveBeenCalledWith(
+        `https://api.test.com/api/v2/subscriptions/${MOCK_SUBSCRIPTION.id}`,
+        expect.objectContaining({ method: "GET" }),
+      );
+    });
+
+    it("should URL-encode the subscription ID", async () => {
+      global.fetch = vi.fn().mockResolvedValue(mockJsonResponse(MOCK_SUBSCRIPTION));
+
+      await client.subscriptions.get("id/with special&chars");
+
+      const calledUrl = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as string;
+      expect(calledUrl).toContain("id%2Fwith%20special%26chars");
+    });
+
+    it("should throw on 404", async () => {
+      global.fetch = vi
+        .fn()
+        .mockResolvedValue(
+          mockJsonResponse({ code: "NOT_FOUND", message: "Subscription not found" }, 404),
+        );
+
+      await expect(client.subscriptions.get("nonexistent")).rejects.toThrow(
+        "Subscription not found",
+      );
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // update()
+  // -----------------------------------------------------------------------
+
+  describe("update()", () => {
+    it("should update a subscription with PATCH", async () => {
+      const updated = { ...MOCK_SUBSCRIPTION, url: "https://new.example.com/hooks" };
+      global.fetch = vi.fn().mockResolvedValue(mockJsonResponse(updated));
+
+      const result = await client.subscriptions.update(MOCK_SUBSCRIPTION.id, {
+        url: "https://new.example.com/hooks",
+      });
+
+      expect(result.url).toBe("https://new.example.com/hooks");
+      expect(global.fetch).toHaveBeenCalledWith(
+        `https://api.test.com/api/v2/subscriptions/${MOCK_SUBSCRIPTION.id}`,
+        expect.objectContaining({ method: "PATCH" }),
+      );
+    });
+
+    it("should send partial update body", async () => {
+      const updated = { ...MOCK_SUBSCRIPTION, enabled: false };
+      global.fetch = vi.fn().mockResolvedValue(mockJsonResponse(updated));
+
+      await client.subscriptions.update(MOCK_SUBSCRIPTION.id, {
+        enabled: false,
+      });
+
+      const callArgs = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      const body = JSON.parse(callArgs?.[1]?.body as string);
+      expect(body.enabled).toBe(false);
+      expect(body.url).toBeUndefined();
+    });
+
+    it("should update event_types array", async () => {
+      const updated = { ...MOCK_SUBSCRIPTION, event_types: ["file_write"] };
+      global.fetch = vi.fn().mockResolvedValue(mockJsonResponse(updated));
+
+      await client.subscriptions.update(MOCK_SUBSCRIPTION.id, {
+        event_types: ["file_write"],
+      });
+
+      const callArgs = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      const body = JSON.parse(callArgs?.[1]?.body as string);
+      expect(body.event_types).toEqual(["file_write"]);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // delete()
+  // -----------------------------------------------------------------------
+
+  describe("delete()", () => {
+    it("should delete a subscription and return confirmation", async () => {
+      const response: DeleteSubscriptionResponse = { deleted: true };
+      global.fetch = vi.fn().mockResolvedValue(mockJsonResponse(response));
+
+      const result = await client.subscriptions.delete(MOCK_SUBSCRIPTION.id);
+
+      expect(result.deleted).toBe(true);
+      expect(global.fetch).toHaveBeenCalledWith(
+        `https://api.test.com/api/v2/subscriptions/${MOCK_SUBSCRIPTION.id}`,
+        expect.objectContaining({ method: "DELETE" }),
+      );
+    });
+
+    it("should throw on 404 for nonexistent subscription", async () => {
+      global.fetch = vi
+        .fn()
+        .mockResolvedValue(
+          mockJsonResponse({ code: "NOT_FOUND", message: "Subscription not found" }, 404),
+        );
+
+      await expect(client.subscriptions.delete("nonexistent")).rejects.toThrow(
+        "Subscription not found",
+      );
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // test()
+  // -----------------------------------------------------------------------
+
+  describe("test()", () => {
+    it("should test a subscription and return success", async () => {
+      const response: TestWebhookResponse = {
+        success: true,
+        event_id: "evt_test_abc123",
+        subscription_id: MOCK_SUBSCRIPTION.id,
+      };
+      global.fetch = vi.fn().mockResolvedValue(mockJsonResponse(response));
+
+      const result = await client.subscriptions.test(MOCK_SUBSCRIPTION.id);
+
+      expect(result.success).toBe(true);
+      expect(result.event_id).toBe("evt_test_abc123");
+      expect(result.subscription_id).toBe(MOCK_SUBSCRIPTION.id);
+      expect(global.fetch).toHaveBeenCalledWith(
+        `https://api.test.com/api/v2/subscriptions/${MOCK_SUBSCRIPTION.id}/test`,
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+
+    it("should handle failed test delivery", async () => {
+      const response: TestWebhookResponse = {
+        success: false,
+        event_id: "evt_test_def456",
+        subscription_id: MOCK_SUBSCRIPTION.id,
+      };
+      global.fetch = vi.fn().mockResolvedValue(mockJsonResponse(response));
+
+      const result = await client.subscriptions.test(MOCK_SUBSCRIPTION.id);
+
+      expect(result.success).toBe(false);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // verifySignature()
+  // -----------------------------------------------------------------------
+
+  describe("verifySignature()", () => {
+    // Known test vector: HMAC-SHA256("test payload", "test-secret")
+    const TEST_PAYLOAD = "test payload";
+    const TEST_SECRET = "test-secret";
+    const TEST_SIGNATURE =
+      "sha256=2f94a757d2246073e26781d117ce0183ebd87b4d66c460494376d5c37d71985b";
+
+    it("should return true for valid signature", () => {
+      const result = SubscriptionsResource.verifySignature(
+        TEST_PAYLOAD,
+        TEST_SECRET,
+        TEST_SIGNATURE,
+      );
+      expect(result).toBe(true);
+    });
+
+    it("should return false for wrong secret", () => {
+      const result = SubscriptionsResource.verifySignature(
+        TEST_PAYLOAD,
+        "wrong-secret",
+        TEST_SIGNATURE,
+      );
+      expect(result).toBe(false);
+    });
+
+    it("should return false for tampered payload", () => {
+      const result = SubscriptionsResource.verifySignature(
+        "tampered payload",
+        TEST_SECRET,
+        TEST_SIGNATURE,
+      );
+      expect(result).toBe(false);
+    });
+
+    it("should return false for malformed signature header", () => {
+      const result = SubscriptionsResource.verifySignature(
+        TEST_PAYLOAD,
+        TEST_SECRET,
+        "not-a-valid-signature",
+      );
+      expect(result).toBe(false);
+    });
+
+    it("should handle Buffer payload", () => {
+      const result = SubscriptionsResource.verifySignature(
+        Buffer.from(TEST_PAYLOAD),
+        TEST_SECRET,
+        TEST_SIGNATURE,
+      );
+      expect(result).toBe(true);
+    });
+
+    it("should return false for undefined signature header", () => {
+      const result = SubscriptionsResource.verifySignature(TEST_PAYLOAD, TEST_SECRET, undefined);
+      expect(result).toBe(false);
+    });
+
+    it("should return false for empty signature header", () => {
+      const result = SubscriptionsResource.verifySignature(TEST_PAYLOAD, TEST_SECRET, "");
+      expect(result).toBe(false);
+    });
+
+    it("should return false for wrong algorithm prefix", () => {
+      const result = SubscriptionsResource.verifySignature(
+        TEST_PAYLOAD,
+        TEST_SECRET,
+        "md5=2f94a757d2246073e26781d117ce0183ebd87b4d66c460494376d5c37d71985b",
+      );
+      expect(result).toBe(false);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Error handling
+  // -----------------------------------------------------------------------
+
+  describe("error handling", () => {
+    it("should propagate 500 errors", async () => {
+      global.fetch = vi
+        .fn()
+        .mockResolvedValue(
+          mockJsonResponse({ code: "INTERNAL_ERROR", message: "Internal server error" }, 500),
+        );
+
+      await expect(client.subscriptions.list()).rejects.toThrow("Internal server error");
+    });
+
+    it("should propagate 401 unauthorized", async () => {
+      global.fetch = vi
+        .fn()
+        .mockResolvedValue(
+          mockJsonResponse({ code: "UNAUTHORIZED", message: "Invalid API key" }, 401),
+        );
+
+      await expect(client.subscriptions.create({ url: "https://x.com" })).rejects.toThrow(
+        "Invalid API key",
+      );
+    });
+  });
+});

--- a/packages/nexus-sdk/src/client.ts
+++ b/packages/nexus-sdk/src/client.ts
@@ -14,6 +14,7 @@ import { PayResource } from "./resources/pay.js";
 import { PermissionsResource } from "./resources/permissions.js";
 import { SandboxResource } from "./resources/sandbox.js";
 import { SecretsAuditResource } from "./resources/secrets-audit.js";
+import { SubscriptionsResource } from "./resources/subscriptions.js";
 import { ToolsResource } from "./resources/tools.js";
 import type { ClientConfig, RetryOptions } from "./types/index.js";
 
@@ -111,6 +112,11 @@ export class NexusClient {
   public readonly secretsAudit: SecretsAuditResource;
 
   /**
+   * Subscriptions resource (webhook notifications — outbound event delivery)
+   */
+  public readonly subscriptions: SubscriptionsResource;
+
+  /**
    * ACE resource (Adaptive Context Engine — trajectories, playbooks, reflection, etc.)
    */
   public readonly ace: AceResource;
@@ -141,6 +147,7 @@ export class NexusClient {
     this.sandbox = new SandboxResource(this._http);
     this.pairing = new PairingResource(this._http);
     this.secretsAudit = new SecretsAuditResource(this._http);
+    this.subscriptions = new SubscriptionsResource(this._http);
     this.ace = new AceResource(this._http);
   }
 

--- a/packages/nexus-sdk/src/index.ts
+++ b/packages/nexus-sdk/src/index.ts
@@ -39,6 +39,7 @@ export { PayResource } from "./resources/pay.js";
 export { PermissionsResource } from "./resources/permissions.js";
 export { SandboxResource } from "./resources/sandbox.js";
 export { SecretsAuditResource } from "./resources/secrets-audit.js";
+export { SubscriptionsResource } from "./resources/subscriptions.js";
 export { ToolsResource } from "./resources/tools.js";
 // ACE types
 export type {
@@ -195,6 +196,17 @@ export type {
   SecretsAuditExportResponse,
   SecretsAuditIntegrityResponse,
 } from "./types/secrets-audit.js";
+export type {
+  CreateSubscriptionParams,
+  DeleteSubscriptionResponse,
+  DeliveryStatus,
+  FileEventType,
+  ListSubscriptionsParams,
+  Subscription,
+  SubscriptionListResponse,
+  TestWebhookResponse,
+  UpdateSubscriptionParams,
+} from "./types/subscriptions.js";
 export type {
   CreateToolParams,
   ListToolsParams,

--- a/packages/nexus-sdk/src/resources/base.ts
+++ b/packages/nexus-sdk/src/resources/base.ts
@@ -18,4 +18,25 @@ export abstract class BaseResource {
   constructor(http: HttpClient) {
     this.http = http;
   }
+
+  /**
+   * Build a query parameter object from params, stripping undefined values.
+   *
+   * Returns undefined if no parameters are set (avoids empty query strings).
+   *
+   * @param params - Raw parameters object (undefined values are omitted)
+   * @returns Query object for HttpClient, or undefined if empty
+   */
+  protected buildQuery(
+    params?: Record<string, string | number | boolean | undefined>,
+  ): Record<string, string | number | boolean> | undefined {
+    if (!params) return undefined;
+    const query: Record<string, string | number | boolean> = {};
+    for (const [key, value] of Object.entries(params)) {
+      if (value !== undefined) {
+        query[key] = value;
+      }
+    }
+    return Object.keys(query).length > 0 ? query : undefined;
+  }
 }

--- a/packages/nexus-sdk/src/resources/subscriptions.ts
+++ b/packages/nexus-sdk/src/resources/subscriptions.ts
@@ -1,0 +1,260 @@
+/**
+ * Subscriptions resource for managing webhook notifications
+ *
+ * Issue #222: Webhook Notifications API (outbound event delivery).
+ * Wraps Nexus API: /api/v2/subscriptions/*
+ *
+ * Subscriptions are zone-scoped (enforced server-side via auth).
+ * Webhook payloads are HMAC-SHA256 signed when a secret is configured.
+ * Subscriptions auto-disable after 10 consecutive delivery failures.
+ */
+
+import { createHmac, timingSafeEqual } from "node:crypto";
+import type {
+  CreateSubscriptionParams,
+  DeleteSubscriptionResponse,
+  ListSubscriptionsParams,
+  Subscription,
+  SubscriptionListResponse,
+  TestWebhookResponse,
+  UpdateSubscriptionParams,
+} from "../types/subscriptions.js";
+import { BaseResource } from "./base.js";
+
+const BASE_PATH = "/api/v2/subscriptions";
+
+/**
+ * Resource for managing webhook subscriptions
+ *
+ * Provides full CRUD operations for webhook subscriptions plus
+ * a test endpoint for verifying delivery and a static helper
+ * for signature verification.
+ *
+ * @example
+ * ```typescript
+ * // Create a webhook subscription
+ * const sub = await client.subscriptions.create({
+ *   url: "https://example.com/webhooks",
+ *   event_types: ["file_write", "file_delete"],
+ *   secret: "whsec_my-signing-secret",
+ * });
+ *
+ * // List all subscriptions
+ * const subs = await client.subscriptions.list();
+ *
+ * // Test a subscription
+ * const result = await client.subscriptions.test(sub.id);
+ * console.log(result.success); // true or false
+ *
+ * // Verify a webhook signature in your handler
+ * const isValid = SubscriptionsResource.verifySignature(
+ *   rawBody,
+ *   "whsec_my-signing-secret",
+ *   request.headers["x-nexus-signature"],
+ * );
+ * ```
+ */
+export class SubscriptionsResource extends BaseResource {
+  /**
+   * Create a new webhook subscription.
+   *
+   * The subscription will begin receiving events matching the specified
+   * event types and patterns as soon as it is created.
+   *
+   * @param params - Subscription configuration
+   * @returns The created subscription
+   *
+   * @example
+   * ```typescript
+   * const sub = await client.subscriptions.create({
+   *   url: "https://example.com/webhooks",
+   *   event_types: ["file_write", "file_delete"],
+   *   patterns: ["/workspace/**\/*"],
+   *   secret: "whsec_my-signing-secret",
+   *   name: "Production webhook",
+   * });
+   * ```
+   */
+  async create(params: CreateSubscriptionParams): Promise<Subscription> {
+    return this.http.request<Subscription>(BASE_PATH, {
+      method: "POST",
+      body: params,
+    });
+  }
+
+  /**
+   * List webhook subscriptions with optional filters and offset-based pagination.
+   *
+   * @param params - Optional filter and pagination parameters
+   * @returns List of subscriptions
+   *
+   * @example
+   * ```typescript
+   * // List all enabled subscriptions
+   * const result = await client.subscriptions.list({ enabled_only: true });
+   *
+   * // Paginate with offset
+   * const page2 = await client.subscriptions.list({ limit: 10, offset: 10 });
+   * ```
+   */
+  async list(params?: ListSubscriptionsParams): Promise<SubscriptionListResponse> {
+    const query = this.buildQuery(
+      params
+        ? {
+            enabled_only: params.enabled_only,
+            limit: params.limit,
+            offset: params.offset,
+          }
+        : undefined,
+    );
+    return this.http.request<SubscriptionListResponse>(BASE_PATH, {
+      method: "GET",
+      ...(query ? { query } : {}),
+    });
+  }
+
+  /**
+   * Get a single webhook subscription by ID.
+   *
+   * Returns 404 if the subscription doesn't exist or belongs to a different zone.
+   *
+   * @param subscriptionId - The subscription UUID
+   * @returns The subscription record
+   *
+   * @example
+   * ```typescript
+   * const sub = await client.subscriptions.get("550e8400-e29b-41d4-a716-446655440000");
+   * console.log(sub.enabled); // true
+   * console.log(sub.consecutive_failures); // 0
+   * ```
+   */
+  async get(subscriptionId: string): Promise<Subscription> {
+    return this.http.request<Subscription>(`${BASE_PATH}/${encodeURIComponent(subscriptionId)}`, {
+      method: "GET",
+    });
+  }
+
+  /**
+   * Update an existing webhook subscription.
+   *
+   * Only provided fields are updated. Re-enabling a disabled subscription
+   * resets the consecutive failure counter.
+   *
+   * @param subscriptionId - The subscription UUID
+   * @param params - Fields to update
+   * @returns The updated subscription
+   *
+   * @example
+   * ```typescript
+   * // Disable a subscription
+   * const updated = await client.subscriptions.update(sub.id, {
+   *   enabled: false,
+   * });
+   *
+   * // Update URL and event types
+   * const updated2 = await client.subscriptions.update(sub.id, {
+   *   url: "https://new-endpoint.example.com/webhooks",
+   *   event_types: ["file_write"],
+   * });
+   * ```
+   */
+  async update(subscriptionId: string, params: UpdateSubscriptionParams): Promise<Subscription> {
+    return this.http.request<Subscription>(`${BASE_PATH}/${encodeURIComponent(subscriptionId)}`, {
+      method: "PATCH",
+      body: params,
+    });
+  }
+
+  /**
+   * Delete a webhook subscription.
+   *
+   * The subscription will immediately stop receiving events.
+   * Returns 404 if the subscription doesn't exist.
+   *
+   * @param subscriptionId - The subscription UUID
+   *
+   * @example
+   * ```typescript
+   * const result = await client.subscriptions.delete("550e8400-e29b-41d4-a716-446655440000");
+   * console.log(result.deleted); // true
+   * ```
+   */
+  async delete(subscriptionId: string): Promise<DeleteSubscriptionResponse> {
+    return this.http.request<DeleteSubscriptionResponse>(
+      `${BASE_PATH}/${encodeURIComponent(subscriptionId)}`,
+      { method: "DELETE" },
+    );
+  }
+
+  /**
+   * Send a test webhook to verify delivery.
+   *
+   * Sends a synthetic event to the subscription's URL and reports
+   * whether delivery was successful.
+   *
+   * @param subscriptionId - The subscription UUID
+   * @returns Test delivery result
+   *
+   * @example
+   * ```typescript
+   * const result = await client.subscriptions.test(sub.id);
+   * if (!result.success) {
+   *   console.error("Webhook endpoint is not reachable");
+   * }
+   * ```
+   */
+  async test(subscriptionId: string): Promise<TestWebhookResponse> {
+    return this.http.request<TestWebhookResponse>(
+      `${BASE_PATH}/${encodeURIComponent(subscriptionId)}/test`,
+      { method: "POST" },
+    );
+  }
+
+  /**
+   * Verify an incoming webhook signature (HMAC-SHA256).
+   *
+   * Uses timing-safe comparison to prevent side-channel attacks.
+   * Call this in your webhook handler to verify that payloads
+   * were sent by Nexus and not tampered with.
+   *
+   * @param payload - The raw request body (string or Buffer)
+   * @param secret - The HMAC secret configured on the subscription
+   * @param signatureHeader - The `X-Nexus-Signature` header value (format: "sha256=..."), or undefined
+   * @returns true if the signature is valid
+   *
+   * @example
+   * ```typescript
+   * app.post("/webhooks", (req, res) => {
+   *   const isValid = SubscriptionsResource.verifySignature(
+   *     req.rawBody,
+   *     process.env.WEBHOOK_SECRET,
+   *     req.headers["x-nexus-signature"],
+   *   );
+   *   if (!isValid) {
+   *     return res.status(401).send("Invalid signature");
+   *   }
+   *   // Process webhook...
+   * });
+   * ```
+   */
+  static verifySignature(
+    payload: string | Buffer,
+    secret: string,
+    signatureHeader: string | undefined,
+  ): boolean {
+    if (!signatureHeader || !signatureHeader.startsWith("sha256=")) {
+      return false;
+    }
+
+    const expectedSig = `sha256=${createHmac("sha256", secret).update(payload).digest("hex")}`;
+
+    const expectedBuf = Buffer.from(expectedSig, "utf-8");
+    const receivedBuf = Buffer.from(signatureHeader, "utf-8");
+
+    if (expectedBuf.length !== receivedBuf.length) {
+      return false;
+    }
+
+    return timingSafeEqual(expectedBuf, receivedBuf);
+  }
+}

--- a/packages/nexus-sdk/src/types/subscriptions.ts
+++ b/packages/nexus-sdk/src/types/subscriptions.ts
@@ -1,0 +1,191 @@
+/**
+ * Subscription types — mirrors Nexus subscriptions API contract
+ *
+ * Issue #222: Webhook Notifications API (outbound event delivery)
+ * Nexus API: /api/v2/subscriptions/*
+ */
+
+// ============================================================================
+// ENUMS
+// ============================================================================
+
+/**
+ * File system event types that can trigger webhook delivery.
+ *
+ * Uses union + string escape hatch: known types get autocomplete,
+ * but unknown types (added server-side) are accepted without SDK update.
+ */
+export type FileEventType =
+  | "file_write"
+  | "file_delete"
+  | "file_rename"
+  | "metadata_change"
+  | "dir_create"
+  | "dir_delete"
+  | (string & {});
+
+/**
+ * Delivery status for a webhook subscription.
+ */
+export type DeliveryStatus = "success" | "failed";
+
+// ============================================================================
+// REQUEST PARAMS
+// ============================================================================
+
+/**
+ * Parameters for creating a new webhook subscription.
+ */
+export interface CreateSubscriptionParams {
+  /** Webhook URL (must be http or https; SSRF-protected server-side) */
+  readonly url: string;
+
+  /** Event types to subscribe to (default: ["file_write", "file_delete", "file_rename"]) */
+  readonly event_types?: readonly FileEventType[];
+
+  /** Glob patterns to filter file paths (e.g., ["/workspace/**\/*", "*.txt"]) */
+  readonly patterns?: readonly string[];
+
+  /** HMAC-SHA256 secret for payload signing */
+  readonly secret?: string;
+
+  /** Human-readable subscription name */
+  readonly name?: string;
+
+  /** Description of the subscription's purpose */
+  readonly description?: string;
+
+  /** Custom metadata included in webhook payloads */
+  readonly metadata?: Readonly<Record<string, unknown>>;
+}
+
+/**
+ * Parameters for updating an existing webhook subscription.
+ *
+ * All fields are optional — only provided fields are updated.
+ */
+export interface UpdateSubscriptionParams {
+  /** Update webhook URL */
+  readonly url?: string;
+
+  /** Update subscribed event types */
+  readonly event_types?: readonly FileEventType[];
+
+  /** Update file path patterns */
+  readonly patterns?: readonly string[];
+
+  /** Update HMAC secret */
+  readonly secret?: string;
+
+  /** Update subscription name */
+  readonly name?: string;
+
+  /** Update description */
+  readonly description?: string;
+
+  /** Update custom metadata */
+  readonly metadata?: Readonly<Record<string, unknown>>;
+
+  /** Enable or disable the subscription (re-enabling resets failure counter) */
+  readonly enabled?: boolean;
+}
+
+/**
+ * Parameters for listing subscriptions with optional filters.
+ *
+ * Uses offset-based pagination (not cursor-based).
+ */
+export interface ListSubscriptionsParams {
+  /** Filter to show only enabled subscriptions (default: false = show all) */
+  readonly enabled_only?: boolean;
+
+  /** Page size (default: 100) */
+  readonly limit?: number;
+
+  /** Offset for pagination (default: 0) */
+  readonly offset?: number;
+}
+
+// ============================================================================
+// RESPONSE TYPES
+// ============================================================================
+
+/**
+ * A webhook subscription record.
+ */
+export interface Subscription {
+  /** Unique subscription identifier (UUID) */
+  readonly id: string;
+
+  /** Zone ID for multi-tenant isolation */
+  readonly zone_id: string;
+
+  /** Webhook URL */
+  readonly url: string;
+
+  /** Subscribed event types */
+  readonly event_types: readonly string[];
+
+  /** File path glob patterns (null if not filtered) */
+  readonly patterns: readonly string[] | null;
+
+  /** Human-readable subscription name */
+  readonly name: string | null;
+
+  /** Description */
+  readonly description: string | null;
+
+  /** Custom metadata included in webhook payloads */
+  readonly metadata: Readonly<Record<string, unknown>> | null;
+
+  /** Whether the subscription is active */
+  readonly enabled: boolean;
+
+  /** Timestamp of last delivery attempt (ISO-8601, null if never delivered) */
+  readonly last_delivery_at: string | null;
+
+  /** Status of last delivery ("success" or "failed", null if never delivered) */
+  readonly last_delivery_status: DeliveryStatus | null;
+
+  /** Count of consecutive delivery failures (auto-disables at 10) */
+  readonly consecutive_failures: number;
+
+  /** Creation timestamp (ISO-8601) */
+  readonly created_at: string;
+
+  /** Last update timestamp (ISO-8601) */
+  readonly updated_at: string;
+
+  /** Creator ID (user or agent) */
+  readonly created_by: string | null;
+}
+
+/**
+ * List of subscriptions.
+ */
+export interface SubscriptionListResponse {
+  /** List of subscriptions */
+  readonly subscriptions: readonly Subscription[];
+}
+
+/**
+ * Response from deleting a webhook subscription.
+ */
+export interface DeleteSubscriptionResponse {
+  /** Whether the subscription was deleted */
+  readonly deleted: boolean;
+}
+
+/**
+ * Response from testing a webhook subscription.
+ */
+export interface TestWebhookResponse {
+  /** Whether the test webhook was delivered successfully */
+  readonly success: boolean;
+
+  /** Unique event ID for the test delivery */
+  readonly event_id: string;
+
+  /** Subscription ID that was tested */
+  readonly subscription_id: string;
+}

--- a/packages/nexus-sdk/tsup.config.ts
+++ b/packages/nexus-sdk/tsup.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
     "resources/permissions": "src/resources/permissions.ts",
     "resources/sandbox": "src/resources/sandbox.ts",
     "resources/secrets-audit": "src/resources/secrets-audit.ts",
+    "resources/subscriptions": "src/resources/subscriptions.ts",
     "http/index": "src/http/index.ts",
   },
   format: ["esm"],


### PR DESCRIPTION
## Summary

- Add `SubscriptionsResource` to `@nexus/sdk` for full webhook notification lifecycle: create, list, get, update, delete, test, and HMAC-SHA256 signature verification
- Add `buildQuery()` utility to `BaseResource` for clean query parameter construction (strips `undefined` values)
- Wire `client.subscriptions` into `NexusClient` with tree-shakeable entry point (`@nexus/sdk/subscriptions`)

## Details

**Types** (`src/types/subscriptions.ts`):
- `FileEventType` union with `(string & {})` escape hatch for forward compatibility
- Immutable (`readonly`) request params: `CreateSubscriptionParams`, `UpdateSubscriptionParams`, `ListSubscriptionsParams`
- Response types: `Subscription`, `SubscriptionListResponse`, `DeleteSubscriptionResponse`, `TestWebhookResponse`

**Resource** (`src/resources/subscriptions.ts`):
- 6 CRUD methods + static `verifySignature()` for webhook handler use
- HMAC-SHA256 with `crypto.timingSafeEqual` for timing-safe signature comparison
- `signatureHeader` accepts `string | undefined` for ergonomic use with raw headers
- Validates `sha256=` prefix before comparison (defense-in-depth)
- All path parameters use `encodeURIComponent`

**Tests**:
- 29 unit tests covering all methods, query params, URL encoding, error propagation, and signature verification edge cases
- 10 E2E tests (full lifecycle: create → get → list → update → test → delete) validated against live Nexus server

**Server-side fixes** (in `~/nexus`, separate repo):
- Fixed `request: Any` → `request: Request` type annotation in subscriptions router
- Fixed `hasattr` → `getattr(..., None) is not None` for SessionLocal null check in fastapi_server.py

## Test plan

- [x] 218 unit tests pass (`npx vitest run`)
- [x] 10 E2E tests pass against live Nexus server (`NEXUS_E2E=1`)
- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [x] Biome lint clean
- [x] Build succeeds with tree-shaken 93B entry (`npx tsup`)
- [ ] CI passes